### PR TITLE
Enahncements for schema generation and data fetching

### DIFF
--- a/graphql-jpa-query-schema/src/main/java/com/introproventures/graphql/jpa/query/schema/GraphQLExecutor.java
+++ b/graphql-jpa-query-schema/src/main/java/com/introproventures/graphql/jpa/query/schema/GraphQLExecutor.java
@@ -43,4 +43,16 @@ public interface GraphQLExecutor {
      */
     ExecutionResult execute(String query, Map<String, Object> arguments);
     
+    /**
+     * Execute GraphQL query provided in query argument and variables for the specified user context
+     *
+     * @param query GraphQL query string
+     * @param arguments List of arguments to substitute into the query
+     * @param userContext The user context under which to run the query
+     * @return GraphQL ExecutionResult
+     */
+    default ExecutionResult execute(String query, Map<String, Object> arguments, Object userContext) {
+        return execute(query, arguments);
+    }
+
 }

--- a/graphql-jpa-query-schema/src/main/java/com/introproventures/graphql/jpa/query/schema/GraphQLSchemaBuilder.java
+++ b/graphql-jpa-query-schema/src/main/java/com/introproventures/graphql/jpa/query/schema/GraphQLSchemaBuilder.java
@@ -1,5 +1,6 @@
 /*
  * Copyright 2017 IntroPro Ventures Inc. and/or its affiliates.
+ * Copyright IBM Corporation 2018
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,54 +16,84 @@
  */
 package com.introproventures.graphql.jpa.query.schema;
 
+import java.lang.reflect.AnnotatedElement;
+
+import com.introproventures.graphql.jpa.query.annotation.GraphQLIgnore;
 import graphql.schema.GraphQLSchema;
 
 /**
  * GraphQL Schema Builder interface specification
- * 
+ *
  * @author Igor Dianov
  *
  */
 public interface GraphQLSchemaBuilder {
-    
+
     /**
      * Configures the name of GraphQL Schema. Cannot be null or empty;
-     * 
+     *
      * @param value GraphQL schema name
      * @return this builder instance
      */
     GraphQLSchemaBuilder name(String value);
-    
+
     /**
-     * Configures the description of GraphQL Schema. 
-     * 
+     * Configures the description of GraphQL Schema.
+     *
      * @param value GraphQL schema description
      * @return this builder instance
      */
     GraphQLSchemaBuilder description(String value);
 
     /**
-     * Add package path to scan for entities to be included in GraphQL Schema. 
+     * Add package path to scan for entities to be included in GraphQL Schema.
      * All Entities are included by default
-     * 
-     * @param path GraphQL entitys package path 
+     *
+     * @param path GraphQL entitys package path
      * @return this builder instance
      */
     GraphQLSchemaBuilder entityPath(String path);
 
     /**
-     * Add package path to scan for entities to be included in GraphQL Schema. 
-     * 
+     * Add package path to scan for entities to be included in GraphQL Schema.
+     *
      * @param instance GraphQL query naming strategy
      * @return this builder instance
      */
     GraphQLSchemaBuilder namingStrategy(NamingStrategy instance);
-    
+
     /**
      * Builds {code #GraphQLSchema} instance
-     * 
+     *
      * @return GraphQLSchema instance
      */
     GraphQLSchema build();
-    
+
+    /**
+     * Define the READ authorization strategy
+     *
+     * @param instance GraphQL query authorization strategy
+     * @return this builder instance
+     */
+    GraphQLSchemaBuilder readAuthorizationStrategy(IQueryAuthorizationStrategy instance);
+
+    /**
+     * Determines whether an entity or attribute is ignored. This can be overridden to use an alternate
+     * mechanism, such as JsonIgnore from Jackson, or a combination of the 2
+     *
+     * @param annotatedElement
+     * @return true, if the entity or attribute is not ignored; false otherwise
+     */
+    default boolean isNotIgnored(AnnotatedElement annotatedElement) {
+        if (annotatedElement != null) {
+            GraphQLIgnore ignoredAnnotation = annotatedElement.getAnnotation(GraphQLIgnore.class);
+            return ignoredAnnotation == null;
+        }
+
+        return false;
+    }
+
+    default boolean useAlternateDataFetchers() {
+        return false;
+    }
 }

--- a/graphql-jpa-query-schema/src/main/java/com/introproventures/graphql/jpa/query/schema/GraphQLSchemaBuilder.java
+++ b/graphql-jpa-query-schema/src/main/java/com/introproventures/graphql/jpa/query/schema/GraphQLSchemaBuilder.java
@@ -16,10 +16,13 @@
  */
 package com.introproventures.graphql.jpa.query.schema;
 
-import java.lang.reflect.AnnotatedElement;
-
 import com.introproventures.graphql.jpa.query.annotation.GraphQLIgnore;
+import graphql.schema.GraphQLDirective;
 import graphql.schema.GraphQLSchema;
+import javax.persistence.metamodel.Attribute;
+import javax.persistence.metamodel.ManagedType;
+import java.lang.reflect.AnnotatedElement;
+import java.util.List;
 
 /**
  * GraphQL Schema Builder interface specification
@@ -29,71 +32,96 @@ import graphql.schema.GraphQLSchema;
  */
 public interface GraphQLSchemaBuilder {
 
-    /**
-     * Configures the name of GraphQL Schema. Cannot be null or empty;
-     *
-     * @param value GraphQL schema name
-     * @return this builder instance
+	/**
+	 * Configures the name of GraphQL Schema. Cannot be null or empty;
+	 *
+	 * @param value
+	 *            GraphQL schema name
+	 * @return this builder instance
+	 */
+	GraphQLSchemaBuilder name(String value);
+
+	/**
+	 * Configures the description of GraphQL Schema.
+	 *
+	 * @param value
+	 *            GraphQL schema description
+	 * @return this builder instance
+	 */
+	GraphQLSchemaBuilder description(String value);
+
+	/**
+	 * Add package path to scan for entities to be included in GraphQL Schema.
+	 * All Entities are included by default
+	 *
+	 * @param path
+	 *            GraphQL entitys package path
+	 * @return this builder instance
+	 */
+	GraphQLSchemaBuilder entityPath(String path);
+
+	/**
+	 * Add package path to scan for entities to be included in GraphQL Schema.
+	 *
+	 * @param instance
+	 *            GraphQL query naming strategy
+	 * @return this builder instance
+	 */
+	GraphQLSchemaBuilder namingStrategy(NamingStrategy instance);
+
+	/**
+	 * Builds {code #GraphQLSchema} instance
+	 *
+	 * @return GraphQLSchema instance
+	 */
+	GraphQLSchema build();
+
+	/**
+	 * Define the READ authorization strategy
+	 *
+	 * @param authorization
+	 *            GraphQL query authorization strategy
+	 * @return this builder instance
+	 */
+	GraphQLSchemaBuilder authorizationStrategy(IQueryAuthorizationStrategy authorization);
+
+	/**
+	 * Determines whether an entity or attribute is ignored. This can be overridden to use an alternate
+	 * mechanism, such as JsonIgnore from Jackson, or a combination of the 2
+	 *
+	 * @param annotatedElement
+	 * @return true, if the entity or attribute is not ignored; false otherwise
+	 */
+	default boolean isNotIgnored(AnnotatedElement annotatedElement) {
+		if (annotatedElement != null) {
+			GraphQLIgnore ignoredAnnotation = annotatedElement.getAnnotation(GraphQLIgnore.class);
+			return ignoredAnnotation == null;
+		}
+
+		return false;
+	}
+
+	/**
+	 * Get one or more authorization directives for the given entity.  If there is any authorization,
+	 * at least the directive named {@link IQueryAuthorizationStrategy.AUTHORIZATION} must be returned in the list
+	 * @param entityType The entity for which authorization directive is required
+	 * @return The list of authorization directives defined for the entity
      */
-    GraphQLSchemaBuilder name(String value);
+	default List<GraphQLDirective> getAuthorizationDirectives(ManagedType<?> entityType) {
+		return null;
+	}
 
-    /**
-     * Configures the description of GraphQL Schema.
-     *
-     * @param value GraphQL schema description
-     * @return this builder instance
-     */
-    GraphQLSchemaBuilder description(String value);
+	/**
+	 * Get one or more authorization directives for the given entity attribute.  If there is any authorization,
+	 * at least the directive named{@link IQueryAuthorizationStrategy.AUTHORIZATION} must be returned in the list
+	 * @param attribute The entity attribute for which authorization directive is required
+	 * @return The list of authorization directives defined for the entity attribute
+	 */
+	default List<GraphQLDirective> getAuthorizationDirectives(Attribute<?, ?> attribute) {
+		return null;
+	}
 
-    /**
-     * Add package path to scan for entities to be included in GraphQL Schema.
-     * All Entities are included by default
-     *
-     * @param path GraphQL entitys package path
-     * @return this builder instance
-     */
-    GraphQLSchemaBuilder entityPath(String path);
-
-    /**
-     * Add package path to scan for entities to be included in GraphQL Schema.
-     *
-     * @param instance GraphQL query naming strategy
-     * @return this builder instance
-     */
-    GraphQLSchemaBuilder namingStrategy(NamingStrategy instance);
-
-    /**
-     * Builds {code #GraphQLSchema} instance
-     *
-     * @return GraphQLSchema instance
-     */
-    GraphQLSchema build();
-
-    /**
-     * Define the READ authorization strategy
-     *
-     * @param instance GraphQL query authorization strategy
-     * @return this builder instance
-     */
-    GraphQLSchemaBuilder readAuthorizationStrategy(IQueryAuthorizationStrategy instance);
-
-    /**
-     * Determines whether an entity or attribute is ignored. This can be overridden to use an alternate
-     * mechanism, such as JsonIgnore from Jackson, or a combination of the 2
-     *
-     * @param annotatedElement
-     * @return true, if the entity or attribute is not ignored; false otherwise
-     */
-    default boolean isNotIgnored(AnnotatedElement annotatedElement) {
-        if (annotatedElement != null) {
-            GraphQLIgnore ignoredAnnotation = annotatedElement.getAnnotation(GraphQLIgnore.class);
-            return ignoredAnnotation == null;
-        }
-
-        return false;
-    }
-
-    default boolean useAlternateDataFetchers() {
-        return false;
-    }
+	default boolean useAlternateDataFetchers() {
+		return false;
+	}
 }

--- a/graphql-jpa-query-schema/src/main/java/com/introproventures/graphql/jpa/query/schema/IQueryAuthorizationStrategy.java
+++ b/graphql-jpa-query-schema/src/main/java/com/introproventures/graphql/jpa/query/schema/IQueryAuthorizationStrategy.java
@@ -15,8 +15,13 @@
  */
 package com.introproventures.graphql.jpa.query.schema;
 
+import com.introproventures.graphql.jpa.query.schema.exception.AuthorizationException;
+import graphql.schema.DataFetchingEnvironment;
+import graphql.schema.GraphQLDirective;
+
 import javax.persistence.metamodel.Attribute;
 import javax.persistence.metamodel.EntityType;
+import java.util.List;
 
 /**
  * Interface for defining authorization to various data returned through the defined schem
@@ -26,11 +31,15 @@ import javax.persistence.metamodel.EntityType;
  * @author Ghada Obaid
  */
 public interface IQueryAuthorizationStrategy {
-    default boolean isAuthorized(EntityType<?> entityType) {
+    static final String AUTHORIZATION = "authorization";
+
+    default boolean isAuthorized(Object context, GraphQLDirective authDirective) {
         return true;
     }
 
-    default boolean isAuthorized(Attribute<?, ?> attribute) {
-        return true;
+    default void checkAuthorization(DataFetchingEnvironment environment) {
+        GraphQLDirective authDirective = environment.getFieldDefinition().getDirective(IQueryAuthorizationStrategy.AUTHORIZATION);
+        if (authDirective != null && !isAuthorized(environment.getContext(), authDirective))
+            throw new AuthorizationException();
     }
 }

--- a/graphql-jpa-query-schema/src/main/java/com/introproventures/graphql/jpa/query/schema/IQueryAuthorizationStrategy.java
+++ b/graphql-jpa-query-schema/src/main/java/com/introproventures/graphql/jpa/query/schema/IQueryAuthorizationStrategy.java
@@ -1,5 +1,4 @@
 /*
- * Copyright 2017 IntroPro Ventures Inc. and/or its affiliates.
  * Copyright IBM Corporation 2018
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -14,28 +13,24 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package com.introproventures.graphql.jpa.query.schema;
 
-import javax.persistence.metamodel.EmbeddableType;
+import javax.persistence.metamodel.Attribute;
 import javax.persistence.metamodel.EntityType;
 
-import org.atteo.evo.inflector.English;
-
-public interface NamingStrategy {
-    default String singularize(String word) {
-        return English.plural(word, 1);
-    };
-
-    default String pluralize(String word) {
-        return English.plural(word);
-    }; 
-
-    default String getName(EntityType<?> entityType) {
-        return entityType.getName();
+/**
+ * Interface for defining authorization to various data returned through the defined schem
+ * <p>
+ * By default, there is no authorization enforced for the data
+ *
+ * @author Ghada Obaid
+ */
+public interface IQueryAuthorizationStrategy {
+    default boolean isAuthorized(EntityType<?> entityType) {
+        return true;
     }
 
-    default String getName(EmbeddableType<?> embeddableType) {
-        return embeddableType.getJavaType().getSimpleName() + "EmbeddableType";
+    default boolean isAuthorized(Attribute<?, ?> attribute) {
+        return true;
     }
 }

--- a/graphql-jpa-query-schema/src/main/java/com/introproventures/graphql/jpa/query/schema/JavaScalars.java
+++ b/graphql-jpa-query-schema/src/main/java/com/introproventures/graphql/jpa/query/schema/JavaScalars.java
@@ -21,6 +21,7 @@ import java.math.BigInteger;
 import java.nio.charset.StandardCharsets;
 import java.text.DateFormat;
 import java.text.ParseException;
+import java.text.SimpleDateFormat;
 import java.time.Instant;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
@@ -221,7 +222,7 @@ public class JavaScalars {
 
         private Date parseStringToDate(String input) {
             try {
-                return DateFormat.getInstance().parse(input);
+                return new SimpleDateFormat("yyyy-MM-dd").parse(input);
             } catch (ParseException e) {
                 log.warn("Failed to parse Date from input: " + input, e);
                 return null;

--- a/graphql-jpa-query-schema/src/main/java/com/introproventures/graphql/jpa/query/schema/JavaScalars.java
+++ b/graphql-jpa-query-schema/src/main/java/com/introproventures/graphql/jpa/query/schema/JavaScalars.java
@@ -1,5 +1,6 @@
 /*
  * Copyright 2017 IntroPro Ventures Inc. and/or its affiliates.
+ * Copyright IBM Corporation 2018
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -17,6 +18,7 @@ package com.introproventures.graphql.jpa.query.schema;
 
 import java.math.BigDecimal;
 import java.math.BigInteger;
+import java.nio.charset.StandardCharsets;
 import java.text.DateFormat;
 import java.text.ParseException;
 import java.time.Instant;
@@ -40,7 +42,7 @@ import graphql.schema.GraphQLScalarType;
 
 /**
  * Provides Registry to resolve GraphQL Query Java Scalar Types
- * 
+ *
  * @author Igor Dianov
  *
  */
@@ -48,7 +50,7 @@ public class JavaScalars {
     static final Logger log = LoggerFactory.getLogger(JavaScalars.class);
 
     private static HashMap<Class<?>, GraphQLScalarType> scalarsRegistry = new HashMap<Class<?>, GraphQLScalarType>();
-    
+
     static {
         scalarsRegistry.put(String.class, Scalars.GraphQLString);
 
@@ -66,19 +68,22 @@ public class JavaScalars {
 
         scalarsRegistry.put(Long.class, Scalars.GraphQLLong);
         scalarsRegistry.put(long.class, Scalars.GraphQLLong);
-            
+
         scalarsRegistry.put(Boolean.class, Scalars.GraphQLBoolean);
         scalarsRegistry.put(boolean.class, Scalars.GraphQLBoolean);
 
         scalarsRegistry.put(BigDecimal.class, Scalars.GraphQLBigDecimal);
-            
+
         scalarsRegistry.put(LocalDateTime.class, new GraphQLScalarType("LocalDateTime", "LocalDateTime type", new GraphQLLocalDateTimeCoercing()));
         scalarsRegistry.put(LocalDate.class, new GraphQLScalarType("LocalDate", "LocalDate type", new GraphQLLocalDateCoercing()));
         scalarsRegistry.put(Date.class, new GraphQLScalarType("Date", "Date type", new GraphQLDateCoercing()));
         scalarsRegistry.put(UUID.class, new GraphQLScalarType("UUID", "UUID type", new GraphQLUUIDCoercing()));
         scalarsRegistry.put(Object.class, new GraphQLScalarType("Object", "Object type", new GraphQLObjectCoercing()));
+        scalarsRegistry.put(java.sql.Date.class, new GraphQLScalarType("SqlDate", "SQL Date type", new GraphQLSqlDateCoercing()));
+        scalarsRegistry.put(java.sql.Timestamp.class, new GraphQLScalarType("SqlTimestamp", "SQL Timestamp type", new GraphQLSqlTimestampCoercing()));
+        scalarsRegistry.put(byte[].class, new GraphQLScalarType("ByteArray", "ByteArray type", new GraphQLLOBCoercing()));
     }
-    
+
     public static GraphQLScalarType of(Class<?> key) {
         return scalarsRegistry.get(key);
     }
@@ -86,12 +91,12 @@ public class JavaScalars {
     public JavaScalars register(Class<?> key, GraphQLScalarType value) {
         Assert.assertNotNull(key, "key parameter cannot be null.");
         Assert.assertNotNull(value, "value parameter cannot be null.");
-        
+
         scalarsRegistry.put(key, value);
-        
+
         return this;
     }
-    
+
     public static class GraphQLLocalDateTimeCoercing implements Coercing<Object, Object> {
         @Override
         public Object serialize(Object input) {
@@ -136,7 +141,7 @@ public class JavaScalars {
             }
         }
     };
-    
+
     public static class GraphQLLocalDateCoercing implements Coercing<Object, Object> {
         @Override
         public Object serialize(Object input) {
@@ -229,14 +234,14 @@ public class JavaScalars {
         @Override
         public Object serialize(Object input) {
             if (input instanceof UUID) {
-                return  input;
+                return input;
             }
             return null;
         }
 
         @Override
         public Object parseValue(Object input) {
-           if (input instanceof String) {
+            if (input instanceof String) {
                 return parseStringToUUID((String) input);
             }
             return null;
@@ -277,5 +282,125 @@ public class JavaScalars {
             return input;
         }
     };
-    
+
+
+    public static class GraphQLSqlDateCoercing implements Coercing<Object, Object> {
+
+        @Override
+        public Object serialize(Object input) {
+            if (input instanceof String) {
+                return parseStringToDate((String) input);
+            } else if (input instanceof Date) {
+                return new java.sql.Date(((Date) input).getTime());
+            } else if (input instanceof Long) {
+                return new java.sql.Date(((Long) input).longValue());
+            } else if (input instanceof Integer) {
+                return new java.sql.Date(((Integer) input).longValue());
+            }
+            return null;
+        }
+
+        @Override
+        public Object parseValue(Object input) {
+            return serialize(input);
+        }
+
+        @Override
+        public Object parseLiteral(Object input) {
+            if (input instanceof StringValue) {
+                return parseStringToDate(((StringValue) input).getValue());
+            } else if (input instanceof IntValue) {
+                BigInteger value = ((IntValue) input).getValue();
+                return new java.sql.Date(value.longValue());
+            }
+            return null;
+        }
+
+        private java.sql.Date parseStringToDate(String input) {
+            try {
+                return new java.sql.Date(DateFormat.getInstance().parse(input).getTime());
+            } catch (ParseException e) {
+                log.warn("Failed to parse SQL Date from input: " + input, e);
+                return null;
+            }
+        }
+    }
+
+    public static class GraphQLSqlTimestampCoercing implements Coercing<Object, Object> {
+
+        @Override
+        public Object serialize(Object input) {
+            if (input instanceof String) {
+                return parseStringToTimestamp((String) input);
+            } else if (input instanceof Date) {
+                return new java.sql.Timestamp(((Date) input).getTime());
+            } else if (input instanceof Long) {
+                return new java.sql.Timestamp(((Long) input).longValue());
+            } else if (input instanceof Integer) {
+                return new java.sql.Timestamp(((Integer) input).longValue());
+            }
+            return null;
+        }
+
+        @Override
+        public Object parseValue(Object input) {
+            return serialize(input);
+        }
+
+        @Override
+        public Object parseLiteral(Object input) {
+            if (input instanceof StringValue) {
+                return parseStringToTimestamp(((StringValue) input).getValue());
+            } else if (input instanceof IntValue) {
+                BigInteger value = ((IntValue) input).getValue();
+                return new java.sql.Date(value.longValue());
+            }
+            return null;
+        }
+
+        private java.sql.Timestamp parseStringToTimestamp(String input) {
+            try {
+                return new java.sql.Timestamp(DateFormat.getInstance().parse(input).getTime());
+            } catch (ParseException e) {
+                log.warn("Failed to parse Timestamp from input: " + input, e);
+                return null;
+            }
+        }
+    }
+
+    public static class GraphQLLOBCoercing implements Coercing<Object, Object> {
+
+        @Override
+        public Object serialize(Object input) {
+            if (input.getClass() == byte[].class) {
+                return input;
+            }
+            return null;
+        }
+
+        @Override
+        public Object parseValue(Object input) {
+            if (input instanceof String) {
+                return parseStringToByteArray((String) input);
+            }
+            return null;
+        }
+
+        @Override
+        public Object parseLiteral(Object input) {
+            if (input instanceof StringValue) {
+                return parseStringToByteArray(((StringValue) input).getValue());
+            }
+            return null;
+        }
+
+        private byte[] parseStringToByteArray(String input) {
+            try {
+                return input.getBytes(StandardCharsets.UTF_8);
+            } catch (IllegalArgumentException e) {
+                log.warn("Failed to parse byte[] from input: " + input, e);
+                return null;
+            }
+        }
+    }
 }

--- a/graphql-jpa-query-schema/src/main/java/com/introproventures/graphql/jpa/query/schema/NamingStrategy.java
+++ b/graphql-jpa-query-schema/src/main/java/com/introproventures/graphql/jpa/query/schema/NamingStrategy.java
@@ -19,6 +19,7 @@ package com.introproventures.graphql.jpa.query.schema;
 
 import javax.persistence.metamodel.EmbeddableType;
 import javax.persistence.metamodel.EntityType;
+import javax.persistence.metamodel.ManagedType;
 
 import org.atteo.evo.inflector.English;
 
@@ -30,6 +31,16 @@ public interface NamingStrategy {
     default String pluralize(String word) {
         return English.plural(word);
     }; 
+
+    default String getName(ManagedType<?> entityType) {
+        if (entityType instanceof EntityType)
+            return getName((EntityType<?>)entityType);
+
+        if (entityType instanceof EmbeddableType)
+            return getName((EmbeddableType<?>) entityType);
+
+        return entityType.getJavaType().getSimpleName();
+    }
 
     default String getName(EntityType<?> entityType) {
         return entityType.getName();

--- a/graphql-jpa-query-schema/src/main/java/com/introproventures/graphql/jpa/query/schema/exception/AuthorizationException.java
+++ b/graphql-jpa-query-schema/src/main/java/com/introproventures/graphql/jpa/query/schema/exception/AuthorizationException.java
@@ -1,0 +1,28 @@
+/*
+ * Copyright IBM Corporation 2018
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.introproventures.graphql.jpa.query.schema.exception;
+
+/**
+ * Authorization exception thrown when the query contains elements to which the user is not authorized
+ *
+ * @author Ghada Obaid
+ */
+public class AuthorizationException extends RuntimeException {
+    public AuthorizationException() {
+        super("AUTH_ERR: You are not authorized to access the requested resource");
+    }
+}

--- a/graphql-jpa-query-schema/src/main/java/com/introproventures/graphql/jpa/query/schema/impl/GraphQLJpaAlternateAttributeDataFetcher.java
+++ b/graphql-jpa-query-schema/src/main/java/com/introproventures/graphql/jpa/query/schema/impl/GraphQLJpaAlternateAttributeDataFetcher.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright IBM Corporation 2018
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.introproventures.graphql.jpa.query.schema.impl;
+
+import javax.persistence.EntityManager;
+import javax.persistence.metamodel.EntityType;
+import javax.persistence.metamodel.PluralAttribute;
+
+import com.introproventures.graphql.jpa.query.schema.IQueryAuthorizationStrategy;
+import com.introproventures.graphql.jpa.query.schema.exception.AuthorizationException;
+import graphql.schema.DataFetchingEnvironment;
+
+/**
+ * Similar to PropertyDataFetcher, this uses getters to retrieve attribute data, allowing JPA to determine how to construct
+ * the SQL based on annotations in the domain model. The attributes thus retrieved are subject to the authorization on the attribute,
+ * if specified in the schema.
+ * <p>
+ * This is useful for retrieving associations that are marked with BatchFetch in Eclipselink
+ *
+ * @author Ghada Obaid
+ */
+class GraphQLJpaAlternateAttributeDataFetcher extends GraphQLJpaOneToManyDataFetcher {
+
+    public GraphQLJpaAlternateAttributeDataFetcher(EntityManager entityManager, EntityType<?> entityType, PluralAttribute<Object, Object, Object> attribute,
+                                                   IQueryAuthorizationStrategy authorizationStrategy) {
+        super(entityManager, entityType, attribute, authorizationStrategy);
+    }
+
+    @Override
+    public Object get(DataFetchingEnvironment environment) {
+        if (authorization != null && !authorization.isAuthorized(attribute))
+            throw new AuthorizationException();
+
+        Object source = environment.getSource();
+
+        return getAttributeValue(source, attribute);
+    }
+}

--- a/graphql-jpa-query-schema/src/main/java/com/introproventures/graphql/jpa/query/schema/impl/GraphQLJpaExecutor.java
+++ b/graphql-jpa-query-schema/src/main/java/com/introproventures/graphql/jpa/query/schema/impl/GraphQLJpaExecutor.java
@@ -1,5 +1,6 @@
 /*
  * Copyright 2017 IntroPro Ventures Inc. and/or its affiliates.
+ * Copyright IBM Corporation 2018
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -17,6 +18,7 @@
 package com.introproventures.graphql.jpa.query.schema.impl;
 
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.Map;
 
 import javax.transaction.Transactional;
@@ -50,7 +52,7 @@ public class GraphQLJpaExecutor implements GraphQLExecutor {
     }
 
     /* (non-Javadoc)
-     * @see org.activiti.services.query.qraphql.jpa.QraphQLExecutor#execute(java.lang.String)
+     * @see org.activiti.services.query.qraphql.jpa.GraphQLExecutor#execute(java.lang.String)
      */
     @Override
     @Transactional(TxType.SUPPORTS)
@@ -59,7 +61,7 @@ public class GraphQLJpaExecutor implements GraphQLExecutor {
     }
 
     /* (non-Javadoc)
-     * @see org.activiti.services.query.qraphql.jpa.QraphQLExecutor#execute(java.lang.String, java.util.Map)
+     * @see org.activiti.services.query.qraphql.jpa.GraphQLExecutor#execute(java.lang.String, java.util.Map)
      */
     @Override
     @Transactional(TxType.SUPPORTS)
@@ -81,4 +83,22 @@ public class GraphQLJpaExecutor implements GraphQLExecutor {
             return graphQL.execute(executionInput);
     }
 
+    @Override
+    @Transactional(TxType.SUPPORTS)
+    public ExecutionResult execute(String query, Map<String, Object> arguments, Object user) {
+
+        // Need to inject variables in context to support parameter bindings in reverse queries
+        Map<String, Object> context = new HashMap<>();
+        context.put("variables", arguments);
+        context.put("userContext", user);
+
+        ExecutionInput executionInput = ExecutionInput.newExecutionInput()
+                .query(query)
+                .variables(arguments)
+                .root(context)
+                .context(context)
+                .build();
+
+        return graphQL.execute(executionInput);
+    }
 }

--- a/graphql-jpa-query-schema/src/main/java/com/introproventures/graphql/jpa/query/schema/impl/GraphQLJpaOneToManyDataFetcher.java
+++ b/graphql-jpa-query-schema/src/main/java/com/introproventures/graphql/jpa/query/schema/impl/GraphQLJpaOneToManyDataFetcher.java
@@ -16,6 +16,9 @@
 
 package com.introproventures.graphql.jpa.query.schema.impl;
 
+import com.introproventures.graphql.jpa.query.schema.IQueryAuthorizationStrategy;
+import com.introproventures.graphql.jpa.query.schema.exception.AuthorizationException;
+
 import java.lang.reflect.Member;
 import java.lang.reflect.Method;
 import java.util.List;
@@ -39,109 +42,113 @@ import graphql.language.Selection;
 import graphql.schema.DataFetchingEnvironment;
 
 /**
- * One-To-Many DataFetcher that uses where argument to filter collection attributes 
- * 
+ * One-To-Many DataFetcher that uses where argument to filter collection attributes
+ *
  * @author Igor Dianov
  *
  */
 class GraphQLJpaOneToManyDataFetcher extends GraphQLJpaQueryDataFetcher {
-    
-    private final PluralAttribute<Object,Object,Object> attribute;
 
-    public GraphQLJpaOneToManyDataFetcher(EntityManager entityManager, EntityType<?> entityType, PluralAttribute<Object,Object,Object> attribute) {
-        super(entityManager, entityType);
-        
+    protected final PluralAttribute<Object, Object, Object> attribute;
+
+    public GraphQLJpaOneToManyDataFetcher(EntityManager entityManager, EntityType<?> entityType, PluralAttribute<Object, Object, Object> attribute,
+                                          IQueryAuthorizationStrategy authorizationStrategy) {
+        super(entityManager, entityType, authorizationStrategy);
+
         this.attribute = attribute;
     }
-    
+
     @Override
     public Object get(DataFetchingEnvironment environment) {
+        if (authorization != null && !authorization.isAuthorized(entityType))
+            throw new AuthorizationException();
+
         Field field = environment.getFields().iterator().next();
 
         Object source = environment.getSource();
         Optional<Argument> whereArg = extractArgument(environment, field, GraphQLJpaSchemaBuilder.QUERY_WHERE_PARAM_NAME);
-        
+
         // Resolve collection query if where argument is present or any field in selection has orderBy argument
-        if(whereArg.isPresent() || hasSelectionAnyOrderBy(field)) {
+        if (whereArg.isPresent() || hasSelectionAnyOrderBy(field)) {
 
             //EntityGraph<?> entityGraph = buildEntityGraph(new Field("select", new SelectionSet(Arrays.asList(field))));
-            
+
             return getQuery(environment, field, true)
-                //.setHint("javax.persistence.fetchgraph", entityGraph) // TODO: fix runtime exception
-                .getResultList();
+                    //.setHint("javax.persistence.fetchgraph", entityGraph) // TODO: fix runtime exception
+                    .getResultList();
         }
 
         // Let hibernate resolve collection query
         return getAttributeValue(source, attribute);
     }
-    
+
     private boolean hasSelectionAnyOrderBy(Field field) {
-    	
-    	if(!hasSelectionSet(field)) return false;
-    	
+
+        if (!hasSelectionSet(field)) return false;
+
         // Loop through all of the fields being requested
-        for(Selection selection : field.getSelectionSet().getSelections()) {
+        for (Selection selection : field.getSelectionSet().getSelections()) {
             if (selection instanceof Field) {
                 Field selectedField = (Field) selection;
 
                 // "__typename" is part of the graphql introspection spec and has to be ignored by jpa
-                if(!"__typename".equals(selectedField.getName())) {
+                if (!TYPENAME.equals(selectedField.getName())) {
 
-	                // Optional orderBy argument
-	                Optional<Argument> orderBy = selectedField.getArguments().stream()
-	                    .filter(this::isOrderByArgument)
-	                    .findFirst();
-	                
-	                if(orderBy.isPresent()) {
-                    	return true;
-	                }
+                    // Optional orderBy argument
+                    Optional<Argument> orderBy = selectedField.getArguments().stream()
+                            .filter(this::isOrderByArgument)
+                            .findFirst();
+
+                    if (orderBy.isPresent()) {
+                        return true;
+                    }
                 }
             }
         }
 
         return false;
-    	
-    }    
-    @SuppressWarnings( { "rawtypes", "unchecked" } )
+
+    }
+    @SuppressWarnings({"rawtypes", "unchecked"})
     @Override
     protected TypedQuery<?> getQuery(DataFetchingEnvironment environment, Field field, boolean isDistinct) {
-        
+
         Object source = environment.getSource();
-        
+
         SingularAttribute parentIdAttribute = entityType.getId(Object.class);
-        
+
         Object parentIdValue = getAttributeValue(source, parentIdAttribute);
-        
+
         CriteriaBuilder cb = entityManager.getCriteriaBuilder();
         CriteriaQuery<Object> query = cb.createQuery((Class<Object>) entityType.getJavaType());
         //CriteriaQuery<Tuple> query = cb.createTupleQuery();
         Root<?> from = query.from(entityType);
-        
+
         from.alias("owner");
-        
+
         // Must use inner join in parent context
         Join join = from.join(attribute.getName())
-            .on(cb.in(from.get(parentIdAttribute.getName())).value(parentIdValue));
-        
+                .on(cb.in(from.get(parentIdAttribute.getName())).value(parentIdValue));
+
         query.select(join.alias(attribute.getName()));
         //query.multiselect(from.alias("owner"), join.alias(attribute.getName()));
-        
+
         List<Predicate> predicates = getFieldArguments(field, query, cb, join).stream()
-            .map(it -> getPredicate(cb, from, join, environment, it))
-            .filter(it -> it != null)
-            .collect(Collectors.toList());
-        
+                .map(it -> getPredicate(cb, from, join, environment, it))
+                .filter(it -> it != null)
+                .collect(Collectors.toList());
+
         query.where(
-            predicates.toArray(new Predicate[predicates.size()])
+                predicates.toArray(new Predicate[predicates.size()])
         );
-        
+
         // optionally add default ordering 
         mayBeAddDefaultOrderBy(query, join, cb);
-        
+
         return entityManager.createQuery(query.distinct(true));
-        
+
     }
-    
+
     /**
      * Fetches the value of the given SingularAttribute on the given
      * entity.
@@ -154,16 +161,16 @@ class GraphQLJpaOneToManyDataFetcher extends GraphQLJpaQueryDataFetcher {
             Member member = field.getJavaMember();
             if (member instanceof Method) {
                 // this should be a getter method:
-                return (FieldType) ((Method)member).invoke(entity);
+                return (FieldType) ((Method) member).invoke(entity);
             } else if (member instanceof java.lang.reflect.Field) {
-                return (FieldType) ((java.lang.reflect.Field)member).get(entity);
+                return (FieldType) ((java.lang.reflect.Field) member).get(entity);
             } else {
                 throw new IllegalArgumentException("Unexpected java member type. Expecting method or field, found: " + member);
             }
         } catch (Exception e) {
             throw new RuntimeException(e);
         }
-    }    
+    }
 
     /**
      * Fetches the value of the given SingularAttribute on the given
@@ -177,15 +184,15 @@ class GraphQLJpaOneToManyDataFetcher extends GraphQLJpaQueryDataFetcher {
             Member member = field.getJavaMember();
             if (member instanceof Method) {
                 // this should be a getter method:
-                return (FieldType) ((Method)member).invoke(entity);
+                return (FieldType) ((Method) member).invoke(entity);
             } else if (member instanceof java.lang.reflect.Field) {
-                return (FieldType) ((java.lang.reflect.Field)member).get(entity);
+                return (FieldType) ((java.lang.reflect.Field) member).get(entity);
             } else {
                 throw new IllegalArgumentException("Unexpected java member type. Expecting method or field, found: " + member);
             }
         } catch (Exception e) {
             throw new RuntimeException(e);
         }
-    }    
-    
+    }
+
 }

--- a/graphql-jpa-query-schema/src/main/java/com/introproventures/graphql/jpa/query/schema/impl/GraphQLJpaPropertyDataFetcher.java
+++ b/graphql-jpa-query-schema/src/main/java/com/introproventures/graphql/jpa/query/schema/impl/GraphQLJpaPropertyDataFetcher.java
@@ -16,13 +16,16 @@
 
 package com.introproventures.graphql.jpa.query.schema.impl;
 
-import javax.persistence.EntityManager;
-import javax.persistence.metamodel.EntityType;
-import javax.persistence.metamodel.PluralAttribute;
-
 import com.introproventures.graphql.jpa.query.schema.IQueryAuthorizationStrategy;
 import com.introproventures.graphql.jpa.query.schema.exception.AuthorizationException;
 import graphql.schema.DataFetchingEnvironment;
+import graphql.schema.GraphQLDirective;
+import graphql.schema.PropertyDataFetcher;
+
+import javax.persistence.EntityManager;
+import javax.persistence.metamodel.Attribute;
+import javax.persistence.metamodel.EntityType;
+import javax.persistence.metamodel.PluralAttribute;
 
 /**
  * Similar to PropertyDataFetcher, this uses getters to retrieve attribute data, allowing JPA to determine how to construct
@@ -33,19 +36,19 @@ import graphql.schema.DataFetchingEnvironment;
  *
  * @author Ghada Obaid
  */
-class GraphQLJpaAlternateAttributeDataFetcher extends GraphQLJpaOneToManyDataFetcher {
+class GraphQLJpaPropertyDataFetcher extends PropertyDataFetcher {
+    private final Attribute<?,?> attribute;
+    private final IQueryAuthorizationStrategy authorization;
 
-    public GraphQLJpaAlternateAttributeDataFetcher(EntityManager entityManager, EntityType<?> entityType, PluralAttribute<Object, Object, Object> attribute,
-                                                   IQueryAuthorizationStrategy authorizationStrategy) {
-        super(entityManager, entityType, attribute, authorizationStrategy);
+    public GraphQLJpaPropertyDataFetcher(Attribute<?,?> attribute, IQueryAuthorizationStrategy authorizationStrategy) {
+        super(attribute.getName());
+        this.attribute = attribute;
+        this.authorization = authorizationStrategy;
     }
 
     @Override
     public Object get(DataFetchingEnvironment environment) {
         authorization.checkAuthorization(environment);
-
-        Object source = environment.getSource();
-
-        return getAttributeValue(source, attribute);
+        return super.get(environment);
     }
 }

--- a/graphql-jpa-query-schema/src/main/java/com/introproventures/graphql/jpa/query/schema/impl/GraphQLJpaQueryAlternateDataFetcher.java
+++ b/graphql-jpa-query-schema/src/main/java/com/introproventures/graphql/jpa/query/schema/impl/GraphQLJpaQueryAlternateDataFetcher.java
@@ -1,0 +1,434 @@
+/*
+ * Copyright 2017 IntroPro Ventures Inc. and/or its affiliates.
+ * Copyright IBM Corporation 2018
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.introproventures.graphql.jpa.query.schema.impl;
+
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.stream.Collectors;
+
+import javax.persistence.EntityManager;
+import javax.persistence.TypedQuery;
+import javax.persistence.criteria.CriteriaBuilder;
+import javax.persistence.criteria.CriteriaQuery;
+import javax.persistence.criteria.From;
+import javax.persistence.criteria.Join;
+import javax.persistence.criteria.JoinType;
+import javax.persistence.criteria.Order;
+import javax.persistence.criteria.Path;
+import javax.persistence.criteria.Predicate;
+import javax.persistence.criteria.Root;
+import javax.persistence.criteria.Selection;
+import javax.persistence.metamodel.Attribute;
+import javax.persistence.metamodel.EntityType;
+import javax.persistence.metamodel.PluralAttribute;
+import javax.persistence.metamodel.SingularAttribute;
+
+import com.introproventures.graphql.jpa.query.schema.IQueryAuthorizationStrategy;
+import com.introproventures.graphql.jpa.query.schema.exception.AuthorizationException;
+import graphql.GraphQLException;
+import static graphql.introspection.Introspection.SchemaMetaFieldDef;
+import static graphql.introspection.Introspection.TypeMetaFieldDef;
+import static graphql.introspection.Introspection.TypeNameMetaFieldDef;
+import graphql.language.Argument;
+import graphql.language.BooleanValue;
+import graphql.language.EnumValue;
+import graphql.language.Field;
+import graphql.language.IntValue;
+import graphql.language.ObjectValue;
+import graphql.schema.DataFetchingEnvironment;
+import graphql.schema.DataFetchingEnvironmentImpl;
+import graphql.schema.GraphQLFieldDefinition;
+import graphql.schema.GraphQLList;
+import graphql.schema.GraphQLObjectType;
+import graphql.schema.GraphQLSchema;
+
+/**
+ * An alternate JPA Query DataFetcher for Eclipselink's BatchFetch support, used in conjunction with the alternate
+ * attribute fetcher
+ * <p>
+ * This implementation fetches entities with page and where criteria expressions
+ *
+ * @author Ghada Obaid
+ */
+class GraphQLJpaQueryAlternateDataFetcher extends QraphQLJpaBaseDataFetcher {
+    public GraphQLJpaQueryAlternateDataFetcher(EntityManager entityManager, EntityType<?> entityType, IQueryAuthorizationStrategy authorizationStrategy) {
+        super(entityManager, entityType, authorizationStrategy);
+    }
+
+    @Override
+    public Object get(DataFetchingEnvironment environment) {
+        if (authorization != null && !authorization.isAuthorized(entityType))
+            throw new AuthorizationException();
+
+        Field field = environment.getFields().iterator().next();
+        Map<String, Object> result = new LinkedHashMap<>();
+
+        // See which fields we're requesting
+        Optional<Field> pagesSelection = getSelectionField(field, GraphQLJpaSchemaBuilder.PAGE_PAGES_PARAM_NAME);
+        Optional<Field> totalSelection = getSelectionField(field, GraphQLJpaSchemaBuilder.PAGE_TOTAL_PARAM_NAME);
+        Optional<Field> recordsSelection = getSelectionField(field, GraphQLJpaSchemaBuilder.QUERY_SELECT_PARAM_NAME);
+
+        Page page = extractPageArgument(environment, field);
+        //Limit the number of rows to return per request
+        if (page.size > 1000)
+            page.size = 1000;
+
+        Argument distinctArg = extractArgument(environment, field, GraphQLJpaSchemaBuilder.SELECT_DISTINCT_PARAM_NAME, new BooleanValue(true));
+
+        boolean isDistinct = ((BooleanValue) distinctArg.getValue()).isValue();
+
+        DataFetchingEnvironment queryEnvironment = environment;
+        Field queryField = field;
+
+        if (recordsSelection.isPresent()) {
+            // Override query environment
+            String fieldName = recordsSelection.get().getName();
+
+            queryEnvironment = Optional.of(getFieldDef(environment.getGraphQLSchema(), (GraphQLObjectType) environment.getParentType(), field))
+                    .map(it -> (GraphQLObjectType) it.getType()).map(it -> it.getFieldDefinition(GraphQLJpaSchemaBuilder.QUERY_SELECT_PARAM_NAME))
+                    .map(it -> (DataFetchingEnvironment) new DataFetchingEnvironmentImpl(environment.getSource(), environment.getArguments(),
+                            environment.getContext(), environment.getRoot(), environment.getFieldDefinition(), environment.getFields(), it.getType(),
+                            environment.getParentType(), environment.getGraphQLSchema(), environment.getFragmentsByName(), environment.getExecutionId(),
+                            environment.getSelectionSet(), environment.getFieldTypeInfo()))
+                    .orElse(environment);
+
+            queryField = new Field(fieldName, field.getArguments(), recordsSelection.get().getSelectionSet());
+
+            TypedQuery<?> query = null;
+            List<Object> entityIds = getIdsToRestrict(environment, queryField, page);
+            query = entityManager.createQuery(getQuery(queryEnvironment, queryField, isDistinct, entityIds));
+
+            result.put(GraphQLJpaSchemaBuilder.QUERY_SELECT_PARAM_NAME, query.getResultList());
+        }
+
+        if (totalSelection.isPresent() || pagesSelection.isPresent()) {
+            final DataFetchingEnvironment countQueryEnvironment = queryEnvironment;
+            final Field countQueryField = queryField;
+
+            final Long total = recordsSelection.map(contentField -> getCountQuery(countQueryEnvironment, countQueryField).getSingleResult())
+                    // if no "content" was selected an empty Field can be used
+                    .orElseGet(() -> getCountQuery(environment, new Field()).getSingleResult());
+
+            result.put(GraphQLJpaSchemaBuilder.PAGE_TOTAL_PARAM_NAME, total);
+            result.put(GraphQLJpaSchemaBuilder.PAGE_PAGES_PARAM_NAME, ((Double) Math.ceil(total / (double) page.size)).longValue());
+        }
+
+        return result;
+    }
+
+    @Override
+    protected Predicate getPredicate(CriteriaBuilder cb, Root<?> root, From<?, ?> path, DataFetchingEnvironment environment, Argument argument) {
+        if (isLogicalArgument(argument) || isDistinctArgument(argument))
+            return null;
+
+        if (isWhereArgument(argument))
+            return getWherePredicate(cb, root, path, new ArgumentEnvironment(environment, argument.getName()), argument);
+
+        return super.getPredicate(cb, root, path, environment, argument);
+    }
+
+    private List<Object> getIdsToRestrict(DataFetchingEnvironment environment, Field field, Page page) {
+        CriteriaBuilder cb = entityManager.getCriteriaBuilder();
+        CriteriaQuery<Object> query = cb.createQuery(Object.class);
+        Root<?> from = query.from(entityType);
+
+        getQuery(environment, field, true, null, cb, query, from);
+
+        SingularAttribute<?, ?> idAttribute = entityType.getId(Object.class);
+        query.select(from.get(idAttribute.getName()));
+
+        List<Object> entityIds = entityManager.createQuery(query).setFirstResult((page.page - 1) * page.size).setMaxResults(page.size).getResultList();
+
+        return entityIds;
+    }
+
+    private TypedQuery<Long> getCountQuery(DataFetchingEnvironment environment, Field field) {
+        CriteriaBuilder cb = entityManager.getCriteriaBuilder();
+        CriteriaQuery<Long> query = cb.createQuery(Long.class);
+        Root<?> root = query.from(entityType);
+
+        getQuery(environment, field, true, null, cb, query, root);
+
+        query.orderBy();
+
+        SingularAttribute<?, ?> idAttribute = entityType.getId(Object.class);
+        query.select(cb.countDistinct(root.get(idAttribute.getName())));
+
+        return entityManager.createQuery(query);
+    }
+
+    private Page extractPageArgument(DataFetchingEnvironment environment, Field field) {
+        Optional<Argument> paginationRequest = field.getArguments().stream().filter(it -> GraphQLJpaSchemaBuilder.PAGE_PARAM_NAME.equals(it.getName()))
+                .findFirst();
+
+        if (paginationRequest.isPresent()) {
+            field.getArguments().remove(paginationRequest.get());
+
+            ObjectValue paginationValues = (ObjectValue) paginationRequest.get().getValue();
+
+            IntValue page = (IntValue) paginationValues.getObjectFields().stream()
+                    .filter(it -> GraphQLJpaSchemaBuilder.PAGE_START_PARAM_NAME.equals(it.getName())).findFirst().get().getValue();
+
+            IntValue size = (IntValue) paginationValues.getObjectFields().stream()
+                    .filter(it -> GraphQLJpaSchemaBuilder.PAGE_LIMIT_PARAM_NAME.equals(it.getName())).findFirst().get().getValue();
+
+            return new Page(page.getValue().intValue(), size.getValue().intValue());
+        }
+
+        return new Page(1, Integer.MAX_VALUE);
+    }
+
+    private Boolean isWhereArgument(Argument argument) {
+        return GraphQLJpaSchemaBuilder.QUERY_WHERE_PARAM_NAME.equals(argument.getName());
+
+    }
+
+    private Boolean isLogicalArgument(Argument argument) {
+        return GraphQLJpaSchemaBuilder.QUERY_LOGICAL_PARAM_NAME.equals(argument.getName());
+    }
+
+    private Boolean isDistinctArgument(Argument argument) {
+        return GraphQLJpaSchemaBuilder.SELECT_DISTINCT_PARAM_NAME.equals(argument.getName());
+    }
+
+    private static final class Page {
+        public Integer page;
+        public Integer size;
+
+        public Page(Integer page, Integer size) {
+            this.page = page;
+            this.size = size;
+        }
+    }
+
+    protected CriteriaQuery<?> getQuery(DataFetchingEnvironment environment, Field field, boolean isDistinct, List<Object> restrictedIds) {
+        CriteriaBuilder cb = entityManager.getCriteriaBuilder();
+        CriteriaQuery<?> query = cb.createQuery(entityType.getJavaType());
+        Root<?> from = query.from(entityType);
+
+        return getQuery(environment, field, isDistinct, restrictedIds, cb, query, from);
+    }
+
+    protected CriteriaQuery<?> getQuery(DataFetchingEnvironment environment, Field field, boolean isDistinct, List<Object> restrictedIds, CriteriaBuilder cb,
+                                        CriteriaQuery<?> query, Root<?> from) {
+
+        from.alias(from.getModel().getName());
+
+        //This is used to generate the proper joins for retricted IDs and count queries
+        if (restrictedIds == null)
+            buildQuery(field, query, from, restrictedIds != null);
+
+        // Where clauses are to be applied for count and ID queries.  Once we have the IDs, there is no more need for the
+        // where clauses
+        List<Predicate> predicates = null;
+        if (restrictedIds != null) {
+            predicates = new ArrayList<>(1);
+            if (!restrictedIds.isEmpty()) {
+                //Ensure that the IN clause has values
+                String idName = entityType.getId(Object.class).getName();
+                CriteriaBuilder.In<Object> in = cb.in(from.get(idName));
+                restrictedIds.forEach(entityId -> in.value(entityId));
+                predicates.add(in);
+            } else {
+                //Ensure an empty result is returned in this case
+                predicates.add(cb.equal(cb.literal(1), cb.literal(0)));
+            }
+        } else {
+            predicates = getPredicates(environment, field, cb, query, from);
+        }
+
+        // Use AND clause to filter results
+        if (!predicates.isEmpty())
+            query.where(predicates.toArray(new Predicate[predicates.size()]));
+
+        //Add orderBy clause
+        List<Order> orderByList = new ArrayList<>(2);
+        setOrderBy(field, query, cb, from, orderByList);
+
+        // optionally add default ordering
+        mayBeAddDefaultOrderBy(query, from, cb);
+
+        return query.distinct(isDistinct);
+    }
+
+    private void buildQuery(Field field, CriteriaQuery<?> query, Root<?> root, boolean doSelect) {
+        List<Selection<?>> selectionList = new ArrayList<Selection<?>>();
+        selections(field).forEach(it -> {
+            if (hasSelectionSet(it)) {
+                Attribute<?, ?> attribute = root.getModel().getAttribute(it.getName());
+                Join<?, ?> join;
+                if (useOuterJoin(attribute, field))
+                    join = root.join(it.getName(), JoinType.LEFT);
+                else
+                    join = root.join(it.getName(), JoinType.INNER);
+                buildSubquery(it, selectionList, query, join, attribute);
+            } else {
+                Path<?> currentPath = root.get(it.getName());
+                selectionList.add(currentPath);
+            }
+
+        });
+
+        if (!selectionList.isEmpty() && doSelect)
+            query.multiselect(selectionList);
+    }
+
+    /**
+     * Determines whether the query should use an inner or outer join. An outer join is used if:
+     * 1. there is no where clause and the attribute is nullable; or
+     * 2. this is a one-to-many or many-to-many relationship
+     *
+     * @param attribute
+     * @param field
+     * @return
+     */
+    private boolean useOuterJoin(Attribute<?, ?> attribute, Field field) {
+        Optional<Argument> whereArgument = field.getArguments().stream().filter(arg -> !isOrderByArgument(arg) && !isDistinctArgument(arg)).findFirst();
+        return (!whereArgument.isPresent()
+                && ((attribute instanceof SingularAttribute && ((SingularAttribute<?, ?>) attribute).isOptional()) || attribute instanceof PluralAttribute));
+    }
+
+    private void buildSubquery(Field field, List<Selection<?>> selectionList, CriteriaQuery<?> query, Join<?, ?> join, Attribute<?, ?> parentAttribute) {
+        selections(field).forEach(it -> {
+            if (hasSelectionSet(it)) {
+                EntityType<?> entityType = entityManager.getMetamodel().entity(parentAttribute.getJavaType());
+                Attribute<?, ?> attribute = entityType.getAttribute(it.getName());
+                Optional<Argument> whereArgument = it.getArguments().stream().filter(arg -> !isOrderByArgument(arg)).findFirst();
+                Join<?, ?> nextJoin;
+                if (useOuterJoin(attribute, it)) {
+                    nextJoin = join.join(it.getName(), JoinType.LEFT);
+                } else {
+                    nextJoin = join.join(it.getName(), JoinType.INNER);
+                }
+                buildSubquery(it, selectionList, query, nextJoin, attribute);
+            }
+        });
+
+    }
+
+    protected List<Predicate> getPredicates(DataFetchingEnvironment environment, Field field, CriteriaBuilder cb, CriteriaQuery<?> query, Root<?> from) {
+        // Build predicates from query arguments
+        List<Predicate> predicates = getFieldArgumentsWithoutProcessingAssociations(field, query, cb, from).stream().map(it -> getPredicate(cb, from, from, environment, it))
+                .filter(it -> it != null).collect(Collectors.toList());
+
+        return predicates;
+    }
+
+    @Override
+    protected GraphQLFieldDefinition getFieldDef(GraphQLSchema schema, GraphQLObjectType parentType, Field field) {
+        if (schema.getQueryType() == parentType) {
+            if (field.getName().equals(SchemaMetaFieldDef.getName())) {
+                return SchemaMetaFieldDef;
+            }
+            if (field.getName().equals(TypeMetaFieldDef.getName())) {
+                return TypeMetaFieldDef;
+            }
+        }
+        if (field.getName().equals(TypeNameMetaFieldDef.getName())) {
+            return TypeNameMetaFieldDef;
+        }
+
+        //When batch fetching, the child's where clause must be part of the parent query in order
+        //to properly restrict the query and get correct counts
+        GraphQLObjectType parentTypeToCheck = parentType;
+        if (parentType.getFieldDefinition("select") != null)
+            parentTypeToCheck = (GraphQLObjectType) ((GraphQLList) parentType.getFieldDefinition("select").getType()).getWrappedType();
+
+        GraphQLFieldDefinition fieldDefinition = parentTypeToCheck.getFieldDefinition(field.getName());
+        if (fieldDefinition == null) {
+            throw new GraphQLException("unknown field " + field.getName());
+        }
+        return fieldDefinition;
+    }
+
+    private List<Argument> getFieldArgumentsWithoutProcessingAssociations(Field field, CriteriaQuery<?> query, CriteriaBuilder cb, From<?, ?> from) {
+
+        List<Argument> arguments = new ArrayList<>();
+
+        if (field.getSelectionSet() == null)
+            return arguments;
+
+        // Loop through all of the fields being requested
+        field.getSelectionSet().getSelections().forEach(selection -> {
+            if (selection instanceof Field) {
+                Field selectedField = (Field) selection;
+
+                // "__typename" is part of the graphql introspection spec and has to be ignored by jpa
+                if (!TYPENAME.equals(selectedField.getName())) {
+
+                    // Process where arguments clauses.
+                    arguments.addAll(selectedField.getArguments().stream().filter(it -> !isOrderByArgument(it))
+                            .map(it -> new Argument(selectedField.getName() + "." + it.getName(), it.getValue())).collect(Collectors.toList()));
+                }
+            }
+        });
+
+        arguments.addAll(field.getArguments());
+
+        return arguments;
+    }
+
+    protected void setOrderBy(Field field, CriteriaQuery<?> query, CriteriaBuilder cb, From<?, ?> from, List<Order> orderList) {
+        if (field.getSelectionSet() == null)
+            return;
+
+        // Loop through all of the fields being requested
+        field.getSelectionSet().getSelections().forEach(selection -> {
+            if (selection instanceof Field) {
+                Field selectedField = (Field) selection;
+
+                // "__typename" is part of the graphql introspection spec and has to be ignored by jpa
+                if (!TYPENAME.equals(selectedField.getName())) {
+
+                    // Process the orderBy clause
+                    if (selectedField.getSelectionSet() != null) {
+                        Join<?, ?> joinToReuse = null;
+                        Attribute<?, ?> attribute = null;
+                        if (from instanceof Root) {
+                            attribute = ((Root<?>) from).getModel().getAttribute(selectedField.getName());
+                        } else {
+                            attribute = ((Join<?, ?>) from).getAttribute();
+                        }
+                        if (useOuterJoin(attribute, selectedField))
+                            joinToReuse = reuseJoin(from, selectedField.getName(), true);
+                        else
+                            joinToReuse = reuseJoin(from, selectedField.getName(), false);
+
+                        setOrderBy(selectedField, query, cb, joinToReuse, orderList);
+                    } else {
+                        Path<?> fieldPath = from.get(selectedField.getName());
+                        selectedField.getArguments().stream().filter(this::isOrderByArgument).forEach(orderByArgument -> {
+                            if ("DESC".equals(((EnumValue) orderByArgument.getValue()).getName()))
+                                orderList.add(cb.desc(fieldPath));
+                            else
+                                orderList.add(cb.asc(fieldPath));
+
+                        });
+                    }
+
+                }
+            }
+        });
+
+        if (!orderList.isEmpty())
+            query.orderBy(orderList);
+    }
+
+}

--- a/graphql-jpa-query-schema/src/main/java/com/introproventures/graphql/jpa/query/schema/impl/GraphQLJpaQueryAlternateDataFetcher.java
+++ b/graphql-jpa-query-schema/src/main/java/com/introproventures/graphql/jpa/query/schema/impl/GraphQLJpaQueryAlternateDataFetcher.java
@@ -308,7 +308,11 @@ class GraphQLJpaQueryAlternateDataFetcher extends QraphQLJpaBaseDataFetcher {
     private void buildSubquery(Field field, List<Selection<?>> selectionList, CriteriaQuery<?> query, Join<?, ?> join, Attribute<?, ?> parentAttribute) {
         selections(field).forEach(it -> {
             if (hasSelectionSet(it)) {
-                EntityType<?> entityType = entityManager.getMetamodel().entity(parentAttribute.getJavaType());
+                EntityType<?> entityType = null;
+                if (parentAttribute.isCollection())
+                    entityType = entityManager.getMetamodel().entity(parentAttribute.getDeclaringType().getJavaType());
+                else
+                    entityType = entityManager.getMetamodel().entity(parentAttribute.getJavaType());
                 Attribute<?, ?> attribute = entityType.getAttribute(it.getName());
                 Optional<Argument> whereArgument = it.getArguments().stream().filter(arg -> !isOrderByArgument(arg)).findFirst();
                 Join<?, ?> nextJoin;

--- a/graphql-jpa-query-schema/src/main/java/com/introproventures/graphql/jpa/query/schema/impl/GraphQLJpaQueryDataFetcher.java
+++ b/graphql-jpa-query-schema/src/main/java/com/introproventures/graphql/jpa/query/schema/impl/GraphQLJpaQueryDataFetcher.java
@@ -33,7 +33,6 @@ import javax.persistence.metamodel.EntityType;
 import javax.persistence.metamodel.SingularAttribute;
 
 import com.introproventures.graphql.jpa.query.schema.IQueryAuthorizationStrategy;
-import com.introproventures.graphql.jpa.query.schema.exception.AuthorizationException;
 import graphql.language.Argument;
 import graphql.language.BooleanValue;
 import graphql.language.Field;
@@ -49,7 +48,7 @@ import graphql.schema.GraphQLObjectType;
  * @author Igor Dianov
  *
  */
-class GraphQLJpaQueryDataFetcher extends QraphQLJpaBaseDataFetcher {
+class GraphQLJpaQueryDataFetcher extends GraphQLJpaBaseDataFetcher {
 
     public GraphQLJpaQueryDataFetcher(EntityManager entityManager, EntityType<?> entityType, IQueryAuthorizationStrategy authorizationStrategy) {
         super(entityManager, entityType, authorizationStrategy);
@@ -57,8 +56,7 @@ class GraphQLJpaQueryDataFetcher extends QraphQLJpaBaseDataFetcher {
 
     @Override
     public Object get(DataFetchingEnvironment environment) {
-        if (authorization != null && !authorization.isAuthorized(entityType))
-            throw new AuthorizationException();
+        authorization.checkAuthorization(environment);
 
         Field field = environment.getFields().iterator().next();
         Map<String, Object> result = new LinkedHashMap<>();
@@ -98,7 +96,8 @@ class GraphQLJpaQueryDataFetcher extends QraphQLJpaBaseDataFetcher {
                                             environment.getFragmentsByName(),
                                             environment.getExecutionId(),
                                             environment.getSelectionSet(),
-                                            environment.getFieldTypeInfo()
+                                            environment.getFieldTypeInfo(),
+                                            environment.getExecutionContext()
                                     )).orElse(environment);
 
             queryField = new Field(fieldName, field.getArguments(), recordsSelection.get().getSelectionSet());

--- a/graphql-jpa-query-schema/src/main/java/com/introproventures/graphql/jpa/query/schema/impl/GraphQLJpaSchemaBuilder.java
+++ b/graphql-jpa-query-schema/src/main/java/com/introproventures/graphql/jpa/query/schema/impl/GraphQLJpaSchemaBuilder.java
@@ -428,16 +428,22 @@ public class GraphQLJpaSchemaBuilder implements GraphQLSchemaBuilder {
 
         String embeddableTypeName = namingStrategy.singularize(namingStrategy.getName(embeddableType));
 
-        GraphQLObjectType objectType = GraphQLObjectType.newObject()
+        GraphQLObjectType.Builder objectTypeBuilder = GraphQLObjectType.newObject()
                 .name(embeddableTypeName)
                 .description(getSchemaDescription(embeddableType.getJavaType()))
                 .fields(embeddableType.getAttributes().stream()
                         .filter(this::isNotIgnored)
                         .map(this::getObjectField)
                         .collect(Collectors.toList())
-                )
-                .build();
+                );
 
+
+        List<GraphQLDirective> authDirectives = getAuthorizationDirectives(embeddableType);
+        if (authDirectives != null){
+            GraphQLDirective [] directives = new GraphQLDirective[authDirectives.size()];
+            objectTypeBuilder.withDirectives(authDirectives.toArray(directives));
+        }
+        GraphQLObjectType objectType = objectTypeBuilder.build();
         embeddableCache.putIfAbsent(embeddableType, objectType);
 
         return objectType;

--- a/graphql-jpa-query-schema/src/main/java/com/introproventures/graphql/jpa/query/schema/impl/GraphQLJpaSchemaBuilder.java
+++ b/graphql-jpa-query-schema/src/main/java/com/introproventures/graphql/jpa/query/schema/impl/GraphQLJpaSchemaBuilder.java
@@ -33,6 +33,7 @@ import javax.persistence.EntityManager;
 import javax.persistence.metamodel.Attribute;
 import javax.persistence.metamodel.EmbeddableType;
 import javax.persistence.metamodel.EntityType;
+import javax.persistence.metamodel.ManagedType;
 import javax.persistence.metamodel.PluralAttribute;
 import javax.persistence.metamodel.SingularAttribute;
 import javax.persistence.metamodel.Type;
@@ -270,7 +271,7 @@ public class GraphQLJpaSchemaBuilder implements GraphQLSchemaBuilder {
 
     private GraphQLInputType getWhereAttributeType(Attribute<?, ?> attribute) {
         //String type =  namingStrategy.singularize(attribute.getName())+((EntityType<?>)attribute.getDeclaringType()).getName()+"Criteria";
-        String type = namingStrategy.singularize(attribute.getName()) + namingStrategy.getName((EntityType<?>) attribute.getDeclaringType()) + "Criteria";
+        String type = namingStrategy.singularize(attribute.getName()) + namingStrategy.getName((ManagedType<?>) attribute.getDeclaringType()) + "Criteria";
 
         if (whereAttributesMap.containsKey(type))
             return whereAttributesMap.get(type);

--- a/graphql-jpa-query-schema/src/main/java/com/introproventures/graphql/jpa/query/schema/impl/GraphQLJpaSimpleDataFetcher.java
+++ b/graphql-jpa-query-schema/src/main/java/com/introproventures/graphql/jpa/query/schema/impl/GraphQLJpaSimpleDataFetcher.java
@@ -22,11 +22,10 @@ import javax.persistence.NoResultException;
 import javax.persistence.metamodel.EntityType;
 
 import com.introproventures.graphql.jpa.query.schema.IQueryAuthorizationStrategy;
-import com.introproventures.graphql.jpa.query.schema.exception.AuthorizationException;
 import graphql.language.Field;
 import graphql.schema.DataFetchingEnvironment;
 
-class GraphQLJpaSimpleDataFetcher extends QraphQLJpaBaseDataFetcher {
+class GraphQLJpaSimpleDataFetcher extends GraphQLJpaBaseDataFetcher {
 
     public GraphQLJpaSimpleDataFetcher(EntityManager entityManager, EntityType<?> entityType, IQueryAuthorizationStrategy authorizationStrategy) {
         super(entityManager, entityType, authorizationStrategy);
@@ -34,8 +33,7 @@ class GraphQLJpaSimpleDataFetcher extends QraphQLJpaBaseDataFetcher {
 
     @Override
     public Object get(DataFetchingEnvironment environment) {
-        if (authorization != null && !authorization.isAuthorized(entityType))
-            throw new AuthorizationException();
+        authorization.checkAuthorization(environment);
 
         Field field = environment.getFields().iterator().next();
 

--- a/graphql-jpa-query-schema/src/main/java/com/introproventures/graphql/jpa/query/schema/impl/GraphQLJpaSimpleDataFetcher.java
+++ b/graphql-jpa-query-schema/src/main/java/com/introproventures/graphql/jpa/query/schema/impl/GraphQLJpaSimpleDataFetcher.java
@@ -21,36 +21,41 @@ import javax.persistence.EntityManager;
 import javax.persistence.NoResultException;
 import javax.persistence.metamodel.EntityType;
 
+import com.introproventures.graphql.jpa.query.schema.IQueryAuthorizationStrategy;
+import com.introproventures.graphql.jpa.query.schema.exception.AuthorizationException;
 import graphql.language.Field;
 import graphql.schema.DataFetchingEnvironment;
 
 class GraphQLJpaSimpleDataFetcher extends QraphQLJpaBaseDataFetcher {
 
-    public GraphQLJpaSimpleDataFetcher(EntityManager entityManager, EntityType<?> entityType) {
-        super(entityManager, entityType);
+    public GraphQLJpaSimpleDataFetcher(EntityManager entityManager, EntityType<?> entityType, IQueryAuthorizationStrategy authorizationStrategy) {
+        super(entityManager, entityType, authorizationStrategy);
     }
-    
+
     @Override
     public Object get(DataFetchingEnvironment environment) {
+        if (authorization != null && !authorization.isAuthorized(entityType))
+            throw new AuthorizationException();
 
         Field field = environment.getFields().iterator().next();
-        
-        if(!field.getArguments().isEmpty()) {
-            
+
+        if (!field.getArguments().isEmpty()) {
+
             try {
                 // Create entity graph from selection
                 EntityGraph<?> entityGraph = buildEntityGraph(field);
-                
-                return super.getQuery(environment, field, true)
-                    .setHint("javax.persistence.fetchgraph", entityGraph)
-                    .getSingleResult();
-                
+
+                //There should not be a need for select DISTINCT when fetching by ID - turning it off as it will fail for entities with byte arrays that hold blobs
+                return super.getQuery(environment, field, false)
+                        .setHint("javax.persistence.fetchgraph", entityGraph)
+                        .getSingleResult();
+
             } catch (NoResultException ignored) {
                 // do nothing
             }
-            
+
         }
 
         return null;
-    }    
+    }
 }

--- a/graphql-jpa-query-schema/src/main/java/com/introproventures/graphql/jpa/query/schema/impl/JpaPredicateBuilder.java
+++ b/graphql-jpa-query-schema/src/main/java/com/introproventures/graphql/jpa/query/schema/impl/JpaPredicateBuilder.java
@@ -1,5 +1,6 @@
 /*
  * Copyright 2017 IntroPro Ventures Inc. and/or its affiliates.
+ * Copyright IBM Corporation 2018
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -18,6 +19,7 @@ package com.introproventures.graphql.jpa.query.schema.impl;
 
 import java.math.BigDecimal;
 import java.math.BigInteger;
+import java.text.SimpleDateFormat;
 import java.util.Collection;
 import java.util.Date;
 import java.util.EnumSet;
@@ -89,10 +91,10 @@ class JpaPredicateBuilder {
     protected Predicate getStringPredicate(Path<String> root, PredicateFilter filter) {
         Expression<String> fieldValue;
 
-        // list or arrays only for in and not in
+        // list or arrays only for in, not in, between and not between
         Predicate arrayValuePredicate = mayBeArrayValuePredicate(root, filter);
 
-        if(arrayValuePredicate == null) {
+        if (arrayValuePredicate == null) {
             String compareValue = filter.getValue().toString();
 
             if (filter.getCriterias().contains(PredicateFilter.Criteria.IN)) {
@@ -184,35 +186,60 @@ class JpaPredicateBuilder {
     }
 
     protected Predicate mayBeArrayValuePredicate(Path<?> path, PredicateFilter filter) {
-        // arrays only for in
+        // arrays only for in, between
         if (filter.getValue().getClass().isArray()) {
             if (!filter.getCriterias().contains(PredicateFilter.Criteria.NE)
-                && !filter.getCriterias().contains(PredicateFilter.Criteria.NIN)) {
+                    && !filter.getCriterias().contains(PredicateFilter.Criteria.NIN)) {
                 CriteriaBuilder.In<Object> in = cb.in(path);
-                for(Object n : (Object[]) filter.getValue()) {
+                for (Object n : (Object[]) filter.getValue()) {
                     in.value(n);
                 }
                 return in;
             } else if (filter.getCriterias().contains(PredicateFilter.Criteria.NE)
-                || filter.getCriterias().contains(PredicateFilter.Criteria.NIN)) {
+                    || filter.getCriterias().contains(PredicateFilter.Criteria.NIN)) {
                 return cb.not(path.in((Object[]) filter.getValue()));
+            } else if (!filter.getCriterias().contains(PredicateFilter.Criteria.NE)
+                    && (filter.getCriterias().contains(Criteria.BETWEEN) || filter.getCriterias().contains(Criteria.NOT_BETWEEN))) {
+
+                Object[] values = (Object[]) filter.getValue();
+                if (values.length == 2) {
+                    Expression<String> name = path.get(filter.getField());
+                    Predicate between = cb.between(name, cb.literal((String) values[0]), cb.literal((String) values[1]));
+                    if (filter.getCriterias().contains(Criteria.BETWEEN))
+                        return between;
+                    return cb.not(between);
+                }
             }
         } else if ((filter.getValue() instanceof Collection)) {
             if (!filter.getCriterias().contains(PredicateFilter.Criteria.NE)
-                && !filter.getCriterias().contains(PredicateFilter.Criteria.NIN)) {
+                    && !filter.getCriterias().contains(PredicateFilter.Criteria.NIN)) {
                 CriteriaBuilder.In<Object> in = cb.in(path);
-                for(Object n : (Collection<?>) filter.getValue()) {
+                for (Object n : (Collection<?>) filter.getValue()) {
                     in.value(n);
                 }
                 return in;
             } else if (filter.getCriterias().contains(PredicateFilter.Criteria.NE)
-                || filter.getCriterias().contains(PredicateFilter.Criteria.NIN)) {
+                    || filter.getCriterias().contains(PredicateFilter.Criteria.NIN)) {
                 return cb.not(path.in((Collection<?>) filter.getValue()));
+            } else if (!filter.getCriterias().contains(PredicateFilter.Criteria.NE)
+                    && (filter.getCriterias().contains(Criteria.NOT_BETWEEN) || filter.getCriterias().contains(Criteria.BETWEEN))) {
+                Expression name = (Expression) path;
+                Collection<?> collection = (Collection<?>) filter.getValue();
+                if (collection.size() == 2) {
+                    Object[] values = collection.toArray();
+                    Expression fromValue = cb.literal(values[0]);
+                    Expression toValue = cb.literal(values[1]);
+                    Predicate between = cb.between(name, fromValue, toValue);
+                    if (filter.getCriterias().contains(Criteria.BETWEEN)) {
+                        return between;
+                    }
+
+                    return cb.not(between);
+                }
             }
         }
 
         return null;
-
     }
 
     protected Predicate getFloatingPointPredicate(Path<? extends Number> root, PredicateFilter filter) {
@@ -258,24 +285,47 @@ class JpaPredicateBuilder {
             }
             // LE or default
             return cb.lessThanOrEqualTo(root, (Date) filter.getValue());
+        } else if (filter.getValue().getClass().isArray() || filter.getValue() instanceof Collection) {
+            if (!filter.getCriterias().contains(PredicateFilter.Criteria.NE)
+                    && (filter.getCriterias().contains(Criteria.BETWEEN) || filter.getCriterias().contains(Criteria.NOT_BETWEEN))) {
+
+                Object[] values;
+                if (filter.getValue().getClass().isArray()) {
+                    values = (Object[]) filter.getValue();
+                } else {
+                    values = ((Collection<?>) filter.getValue()).toArray();
+                }
+
+                if (values.length == 2) {
+                    Expression<Date> name = (Expression<Date>) root;
+                    SimpleDateFormat dateFormat = new SimpleDateFormat("yyyy-MM-dd");
+                    Expression<Date> fromDate = cb.literal((Date) values[0]);
+                    Expression<Date> toDate = cb.literal((Date) values[1]);
+                    Predicate between = cb.between(name, fromDate, toDate);
+                    if (filter.getCriterias().contains(Criteria.BETWEEN))
+                        return between;
+                    return cb.not(between);
+                }
+            }
         }
+
         return null;
     }
 
     @SuppressWarnings("unchecked")
-    private Predicate getTypedPredicate(From<?,?> from, Path<?> field, PredicateFilter filter) {
+    private Predicate getTypedPredicate(From<?, ?> from, Path<?> field, PredicateFilter filter) {
         Class<?> type = field.getJavaType();
         Object value = filter.getValue();
         Set<Criteria> criterias = filter.getCriterias();
 
-        if(value == null) {
+        if (value == null) {
             return cb.disjunction();
         }
 
-        if(criterias.contains(Criteria.IS_NULL)) {
+        if (criterias.contains(Criteria.IS_NULL)) {
             return (boolean) value ? cb.isNull(field) : cb.isNotNull(field);
         } else if (criterias.contains(Criteria.NOT_NULL)) {
-            return (boolean) value ? cb.isNotNull(field) : cb.isNull(field) ;
+            return (boolean) value ? cb.isNotNull(field) : cb.isNull(field);
         }
 
         PredicateFilter predicateFilter = new PredicateFilter(filter.getField(), value, criterias);
@@ -283,7 +333,7 @@ class JpaPredicateBuilder {
         if (type.isPrimitive())
             type = JpaQueryBuilder.PRIMITIVES_TO_WRAPPERS.get(type);
         if (type.equals(String.class)) {
-            return getStringPredicate((Path<String>)field, filter);
+            return getStringPredicate((Path<String>) field, filter);
         }
         else if (type.equals(Long.class)
                 || type.equals(BigInteger.class)
@@ -304,7 +354,7 @@ class JpaPredicateBuilder {
             return getBooleanPredicate(field, predicateFilter);
         }
         else if(Collection.class.isAssignableFrom(type)) {
-            if(field.getModel() == null)
+            if (field.getModel() == null)
                 return from.join(filter.getField()).in(value);
         }
 
@@ -321,7 +371,7 @@ class JpaPredicateBuilder {
      * @return constructed predicate, returns null if value cannot be converted
      * to field type
      */
-    public Predicate getPredicate(From<?,?> from, Path<?> field, PredicateFilter filter) {
+    public Predicate getPredicate(From<?, ?> from, Path<?> field, PredicateFilter filter) {
         return getTypedPredicate(from, field, filter);
     }
 }

--- a/graphql-jpa-query-schema/src/main/java/com/introproventures/graphql/jpa/query/schema/impl/JpaPredicateBuilder.java
+++ b/graphql-jpa-query-schema/src/main/java/com/introproventures/graphql/jpa/query/schema/impl/JpaPredicateBuilder.java
@@ -212,7 +212,8 @@ class JpaPredicateBuilder {
             }
         } else if ((filter.getValue() instanceof Collection)) {
             if (!filter.getCriterias().contains(PredicateFilter.Criteria.NE)
-                    && !filter.getCriterias().contains(PredicateFilter.Criteria.NIN)) {
+                    && !filter.getCriterias().contains(PredicateFilter.Criteria.NIN) &&
+                    !(filter.getCriterias().contains(Criteria.NOT_BETWEEN) || filter.getCriterias().contains(Criteria.BETWEEN))) {
                 CriteriaBuilder.In<Object> in = cb.in(path);
                 for (Object n : (Collection<?>) filter.getValue()) {
                     in.value(n);

--- a/graphql-jpa-query-schema/src/main/java/com/introproventures/graphql/jpa/query/schema/impl/PredicateFilter.java
+++ b/graphql-jpa-query-schema/src/main/java/com/introproventures/graphql/jpa/query/schema/impl/PredicateFilter.java
@@ -1,5 +1,6 @@
 /*
  * Copyright 2017 IntroPro Ventures Inc. and/or its affiliates.
+ * Copyright IBM Corporation 2018
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -95,6 +96,14 @@ class PredicateFilter implements Comparable<PredicateFilter>, Serializable {
          * Not In condition
          */
         NIN,
+        /**
+         * Between condition
+         */
+        BETWEEN,
+        /**
+         * Not Between condition
+         */
+        NOT_BETWEEN,
     }
 
     private final String field;

--- a/graphql-jpa-query-schema/src/main/java/com/introproventures/graphql/jpa/query/schema/impl/QraphQLJpaBaseDataFetcher.java
+++ b/graphql-jpa-query-schema/src/main/java/com/introproventures/graphql/jpa/query/schema/impl/QraphQLJpaBaseDataFetcher.java
@@ -1,5 +1,6 @@
 /*
  * Copyright 2017 IntroPro Ventures Inc. and/or its affiliates.
+ * Copyright IBM Corporation 2018
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -51,7 +52,8 @@ import javax.persistence.metamodel.PluralAttribute;
 import javax.persistence.metamodel.SingularAttribute;
 
 import com.introproventures.graphql.jpa.query.annotation.GraphQLDefaultOrderBy;
-
+import com.introproventures.graphql.jpa.query.schema.IQueryAuthorizationStrategy;
+import com.introproventures.graphql.jpa.query.schema.exception.AuthorizationException;
 import graphql.GraphQLException;
 import graphql.execution.ValuesResolver;
 import graphql.language.Argument;
@@ -83,29 +85,34 @@ import graphql.schema.GraphQLType;
  * Provides base implemetation for GraphQL JPA Query Data Fetchers
  *
  * @author Igor Dianov
- *
  */
 class QraphQLJpaBaseDataFetcher implements DataFetcher<Object> {
 
     // "__typename" is part of the graphql introspection spec and has to be ignored
-    private static final String TYPENAME = "__typename";
+    protected static final String TYPENAME = "__typename";
 
     protected final EntityManager entityManager;
     protected final EntityType<?> entityType;
+    protected final IQueryAuthorizationStrategy authorization;
 
     /**
      * Creates JPA entity DataFetcher instance
      *
      * @param entityManager
      * @param entityType
+     * @param queryAuthorization
      */
-    public QraphQLJpaBaseDataFetcher(EntityManager entityManager, EntityType<?> entityType) {
+    public QraphQLJpaBaseDataFetcher(EntityManager entityManager, EntityType<?> entityType, IQueryAuthorizationStrategy queryAuthorization) {
         this.entityManager = entityManager;
         this.entityType = entityType;
+        this.authorization = queryAuthorization;
     }
 
     @Override
     public Object get(DataFetchingEnvironment environment) {
+        if (authorization != null && !authorization.isAuthorized(entityType))
+            throw new AuthorizationException();
+
         return getQuery(environment, environment.getFields().iterator().next(), true).getResultList();
     }
 
@@ -116,16 +123,7 @@ class QraphQLJpaBaseDataFetcher implements DataFetcher<Object> {
 
         from.alias(from.getModel().getName());
 
-        // Build predicates from query arguments
-        List<Predicate> predicates =  getFieldArguments(field, query, cb, from)
-            .stream()
-            .map(it -> getPredicate(cb, from, from, environment, it))
-            .filter(it -> it != null)
-            .collect(Collectors.toList());
-
-        // Use AND clause to filter results
-        if(!predicates.isEmpty())
-            query.where(predicates.toArray(new Predicate[predicates.size()]));
+        setPredicates(environment, field, cb, query, from);
 
         // optionally add default ordering
         mayBeAddDefaultOrderBy(query, from, cb);
@@ -133,7 +131,21 @@ class QraphQLJpaBaseDataFetcher implements DataFetcher<Object> {
         return entityManager.createQuery(query.distinct(isDistinct));
     }
 
-    protected final List<Argument> getFieldArguments(Field field, CriteriaQuery<?> query, CriteriaBuilder cb, From<?,?> from) {
+
+    protected void setPredicates(DataFetchingEnvironment environment, Field field, CriteriaBuilder cb, CriteriaQuery<?> query, Root<?> from) {
+        // Build predicates from query arguments
+        List<Predicate> predicates = getFieldArguments(field, query, cb, from)
+                .stream()
+                .map(it -> getPredicate(cb, from, from, environment, it))
+                .filter(it -> it != null)
+                .collect(Collectors.toList());
+
+        // Use AND clause to filter results
+        if (!predicates.isEmpty())
+            query.where(predicates.toArray(new Predicate[predicates.size()]));
+    }
+
+    protected final List<Argument> getFieldArguments(Field field, CriteriaQuery<?> query, CriteriaBuilder cb, From<?, ?> from) {
 
         List<Argument> arguments = new ArrayList<>();
 
@@ -143,16 +155,16 @@ class QraphQLJpaBaseDataFetcher implements DataFetcher<Object> {
                 Field selectedField = (Field) selection;
 
                 // "__typename" is part of the graphql introspection spec and has to be ignored by jpa
-                if(!TYPENAME.equals(selectedField.getName())) {
+                if (!TYPENAME.equals(selectedField.getName())) {
 
                     Path<?> fieldPath = from.get(selectedField.getName());
 
                     // Build predicate arguments for singular attributes only
-                    if(fieldPath.getModel() instanceof SingularAttribute) {
+                    if (fieldPath.getModel() instanceof SingularAttribute) {
                         // Process the orderBy clause
                         Optional<Argument> orderByArgument = selectedField.getArguments().stream()
-                            .filter(this::isOrderByArgument)
-                            .findFirst();
+                                .filter(this::isOrderByArgument)
+                                .findFirst();
 
                         if (orderByArgument.isPresent()) {
                             if ("DESC".equals(((EnumValue) orderByArgument.get().getValue()).getName()))
@@ -163,22 +175,22 @@ class QraphQLJpaBaseDataFetcher implements DataFetcher<Object> {
 
                         // Process where arguments clauses.
                         arguments.addAll(selectedField.getArguments()
-                            .stream()
-                            .filter(it -> !isOrderByArgument(it))
-                            .map(it -> new Argument(selectedField.getName() + "." + it.getName(), it.getValue()))
-                            .collect(Collectors.toList()));
+                                .stream()
+                                .filter(it -> !isOrderByArgument(it))
+                                .map(it -> new Argument(selectedField.getName() + "." + it.getName(), it.getValue()))
+                                .collect(Collectors.toList()));
 
                         // Check if it's an object and the foreign side is One.  Then we can eagerly fetch causing an inner join instead of 2 queries
                         if (fieldPath.getModel() instanceof SingularAttribute) {
-                            SingularAttribute<?,?> attribute = (SingularAttribute<?,?>) fieldPath.getModel();
+                            SingularAttribute<?, ?> attribute = (SingularAttribute<?, ?>) fieldPath.getModel();
                             if (attribute.getPersistentAttributeType() == Attribute.PersistentAttributeType.MANY_TO_ONE
-                                || attribute.getPersistentAttributeType() == Attribute.PersistentAttributeType.ONE_TO_ONE
-                            ) {
+                                    || attribute.getPersistentAttributeType() == Attribute.PersistentAttributeType.ONE_TO_ONE
+                                    ) {
                                 from.fetch(selectedField.getName());
                             }
                         }
-                    } else  {
-                    	// Do nothing
+                    } else {
+                        // Do nothing
                     }
                 }
             }
@@ -197,7 +209,7 @@ class QraphQLJpaBaseDataFetcher implements DataFetcher<Object> {
      * @param from
      * @param cb
      */
-    protected void mayBeAddDefaultOrderBy(CriteriaQuery<?> query, From<?,?> from, CriteriaBuilder cb) {
+    protected void mayBeAddDefaultOrderBy(CriteriaQuery<?> query, From<?, ?> from, CriteriaBuilder cb) {
         if (query.getOrderList() == null || query.getOrderList().isEmpty()) {
             EntityType<?> fromEntityType = entityType;
             try {
@@ -245,186 +257,186 @@ class QraphQLJpaBaseDataFetcher implements DataFetcher<Object> {
         return GraphQLJpaSchemaBuilder.ORDER_BY_PARAM_NAME.equals(argument.getName());
     }
 
-    @SuppressWarnings( "unchecked" )
-    protected Predicate getPredicate(CriteriaBuilder cb, Root<?> from, From<?,?> path, DataFetchingEnvironment environment, Argument argument) {
+    @SuppressWarnings("unchecked")
+    protected Predicate getPredicate(CriteriaBuilder cb, Root<?> from, From<?, ?> path, DataFetchingEnvironment environment, Argument argument) {
 
-        if(!argument.getName().contains(".")) {
-            Attribute<?,?> argumentEntityAttribute = getAttribute(environment, argument);
+        if (!argument.getName().contains(".")) {
+            Attribute<?, ?> argumentEntityAttribute = getAttribute(environment, argument);
 
             // If the argument is a list, let's assume we need to join and do an 'in' clause
             if (argumentEntityAttribute instanceof PluralAttribute) {
                 return from.join(argument.getName())
-                    .in(convertValue(environment, argument, argument.getValue()));
+                        .in(convertValue(environment, argument, argument.getValue()));
             }
 
             return cb.equal(path.get(argument.getName()), convertValue(environment, argument, argument.getValue()));
         } else {
-            if(!argument.getName().endsWith(".where")) {
+            if (!argument.getName().endsWith(".where")) {
                 Path<?> field = getCompoundJoinedPath(path, argument.getName(), false);
 
                 return cb.equal(field, convertValue(environment, argument, argument.getValue()));
             } else {
                 String fieldName = argument.getName().split("\\.")[0];
 
-                From<?,?> join = getCompoundJoin(path, argument.getName(), false);
-                Argument where = new Argument("where",  argument.getValue());
+                From<?, ?> join = getCompoundJoin(path, argument.getName(), false);
+                Argument where = new Argument("where", argument.getValue());
                 Map<String, Object> variables = Optional.ofNullable(environment.getContext())
-                		.filter(it -> it instanceof Map)
-                		.map(it -> (Map<String, Object>) it)
-                		.map(it -> (Map<String, Object>) it.get("variables"))
-                		.orElse(Collections.emptyMap());
+                        .filter(it -> it instanceof Map)
+                        .map(it -> (Map<String, Object>) it)
+                        .map(it -> (Map<String, Object>) it.get("variables"))
+                        .orElse(Collections.emptyMap());
 
                 GraphQLFieldDefinition fieldDef = getFieldDef(
-                    environment.getGraphQLSchema(),
-                    this.getObjectType(environment, argument),
-                    new Field(fieldName)
+                        environment.getGraphQLSchema(),
+                        this.getObjectType(environment, argument),
+                        new Field(fieldName)
                 );
 
                 Map<String, Object> arguments = (Map<String, Object>) new ValuesResolver()
-                    .getArgumentValues(fieldDef.getArguments(), Collections.singletonList(where), variables)
-                    .get("where");
+                        .getArgumentValues(fieldDef.getArguments(), Collections.singletonList(where), variables)
+                        .get("where");
 
                 return getWherePredicate(cb, from, join, new WherePredicateEnvironment(environment, arguments), where);
             }
         }
     }
 
-    @SuppressWarnings( "unchecked" )
+    @SuppressWarnings("unchecked")
     private <R extends Value> R getValue(Argument argument) {
         return (R) argument.getValue();
     }
 
 
-    @SuppressWarnings( "serial" )
-    protected Predicate getWherePredicate(CriteriaBuilder cb, Root<?> root,  From<?,?> path, DataFetchingEnvironment environment, Argument argument) {
+    @SuppressWarnings("serial")
+    protected Predicate getWherePredicate(CriteriaBuilder cb, Root<?> root, From<?, ?> path, DataFetchingEnvironment environment, Argument argument) {
         ObjectValue whereValue = getValue(argument);
 
-        if(whereValue.getChildren().isEmpty())
+        if (whereValue.getChildren().isEmpty())
             return cb.conjunction();
 
         return getArgumentPredicate(cb, (path != null) ? path : root,
-            new DataFetchingEnvironmentImpl(
-                environment.getSource(),
-                new LinkedHashMap<String,Object>() {{
-                    put(Logical.AND.name(), environment.getArguments());
-                }},
-                environment.getContext(),
-                environment.getRoot(),
-                environment.getFieldDefinition(),
-                environment.getFields(),
-                environment.getFieldType(),
-                environment.getParentType(),
-                environment.getGraphQLSchema(),
-                environment.getFragmentsByName(),
-                environment.getExecutionId(),
-                environment.getSelectionSet(),
-                environment.getFieldTypeInfo()
-            ), new Argument(Logical.AND.name(), whereValue)
-         );
+                new DataFetchingEnvironmentImpl(
+                        environment.getSource(),
+                        new LinkedHashMap<String, Object>() {{
+                            put(Logical.AND.name(), environment.getArguments());
+                        }},
+                        environment.getContext(),
+                        environment.getRoot(),
+                        environment.getFieldDefinition(),
+                        environment.getFields(),
+                        environment.getFieldType(),
+                        environment.getParentType(),
+                        environment.getGraphQLSchema(),
+                        environment.getFragmentsByName(),
+                        environment.getExecutionId(),
+                        environment.getSelectionSet(),
+                        environment.getFieldTypeInfo()
+                ), new Argument(Logical.AND.name(), whereValue)
+        );
     }
 
-    protected Predicate getArgumentPredicate(CriteriaBuilder cb, From<?,?> path,
-        DataFetchingEnvironment environment, Argument argument) {
+    protected Predicate getArgumentPredicate(CriteriaBuilder cb, From<?, ?> path,
+                                             DataFetchingEnvironment environment, Argument argument) {
         ObjectValue whereValue = getValue(argument);
 
         if (whereValue.getChildren().isEmpty())
             return cb.disjunction();
 
         Logical logical = Optional.of(argument.getName())
-            .filter(it -> Arrays.asList("AND", "OR").contains(it))
-            .map(it -> Logical.valueOf(it))
-            .orElse(Logical.AND);
+                .filter(it -> Arrays.asList("AND", "OR").contains(it))
+                .map(it -> Logical.valueOf(it))
+                .orElse(Logical.AND);
 
         List<Predicate> predicates = new ArrayList<>();
 
         whereValue.getObjectFields().stream()
-            .filter(it -> Arrays.asList("AND", "OR").contains(it.getName()))
-            .map(it -> getArgumentPredicate(cb, path,
-                new ArgumentEnvironment(environment, argument.getName()),
-                new Argument(it.getName(), it.getValue())))
-            .forEach(predicates::add);
+                .filter(it -> Arrays.asList("AND", "OR").contains(it.getName()))
+                .map(it -> getArgumentPredicate(cb, path,
+                        new ArgumentEnvironment(environment, argument.getName()),
+                        new Argument(it.getName(), it.getValue())))
+                .forEach(predicates::add);
 
         whereValue.getObjectFields().stream()
-            .filter(it -> !Arrays.asList("AND", "OR").contains(it.getName()))
-            .map(it -> getFieldPredicate(it.getName(), cb, path, it,
-                new ArgumentEnvironment(environment, argument.getName()),
-                new Argument(it.getName(), it.getValue())))
-            .filter(predicate -> predicate != null)
-            .forEach(predicates::add);
+                .filter(it -> !Arrays.asList("AND", "OR").contains(it.getName()))
+                .map(it -> getFieldPredicate(it.getName(), cb, path, it,
+                        new ArgumentEnvironment(environment, argument.getName()),
+                        new Argument(it.getName(), it.getValue())))
+                .filter(predicate -> predicate != null)
+                .forEach(predicates::add);
 
         if (predicates.isEmpty())
             predicates.add(cb.disjunction());
 
         return (logical == Logical.OR)
-            ? cb.or(predicates.toArray(new Predicate[predicates.size()]))
-            : cb.and(predicates.toArray(new Predicate[predicates.size()]));
+                ? cb.or(predicates.toArray(new Predicate[predicates.size()]))
+                : cb.and(predicates.toArray(new Predicate[predicates.size()]));
     }
 
-    private Predicate getFieldPredicate(String fieldName, CriteriaBuilder cb, From<?,?> path, ObjectField objectField, DataFetchingEnvironment environment, Argument argument) {
+    private Predicate getFieldPredicate(String fieldName, CriteriaBuilder cb, From<?, ?> path, ObjectField objectField, DataFetchingEnvironment environment, Argument argument) {
         ObjectValue expressionValue = (ObjectValue) objectField.getValue();
 
-        if(expressionValue.getChildren().isEmpty())
+        if (expressionValue.getChildren().isEmpty())
             return cb.disjunction();
 
         Logical logical = Optional.of(argument.getName())
-            .filter(it -> Arrays.asList("AND","OR").contains(it))
-            .map(it -> Logical.valueOf(it))
-            .orElse(Logical.AND);
+                .filter(it -> Arrays.asList("AND", "OR").contains(it))
+                .map(it -> Logical.valueOf(it))
+                .orElse(Logical.AND);
 
         List<Predicate> predicates = new ArrayList<>();
 
         expressionValue.getObjectFields().stream()
-            .filter(it -> Arrays.asList("AND","OR").contains(it.getName()))
-            .map(it -> getFieldPredicate(fieldName, cb, path, it,
-                new ArgumentEnvironment(environment, argument.getName()),
-                new Argument(it.getName(), it.getValue()))
-            )
-            .forEach(predicates::add);
+                .filter(it -> Arrays.asList("AND", "OR").contains(it.getName()))
+                .map(it -> getFieldPredicate(fieldName, cb, path, it,
+                        new ArgumentEnvironment(environment, argument.getName()),
+                        new Argument(it.getName(), it.getValue()))
+                )
+                .forEach(predicates::add);
 
         JpaPredicateBuilder pb = new JpaPredicateBuilder(cb, EnumSet.of(Logical.AND));
 
         expressionValue.getObjectFields().stream()
-            .filter(it -> !Arrays.asList("AND","OR").contains(it.getName()))
-            .map(it -> getPredicateFilter(new ObjectField(fieldName, it.getValue()),
-                new ArgumentEnvironment(environment, argument.getName()),
-                new Argument(it.getName(), it.getValue()))
-            )
-            .sorted()
-            .map(it -> pb.getPredicate(path, path.get(it.getField()), it))
-            .filter(predicate -> predicate != null)
-            .forEach(predicates::add);
+                .filter(it -> !Arrays.asList("AND", "OR").contains(it.getName()))
+                .map(it -> getPredicateFilter(new ObjectField(fieldName, it.getValue()),
+                        new ArgumentEnvironment(environment, argument.getName()),
+                        new Argument(it.getName(), it.getValue()))
+                )
+                .sorted()
+                .map(it -> pb.getPredicate(path, path.get(it.getField()), it))
+                .filter(predicate -> predicate != null)
+                .forEach(predicates::add);
 
-        return  (logical == Logical.OR)
-            ? cb.or(predicates.toArray(new Predicate[predicates.size()]))
-            : cb.and(predicates.toArray(new Predicate[predicates.size()]));
+        return (logical == Logical.OR)
+                ? cb.or(predicates.toArray(new Predicate[predicates.size()]))
+                : cb.and(predicates.toArray(new Predicate[predicates.size()]));
 
     }
 
     @SuppressWarnings("serial")
-	private PredicateFilter getPredicateFilter(ObjectField objectField, DataFetchingEnvironment environment, Argument argument) {
+    private PredicateFilter getPredicateFilter(ObjectField objectField, DataFetchingEnvironment environment, Argument argument) {
         EnumSet<PredicateFilter.Criteria> options =
-            EnumSet.of(PredicateFilter.Criteria.valueOf(argument.getName()));
+                EnumSet.of(PredicateFilter.Criteria.valueOf(argument.getName()));
 
-        Object filterValue = convertValue( new DataFetchingEnvironmentImpl(
-            environment.getSource(),
-            new LinkedHashMap<String,Object>() {{
-                put(objectField.getName(), environment.getArgument(argument.getName()));
-            }},
-            environment.getContext(),
-            environment.getRoot(),
-            environment.getFieldDefinition(),
-            environment.getFields(),
-            environment.getFieldType(),
-            environment.getParentType(),
-            environment.getGraphQLSchema(),
-            environment.getFragmentsByName(),
-            environment.getExecutionId(),
-            environment.getSelectionSet(),
-            environment.getFieldTypeInfo()
-        ),
-            new Argument(objectField.getName(), argument.getValue()), argument.getValue() );
+        Object filterValue = convertValue(new DataFetchingEnvironmentImpl(
+                        environment.getSource(),
+                        new LinkedHashMap<String, Object>() {{
+                            put(objectField.getName(), environment.getArgument(argument.getName()));
+                        }},
+                        environment.getContext(),
+                        environment.getRoot(),
+                        environment.getFieldDefinition(),
+                        environment.getFields(),
+                        environment.getFieldType(),
+                        environment.getParentType(),
+                        environment.getGraphQLSchema(),
+                        environment.getFragmentsByName(),
+                        environment.getExecutionId(),
+                        environment.getSelectionSet(),
+                        environment.getFieldTypeInfo()
+                ),
+                new Argument(objectField.getName(), argument.getValue()), argument.getValue());
 
-        return new PredicateFilter(objectField.getName(), filterValue, options );
+        return new PredicateFilter(objectField.getName(), filterValue, options);
 
     }
 
@@ -432,19 +444,19 @@ class QraphQLJpaBaseDataFetcher implements DataFetcher<Object> {
 
         public ArgumentEnvironment(DataFetchingEnvironment environment, String argumentName) {
             super(
-                environment.getSource(),
-                environment.getArgument(argumentName),
-                environment.getContext(),
-                environment.getRoot(),
-                environment.getFieldDefinition(),
-                environment.getFields(),
-                environment.getFieldType(),
-                environment.getParentType(),
-                environment.getGraphQLSchema(),
-                environment.getFragmentsByName(),
-                environment.getExecutionId(),
-                environment.getSelectionSet(),
-                environment.getFieldTypeInfo()
+                    environment.getSource(),
+                    environment.getArgument(argumentName),
+                    environment.getContext(),
+                    environment.getRoot(),
+                    environment.getFieldDefinition(),
+                    environment.getFields(),
+                    environment.getFieldType(),
+                    environment.getParentType(),
+                    environment.getGraphQLSchema(),
+                    environment.getFragmentsByName(),
+                    environment.getExecutionId(),
+                    environment.getSelectionSet(),
+                    environment.getFieldTypeInfo()
             );
         }
     }
@@ -453,19 +465,19 @@ class QraphQLJpaBaseDataFetcher implements DataFetcher<Object> {
 
         public WherePredicateEnvironment(DataFetchingEnvironment environment, Map<String, Object> arguments) {
             super(
-                environment.getSource(),
-                arguments,
-                environment.getContext(),
-                environment.getRoot(),
-                environment.getFieldDefinition(),
-                environment.getFields(),
-                environment.getFieldType(),
-                environment.getParentType(),
-                environment.getGraphQLSchema(),
-                environment.getFragmentsByName(),
-                environment.getExecutionId(),
-                environment.getSelectionSet(),
-                environment.getFieldTypeInfo()
+                    environment.getSource(),
+                    arguments,
+                    environment.getContext(),
+                    environment.getRoot(),
+                    environment.getFieldDefinition(),
+                    environment.getFields(),
+                    environment.getFieldType(),
+                    environment.getParentType(),
+                    environment.getGraphQLSchema(),
+                    environment.getFragmentsByName(),
+                    environment.getExecutionId(),
+                    environment.getSelectionSet(),
+                    environment.getFieldTypeInfo()
             );
         }
     }
@@ -475,10 +487,10 @@ class QraphQLJpaBaseDataFetcher implements DataFetcher<Object> {
      * @param fieldName
      * @return Path of compound field to the primitive type
      */
-    private From<?,?> getCompoundJoin(From<?,?> rootPath, String fieldName, boolean outer) {
+    private From<?, ?> getCompoundJoin(From<?, ?> rootPath, String fieldName, boolean outer) {
         String[] compoundField = fieldName.split("\\.");
 
-        Join<?,?> join;
+        Join<?, ?> join;
 
         if (compoundField.length == 1) {
             return rootPath;
@@ -501,10 +513,10 @@ class QraphQLJpaBaseDataFetcher implements DataFetcher<Object> {
      * @param fieldName
      * @return Path of compound field to the primitive type
      */
-    private Path<?> getCompoundJoinedPath(From<?,?> rootPath, String fieldName, boolean outer) {
+    private Path<?> getCompoundJoinedPath(From<?, ?> rootPath, String fieldName, boolean outer) {
         String[] compoundField = fieldName.split("\\.");
 
-        Join<?,?> join;
+        Join<?, ?> join;
 
         if (compoundField.length == 1) {
             return rootPath.get(compoundField[0]);
@@ -524,9 +536,9 @@ class QraphQLJpaBaseDataFetcher implements DataFetcher<Object> {
     }
 
     // trying to find already existing joins to reuse
-    private Join<?,?> reuseJoin(From<?, ?> path, String fieldName, boolean outer) {
+    protected Join<?, ?> reuseJoin(From<?, ?> path, String fieldName, boolean outer) {
 
-        for (Join<?,?> join : path.getJoins()) {
+        for (Join<?, ?> join : path.getJoins()) {
             if (join.getAttribute().getName().equals(fieldName)) {
                 if ((join.getJoinType() == JoinType.LEFT) == outer) {
                     //logger.debug("Reusing existing join for field " + fieldName);
@@ -537,12 +549,12 @@ class QraphQLJpaBaseDataFetcher implements DataFetcher<Object> {
         return outer ? path.join(fieldName, JoinType.LEFT) : path.join(fieldName);
     }
 
-    @SuppressWarnings( { "unchecked", "rawtypes" } )
+    @SuppressWarnings({"unchecked", "rawtypes"})
     protected Object convertValue(DataFetchingEnvironment environment, Argument argument, Value value) {
         if (value instanceof NullValue) {
             return null;
         } else if (value instanceof StringValue) {
-            Object convertedValue =  environment.getArgument(argument.getName());
+            Object convertedValue = environment.getArgument(argument.getName());
             if (convertedValue != null) {
                 // Return real typed resolved value even if the Value is a StringValue
                 return convertedValue;
@@ -555,27 +567,27 @@ class QraphQLJpaBaseDataFetcher implements DataFetcher<Object> {
             // Get resolved variable in environment arguments
             return environment.getArguments().get(argument.getName());
         else if (value instanceof ArrayValue) {
-            Object convertedValue =  environment.getArgument(argument.getName());
+            Object convertedValue = environment.getArgument(argument.getName());
             if (convertedValue != null) {
                 // unwrap [[EnumValue{name='value'}]]
-                if(convertedValue instanceof Collection
-                    && ((Collection) convertedValue).stream().allMatch(it->it instanceof Collection)) {
+                if (convertedValue instanceof Collection
+                        && ((Collection) convertedValue).stream().allMatch(it -> it instanceof Collection)) {
                     convertedValue = ((Collection) convertedValue).iterator().next();
                 }
 
-                if(convertedValue instanceof Collection
-                    && ((Collection) convertedValue).stream().anyMatch(it->it instanceof Value)) {
+                if (convertedValue instanceof Collection
+                        && ((Collection) convertedValue).stream().anyMatch(it -> it instanceof Value)) {
                     return ((Collection) convertedValue).stream()
-                        .map((it) -> convertValue(environment, argument, (Value) it))
-                        .collect(Collectors.toList());
+                            .map((it) -> convertValue(environment, argument, (Value) it))
+                            .collect(Collectors.toList());
                 }
                 // Return real typed resolved array value
                 return convertedValue;
             } else {
                 // Wrap converted values in ArrayList
                 return ((ArrayValue) value).getValues().stream()
-                    .map((it) -> convertValue(environment, argument, it))
-                    .collect(Collectors.toList());
+                        .map((it) -> convertValue(environment, argument, it))
+                        .collect(Collectors.toList());
             }
 
         }
@@ -602,10 +614,10 @@ class QraphQLJpaBaseDataFetcher implements DataFetcher<Object> {
      * @return Java class type
      */
     protected Class<?> getJavaType(DataFetchingEnvironment environment, Argument argument) {
-        Attribute<?,?> argumentEntityAttribute = getAttribute(environment, argument);
+        Attribute<?, ?> argumentEntityAttribute = getAttribute(environment, argument);
 
         if (argumentEntityAttribute instanceof PluralAttribute)
-            return ((PluralAttribute<?,?,?>) argumentEntityAttribute).getElementType().getJavaType();
+            return ((PluralAttribute<?, ?, ?>) argumentEntityAttribute).getElementType().getJavaType();
 
         return argumentEntityAttribute.getJavaType();
     }
@@ -617,7 +629,7 @@ class QraphQLJpaBaseDataFetcher implements DataFetcher<Object> {
      * @param argument
      * @return JPA model attribute
      */
-    private Attribute<?,?> getAttribute(DataFetchingEnvironment environment, Argument argument) {
+    private Attribute<?, ?> getAttribute(DataFetchingEnvironment environment, Argument argument) {
         GraphQLObjectType objectType = getObjectType(environment, argument);
         EntityType<?> entityType = getEntityType(objectType);
 
@@ -634,10 +646,10 @@ class QraphQLJpaBaseDataFetcher implements DataFetcher<Object> {
      */
     private EntityType<?> getEntityType(GraphQLObjectType objectType) {
         return entityManager.getMetamodel()
-            .getEntities().stream()
-            .filter(it -> it.getName().equals(objectType.getName()))
-            .findFirst()
-            .get();
+                .getEntities().stream()
+                .filter(it -> it.getName().equals(objectType.getName()))
+                .findFirst()
+                .get();
     }
 
     /**
@@ -661,15 +673,15 @@ class QraphQLJpaBaseDataFetcher implements DataFetcher<Object> {
 
     protected Optional<Argument> extractArgument(DataFetchingEnvironment environment, Field field, String argumentName) {
         return field.getArguments()
-            .stream()
-            .filter(it -> argumentName.equals(it.getName()))
-            .findFirst();
+                .stream()
+                .filter(it -> argumentName.equals(it.getName()))
+                .findFirst();
     }
 
 
     protected Argument extractArgument(DataFetchingEnvironment environment, Field field, String argumentName, Value defaultValue) {
         return extractArgument(environment, field, argumentName)
-            .orElse(new Argument(argumentName, defaultValue));
+                .orElse(new Argument(argumentName, defaultValue));
     }
 
     protected GraphQLFieldDefinition getFieldDef(GraphQLSchema schema, GraphQLObjectType parentType, Field field) {
@@ -694,12 +706,12 @@ class QraphQLJpaBaseDataFetcher implements DataFetcher<Object> {
 
     protected Subgraph<?> buildSubgraph(Field field, Subgraph<?> subgraph) {
 
-        selections(field).forEach(it ->{
-            if(hasSelectionSet(it)) {
+        selections(field).forEach(it -> {
+            if (hasSelectionSet(it)) {
                 Subgraph<?> sg = subgraph.addSubgraph(it.getName());
                 buildSubgraph(it, sg);
             } else {
-                if(!TYPENAME.equals(it.getName()))
+                if (!TYPENAME.equals(it.getName()))
                     subgraph.addAttributeNodes(it.getName());
             }
         });
@@ -713,27 +725,27 @@ class QraphQLJpaBaseDataFetcher implements DataFetcher<Object> {
         EntityGraph<?> entityGraph = this.entityManager.createEntityGraph(entityType.getJavaType());
 
         selections(root)
-            .forEach(it -> {
-                if(hasSelectionSet(it) 
-                		&& hasNoArguments(it) 
-                		&& isManagedType(entityType.getAttribute(it.getName()))
-                ) {
-                    Subgraph<?> sg = entityGraph.addSubgraph(it.getName());
-                    buildSubgraph(it, sg);
-                } else {
-                    if(!TYPENAME.equals(it.getName()))
-                        entityGraph.addAttributeNodes(it.getName());
-                }
-            });
+                .forEach(it -> {
+                    if (hasSelectionSet(it)
+                            && hasNoArguments(it)
+                            && isManagedType(entityType.getAttribute(it.getName()))
+                            ) {
+                        Subgraph<?> sg = entityGraph.addSubgraph(it.getName());
+                        buildSubgraph(it, sg);
+                    } else {
+                        if (!TYPENAME.equals(it.getName()))
+                            entityGraph.addAttributeNodes(it.getName());
+                    }
+                });
 
         return entityGraph;
     };
 
     
-    protected final boolean isManagedType(Attribute<?,?> attribute) {
-    	return attribute.getPersistentAttributeType() != PersistentAttributeType.EMBEDDED 
-    			&& attribute.getPersistentAttributeType() != PersistentAttributeType.BASIC
-    			&& attribute.getPersistentAttributeType() != PersistentAttributeType.ELEMENT_COLLECTION;
+    protected final boolean isManagedType(Attribute<?, ?> attribute) {
+        return attribute.getPersistentAttributeType() != PersistentAttributeType.EMBEDDED
+                && attribute.getPersistentAttributeType() != PersistentAttributeType.BASIC
+                && attribute.getPersistentAttributeType() != PersistentAttributeType.ELEMENT_COLLECTION;
     }
 
     protected final boolean hasNoArguments(Field field) {
@@ -750,54 +762,54 @@ class QraphQLJpaBaseDataFetcher implements DataFetcher<Object> {
 
     protected final Stream<Field> selections(Field field) {
         SelectionSet selectionSet = field.getSelectionSet() != null
-            ? field.getSelectionSet()
-            : new SelectionSet(Collections.emptyList());
+                ? field.getSelectionSet()
+                : new SelectionSet(Collections.emptyList());
 
         return selectionSet.getSelections()
-            .stream()
-            .filter(it -> it instanceof Field)
-            .map(it -> (Field) it);
+                .stream()
+                .filter(it -> it instanceof Field)
+                .map(it -> (Field) it);
     }
 
     protected final Stream<Field> flatten(Field field) {
         SelectionSet selectionSet = field.getSelectionSet() != null
-            ? field.getSelectionSet()
-            : new SelectionSet(Collections.emptyList());
+                ? field.getSelectionSet()
+                : new SelectionSet(Collections.emptyList());
 
         return Stream.concat(
-            Stream.of(field),
-            selectionSet.getSelections()
-            .stream()
-            .filter(it -> it instanceof Field)
-            .flatMap(selection -> this.flatten((Field) selection))
+                Stream.of(field),
+                selectionSet.getSelections()
+                        .stream()
+                        .filter(it -> it instanceof Field)
+                        .flatMap(selection -> this.flatten((Field) selection))
         );
     }
 
 
-    @SuppressWarnings( "unchecked" )
+    @SuppressWarnings("unchecked")
     protected final <R extends Value> R getObjectFieldValue(ObjectValue objectValue, String fieldName) {
         return (R) getObjectField(objectValue, fieldName)
-            .map(it-> it.getValue())
-            .orElse(new NullValue());
+                .map(it -> it.getValue())
+                .orElse(new NullValue());
     }
 
-    @SuppressWarnings( "unchecked" )
+    @SuppressWarnings("unchecked")
     protected final <R> R getArgumentValue(Argument argument) {
         return (R) argument.getValue();
     }
 
     protected final Optional<ObjectField> getObjectField(ObjectValue objectValue, String fieldName) {
         return objectValue.getObjectFields().stream()
-            .filter(it -> fieldName.equals(it.getName()))
-            .findFirst();
+                .filter(it -> fieldName.equals(it.getName()))
+                .findFirst();
     }
 
     protected final Optional<Field> getSelectionField(Field field, String fieldName) {
         return field.getSelectionSet().getSelections().stream()
-            .filter(it -> it instanceof Field)
-            .map(it -> (Field) it)
-            .filter(it -> fieldName.equals(it.getName()))
-            .findFirst();
+                .filter(it -> it instanceof Field)
+                .map(it -> (Field) it)
+                .filter(it -> fieldName.equals(it.getName()))
+                .findFirst();
     }
 
     class NullValue implements Value {

--- a/graphql-jpa-query-schema/src/test/java/com/introproventures/graphql/jpa/query/schema/GraphQLExecutorTests.java
+++ b/graphql-jpa-query-schema/src/test/java/com/introproventures/graphql/jpa/query/schema/GraphQLExecutorTests.java
@@ -196,7 +196,77 @@ public class GraphQLExecutorTests {
         // then
         assertThat(result.toString()).isEqualTo(expected);
     }
-    
+
+    @Test
+    public void queryWithNumericBetweenPredicate() {
+        //given:
+        String query = "query { Books ( where: { id: {BETWEEN: [2, 5]}}) { select { id title} } }";
+
+        String expected = "{Books={select=[" +
+                "{id=2, title=War and Peace}, " +
+                "{id=3, title=Anna Karenina}, " +
+                "{id=5, title=The Cherry Orchard}" +
+                "]}}";
+
+        //when:
+        Object result = executor.execute(query).getData();
+
+        //then:
+        assertThat(result.toString()).isEqualTo(expected);
+    }
+
+    @Test
+    public void queryWithNumericNotBetweenPredicate() {
+        //given:
+        String query = "query { Books ( where: { id: {NOT_BETWEEN: [2, 5]}}) { select { id title} } }";
+
+        String expected = "{Books={select=[" +
+                "{id=6, title=The Seagull}, " +
+                "{id=7, title=Three Sisters}" +
+                "]}}";
+
+        //when:
+        Object result = executor.execute(query).getData();
+
+        //then:
+        assertThat(result.toString()).isEqualTo(expected);
+    }
+
+    @Test
+    public void queryWithDateBetweenPredicate() {
+        //given:
+        String query = "query { Books ( where: { publicationDate: {BETWEEN: [\"1869-01-01\", \"1896-01-01\"]}}) { select { id title publicationDate} } }";
+
+        String expected = "{Books={select=[" +
+                "{id=2, title=War and Peace, publicationDate=1869-01-01 00:00:00.0}, " +
+                "{id=3, title=Anna Karenina, publicationDate=1877-04-01 00:00:00.0}" +
+                "]}}";
+
+        //when:
+        Object result = executor.execute(query).getData();
+
+        //then:
+        assertThat(result.toString()).isEqualTo(expected);
+    }
+
+    @Test
+    public void queryWithDateNotBetweenPredicate() {
+        //given:
+        String query = "query { Books ( where: { publicationDate: {NOT_BETWEEN: [\"1869-01-01\", \"1896-01-01\"]}}) { select { id title publicationDate} } }";
+
+        String expected = "{Books={select=[" +
+                "{id=5, title=The Cherry Orchard, publicationDate=1904-01-17 00:00:00.0}, " +
+                "{id=6, title=The Seagull, publicationDate=1896-10-17 00:00:00.0}, " +
+                "{id=7, title=Three Sisters, publicationDate=1900-01-01 00:00:00.0}" +
+                "]}}";
+
+        //when:
+        Object result = executor.execute(query).getData();
+
+        //then:
+        assertThat(result.toString()).isEqualTo(expected);
+    }
+
 //    // TODO
 //    @Test
 //    public void queryForEntityWithEmeddableTypeAndWhere() {
@@ -211,7 +281,7 @@ public class GraphQLExecutorTests {
 //        // then
 //        assertThat(result.toString()).isEqualTo(expected);
 //    }
-    
-    
+
+
 
 }

--- a/graphql-jpa-query-schema/src/test/java/com/introproventures/graphql/jpa/query/schema/StarwarsQueryAuthTests.java
+++ b/graphql-jpa-query-schema/src/test/java/com/introproventures/graphql/jpa/query/schema/StarwarsQueryAuthTests.java
@@ -1,0 +1,167 @@
+/*
+ * Copyright 2017 IntroPro Ventures Inc. and/or its affiliates.
+ * Copyright IBM Corporation 2018
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.introproventures.graphql.jpa.query.schema;
+
+import com.introproventures.graphql.jpa.query.schema.impl.GraphQLJpaExecutor;
+import com.introproventures.graphql.jpa.query.schema.security.GraphQLJpaSchemaWithExtensionsBuilder;
+import com.introproventures.graphql.jpa.query.schema.security.User;
+import graphql.ExecutionResult;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.context.annotation.Bean;
+import org.springframework.test.context.junit4.SpringRunner;
+
+import javax.persistence.EntityManager;
+import javax.persistence.Query;
+import javax.transaction.Transactional;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.fail;
+
+@RunWith(SpringRunner.class)
+@SpringBootTest
+public class StarwarsQueryAuthTests {
+
+    @SpringBootApplication
+    static class Application {
+        @Bean
+        public GraphQLExecutor graphQLExecutor(final GraphQLSchemaBuilder graphQLSchemaBuilder) {
+            return new GraphQLJpaExecutor(graphQLSchemaBuilder.build());
+        }
+
+        @Bean
+        public GraphQLSchemaBuilder graphQLSchemaBuilder(final EntityManager entityManager) {
+
+            return new GraphQLJpaSchemaWithExtensionsBuilder(entityManager)
+                    .name("StarwarsAuth")
+                    .description("Starwars JPA test schema with authorizations");
+        }
+    }
+
+
+    @Autowired
+    private GraphQLExecutor executor;
+
+    @Autowired
+    private EntityManager em;
+
+    @Test
+    public void contextLoads() {
+    }
+
+    @Test
+    @Transactional
+    public void JPASampleTester() {
+        // given:
+        Query query = em.createQuery("select h, h.friends from Human h");
+
+        // when:
+        List<?> result = query.getResultList();
+
+        // then:
+        assertThat(result).isNotEmpty();
+        assertThat(result).hasSize(13);
+    }
+
+    @Test
+    public void getHumanForAuthorizedUser() {
+        //given:
+        String query = "query HumanQuery { Humans { select {name homePlanet gender { description } } } }";
+
+        String expected = "{Humans={select=[" +
+                "{name=Luke Skywalker, homePlanet=Tatooine, gender={description=Male}}, " +
+                "{name=Darth Vader, homePlanet=Tatooine, gender={description=Male}}, " +
+                "{name=Han Solo, homePlanet=null, gender={description=Male}}, " +
+                "{name=Leia Organa, homePlanet=Alderaan, gender={description=Female}}, " +
+                "{name=Wilhuff Tarkin, homePlanet=null, gender={description=Male}}" +
+                "]}}";
+
+        //when:
+        User user = new User.Builder().name("Test User").userId("testu").withRole("admin").withRole("user").build();
+        ExecutionResult executionResult = executor.execute(query, null, user);
+        if (executionResult.getErrors().size() > 0) {
+            fail(executionResult.getErrors().get(0).getMessage());
+        }
+
+        Object result = executionResult.getData();
+
+        //then:
+        assertThat(result.toString()).isEqualTo(expected);
+    }
+
+    @Test
+    public void getHumanForUnauthorizedEntity() {
+        //given:
+        String query = "query HumanQuery { Humans { select {name homePlanet gender { description } } } }";
+
+        String expected = "Exception while fetching data (/Humans) : AUTH_ERR: You are not authorized to access the requested resource";
+
+        //when:
+        User user = new User.Builder().name("Test User").userId("testu").withRole("admin").build();
+        String result = executor.execute(query, null, user).getErrors().get(0).getMessage();
+
+        //then:
+        assertThat(result).isEqualTo(expected);
+    }
+
+    @Test
+    public void getHumanForUnauthorizedAttribute() {
+        //given:
+        String query = "query HumanQuery { Humans { select {name homePlanet gender { description } } } }";
+
+        String expected = "Exception while fetching data (/Humans/select[0]/gender) : AUTH_ERR: You are not authorized to access the requested resource";
+
+        //when:
+        User user = new User.Builder().name("Test User").userId("testu").withRole("user").build();
+        String result = executor.execute(query, null, user).getErrors().get(0).getMessage();
+
+        //then:
+        assertThat(result).isEqualTo(expected);
+    }
+
+    @Test
+    public void getHumanForAuthorizedAttributes() {
+        //given:
+        String query = "query HumanQuery { Humans { select {name homePlanet } } }";
+
+        String expected = "{Humans={select=[" +
+                "{name=Luke Skywalker, homePlanet=Tatooine}, " +
+                "{name=Darth Vader, homePlanet=Tatooine}, " +
+                "{name=Han Solo, homePlanet=null}, " +
+                "{name=Leia Organa, homePlanet=Alderaan}, " +
+                "{name=Wilhuff Tarkin, homePlanet=null}" +
+                "]}}";
+
+        //when:
+        User user = new User.Builder().name("Test User").userId("testu").withRole("admin").withRole("user").build();
+        ExecutionResult executionResult = executor.execute(query, null, user);
+        if (executionResult.getErrors().size() > 0) {
+            fail(executionResult.getErrors().get(0).getMessage());
+        }
+
+        Object result = executionResult.getData();
+
+        //then:
+        assertThat(result.toString()).isEqualTo(expected);
+    }
+
+}

--- a/graphql-jpa-query-schema/src/test/java/com/introproventures/graphql/jpa/query/schema/StarwarsQueryExecutorTests.java
+++ b/graphql-jpa-query-schema/src/test/java/com/introproventures/graphql/jpa/query/schema/StarwarsQueryExecutorTests.java
@@ -377,6 +377,41 @@ public class StarwarsQueryExecutorTests {
     }
 
     @Test
+    public void queryWithStringBetweenPredicate() {
+        //given:
+        String query = "query { Humans ( where: { id: {BETWEEN: [\"1001\", \"1003\"]}}) { select { id } } }";
+
+        String expected = "{Humans={select=["
+                + "{id=1001}, "
+                + "{id=1002}, "
+                + "{id=1003}"
+                + "]}}";
+
+        //when:
+        Object result = executor.execute(query).getData();
+
+        //then:
+        assertThat(result.toString()).isEqualTo(expected);
+    }
+
+    @Test
+    public void queryWithStringNotBetweenPredicate() {
+        //given:
+        String query = "query { Humans ( where: { id: {NOT_BETWEEN: [\"1001\", \"1003\"]}}) { select { id } } }";
+
+        String expected = "{Humans={select=["
+                + "{id=1000}, "
+                + "{id=1004}"
+                + "]}}";
+
+        //when:
+        Object result = executor.execute(query).getData();
+
+        //then:
+        assertThat(result.toString()).isEqualTo(expected);
+    }
+
+    @Test
     public void queryByRestrictingSubObject() {
         //given:
         String query = "query { Humans { select { name gender(where:{ code: {EQ: \"Male\"}}) { description } } } }";

--- a/graphql-jpa-query-schema/src/test/java/com/introproventures/graphql/jpa/query/schema/StarwarsQueryExecutorTests.java
+++ b/graphql-jpa-query-schema/src/test/java/com/introproventures/graphql/jpa/query/schema/StarwarsQueryExecutorTests.java
@@ -52,8 +52,8 @@ public class StarwarsQueryExecutorTests {
         public GraphQLSchemaBuilder graphQLSchemaBuilder(final EntityManager entityManager) {
 
             return new GraphQLJpaSchemaBuilder(entityManager)
-                .name("Starwars")
-                .description("Starwars JPA test schema");
+                    .name("Starwars")
+                    .description("Starwars JPA test schema");
         }
 
     }
@@ -127,7 +127,7 @@ public class StarwarsQueryExecutorTests {
     }
 
     @SuppressWarnings("serial")
-	@Test
+    @Test
     public void queryManyToOneJoinByIdWithVariables() {
         //given:
         String query = "query($id: String!) { Humans { select { name, homePlanet, favoriteDroid(where: {id: {EQ: $id}}) { name} } } }";
@@ -138,7 +138,7 @@ public class StarwarsQueryExecutorTests {
         String expected = "{Humans={select=[{name=Darth Vader, homePlanet=Tatooine, favoriteDroid={name=R2-D2}}]}}";
 
         //when:
-        Object result = executor.execute(query,variables).getData();
+        Object result = executor.execute(query, variables).getData();
 
         //then:
         assertThat(result.toString()).isEqualTo(expected);
@@ -151,8 +151,8 @@ public class StarwarsQueryExecutorTests {
 
 
         String expected = "{Humans={select=["
-            + "{name=Luke Skywalker, homePlanet=Tatooine, friends=[{name=C-3PO}, {name=Leia Organa}, {name=R2-D2}, {name=Han Solo}]}"
-            + "]}}";
+                + "{name=Luke Skywalker, homePlanet=Tatooine, friends=[{name=C-3PO}, {name=Leia Organa}, {name=R2-D2}, {name=Han Solo}]}"
+                + "]}}";
 
 
 
@@ -215,7 +215,7 @@ public class StarwarsQueryExecutorTests {
     public void queryAllowsUseFragmentToAvoidDuplicatingContent() {
         //given:
         String query = "query UseFragment { luke: Human(id: \"1000\") { ...HumanFragment } leia: Human(id: \"1003\") { ...HumanFragment } }"
-                      +"fragment HumanFragment on Human { name, homePlanet }";
+                + "fragment HumanFragment on Human { name, homePlanet }";
 
         String expected = "{luke={name=Luke Skywalker, homePlanet=Tatooine}, leia={name=Leia Organa, homePlanet=Alderaan}}";
 
@@ -233,9 +233,9 @@ public class StarwarsQueryExecutorTests {
 
 
         String expected = "{Droid={name=R2-D2, friends=["
-            + "{name=Leia Organa, appearsIn=[A_NEW_HOPE, EMPIRE_STRIKES_BACK, RETURN_OF_THE_JEDI, THE_FORCE_AWAKENS], friends=[{name=C-3PO}, {name=R2-D2}, {name=Han Solo}, {name=Luke Skywalker}]}, "
-            + "{name=Han Solo, appearsIn=[A_NEW_HOPE, EMPIRE_STRIKES_BACK, RETURN_OF_THE_JEDI, THE_FORCE_AWAKENS], friends=[{name=R2-D2}, {name=Leia Organa}, {name=Luke Skywalker}]}, "
-            + "{name=Luke Skywalker, appearsIn=[A_NEW_HOPE, EMPIRE_STRIKES_BACK, RETURN_OF_THE_JEDI, THE_FORCE_AWAKENS], friends=[{name=C-3PO}, {name=R2-D2}, {name=Leia Organa}, {name=Han Solo}]}"
+                + "{name=Leia Organa, appearsIn=[A_NEW_HOPE, EMPIRE_STRIKES_BACK, RETURN_OF_THE_JEDI, THE_FORCE_AWAKENS], friends=[{name=C-3PO}, {name=R2-D2}, {name=Han Solo}, {name=Luke Skywalker}]}, "
+            + "{name=Han Solo, appearsIn=[A_NEW_HOPE, EMPIRE_STRIKES_BACK, RETURN_OF_THE_JEDI, THE_FORCE_AWAKENS], friends=[{name=Leia Organa}, {name=R2-D2}, {name=Luke Skywalker}]}, "
+            + "{name=Luke Skywalker, appearsIn=[A_NEW_HOPE, EMPIRE_STRIKES_BACK, RETURN_OF_THE_JEDI, THE_FORCE_AWAKENS], friends=[{name=C-3PO}, {name=Leia Organa}, {name=R2-D2}, {name=Han Solo}]}"
             + "]}}";
 
         //when:
@@ -252,10 +252,10 @@ public class StarwarsQueryExecutorTests {
         String query = "query { Droids(where: {id: {EQ: \"2001\"}}) { select { name, friends { name, appearsIn, friends { name } } }  }}";
 
         String expected = "{Droids={select=[{name=R2-D2, friends=["
-            + "{name=Leia Organa, appearsIn=[A_NEW_HOPE, EMPIRE_STRIKES_BACK, RETURN_OF_THE_JEDI, THE_FORCE_AWAKENS], friends=[{name=C-3PO}, {name=R2-D2}, {name=Han Solo}, {name=Luke Skywalker}]}, "
-            + "{name=Han Solo, appearsIn=[A_NEW_HOPE, EMPIRE_STRIKES_BACK, RETURN_OF_THE_JEDI, THE_FORCE_AWAKENS], friends=[{name=R2-D2}, {name=Leia Organa}, {name=Luke Skywalker}]}, "
-            + "{name=Luke Skywalker, appearsIn=[A_NEW_HOPE, EMPIRE_STRIKES_BACK, RETURN_OF_THE_JEDI, THE_FORCE_AWAKENS], friends=[{name=C-3PO}, {name=R2-D2}, {name=Leia Organa}, {name=Han Solo}]}]}"
-            + "]}}";
+                + "{name=Leia Organa, appearsIn=[A_NEW_HOPE, EMPIRE_STRIKES_BACK, RETURN_OF_THE_JEDI, THE_FORCE_AWAKENS], friends=[{name=C-3PO}, {name=R2-D2}, {name=Han Solo}, {name=Luke Skywalker}]}, "
+                + "{name=Han Solo, appearsIn=[A_NEW_HOPE, EMPIRE_STRIKES_BACK, RETURN_OF_THE_JEDI, THE_FORCE_AWAKENS], friends=[{name=R2-D2}, {name=Leia Organa}, {name=Luke Skywalker}]}, "
+                + "{name=Luke Skywalker, appearsIn=[A_NEW_HOPE, EMPIRE_STRIKES_BACK, RETURN_OF_THE_JEDI, THE_FORCE_AWAKENS], friends=[{name=C-3PO}, {name=R2-D2}, {name=Leia Organa}, {name=Han Solo}]}]}"
+                + "]}}";
 
         //when:
         Object result = executor.execute(query).getData();
@@ -299,12 +299,12 @@ public class StarwarsQueryExecutorTests {
         String query = "query { Humans { select {name(orderBy: DESC) homePlanet } } }";
 
         String expected = "{Humans={select=["
-            + "{name=Wilhuff Tarkin, homePlanet=null}, "
-            + "{name=Luke Skywalker, homePlanet=Tatooine}, "
-            + "{name=Leia Organa, homePlanet=Alderaan}, "
-            + "{name=Han Solo, homePlanet=null}, "
-            + "{name=Darth Vader, homePlanet=Tatooine}"
-            + "]}}";
+                + "{name=Wilhuff Tarkin, homePlanet=null}, "
+                + "{name=Luke Skywalker, homePlanet=Tatooine}, "
+                + "{name=Leia Organa, homePlanet=Alderaan}, "
+                + "{name=Han Solo, homePlanet=null}, "
+                + "{name=Darth Vader, homePlanet=Tatooine}"
+                + "]}}";
 
         //when:
         Object result = executor.execute(query).getData();
@@ -319,15 +319,15 @@ public class StarwarsQueryExecutorTests {
         String query = "query { Humans(where: {id: {EQ: \"1000\"}}) { select {name(orderBy: DESC) homePlanet friends { name(orderBy:DESC) } } } }";
 
         String expected = "{Humans={select=["
-            + "{name=Luke Skywalker, homePlanet=Tatooine, "
-	            + "friends=["
-		            + "{name=R2-D2}, "
-		            + "{name=Leia Organa}, "
-		            + "{name=Han Solo}, "
-		            + "{name=C-3PO}"
-		        + "]"
-	        + "}"
-            + "]}}";
+                + "{name=Luke Skywalker, homePlanet=Tatooine, "
+                + "friends=["
+                + "{name=R2-D2}, "
+                + "{name=Leia Organa}, "
+                + "{name=Han Solo}, "
+                + "{name=C-3PO}"
+                + "]"
+                + "}"
+                + "]}}";
 
         //when:
         Object result = executor.execute(query).getData();
@@ -342,12 +342,12 @@ public class StarwarsQueryExecutorTests {
         String query = "query { Humans { select { id } } }";
 
         String expected = "{Humans={select=["
-	            + "{id=1000}, "
-	            + "{id=1001}, "
-	            + "{id=1002}, "
-	            + "{id=1003}, "
-	            + "{id=1004}"
-            + "]}}";
+                + "{id=1000}, "
+                + "{id=1001}, "
+                + "{id=1002}, "
+                + "{id=1003}, "
+                + "{id=1004}"
+                + "]}}";
 
         //when:
         Object result = executor.execute(query).getData();
@@ -364,10 +364,10 @@ public class StarwarsQueryExecutorTests {
 
 
         String expected = "{Humans={select=["
-            + "{name=Luke Skywalker, appearsIn=[A_NEW_HOPE, EMPIRE_STRIKES_BACK, RETURN_OF_THE_JEDI, THE_FORCE_AWAKENS]}, "
-            + "{name=Han Solo, appearsIn=[A_NEW_HOPE, EMPIRE_STRIKES_BACK, RETURN_OF_THE_JEDI, THE_FORCE_AWAKENS]}, "
-            + "{name=Leia Organa, appearsIn=[A_NEW_HOPE, EMPIRE_STRIKES_BACK, RETURN_OF_THE_JEDI, THE_FORCE_AWAKENS]}"
-            + "]}}";
+                + "{name=Luke Skywalker, appearsIn=[A_NEW_HOPE, EMPIRE_STRIKES_BACK, RETURN_OF_THE_JEDI, THE_FORCE_AWAKENS]}, "
+                + "{name=Han Solo, appearsIn=[A_NEW_HOPE, EMPIRE_STRIKES_BACK, RETURN_OF_THE_JEDI, THE_FORCE_AWAKENS]}, "
+                + "{name=Leia Organa, appearsIn=[A_NEW_HOPE, EMPIRE_STRIKES_BACK, RETURN_OF_THE_JEDI, THE_FORCE_AWAKENS]}"
+                + "]}}";
 
         //when:
         Object result = executor.execute(query).getData();
@@ -382,11 +382,11 @@ public class StarwarsQueryExecutorTests {
         String query = "query { Humans { select { name gender(where:{ code: {EQ: \"Male\"}}) { description } } } }";
 
         String expected = "{Humans={select=["
-            + "{name=Luke Skywalker, gender={description=Male}}, "
-            + "{name=Darth Vader, gender={description=Male}}, "
-            + "{name=Han Solo, gender={description=Male}}, "
-            + "{name=Wilhuff Tarkin, gender={description=Male}}"
-            + "]}}";
+                + "{name=Luke Skywalker, gender={description=Male}}, "
+                + "{name=Darth Vader, gender={description=Male}}, "
+                + "{name=Han Solo, gender={description=Male}}, "
+                + "{name=Wilhuff Tarkin, gender={description=Male}}"
+                + "]}}";
 
         //when:
         Object result = executor.execute(query).getData();
@@ -429,9 +429,9 @@ public class StarwarsQueryExecutorTests {
         String query = "query { CodeLists(where: { active: {EQ:true}}) { select {id description active type sequence } } }";
 
         String expected = "{CodeLists={select=["
-            + "{id=0, description=Male, active=true, type=org.crygier.graphql.model.starwars.Gender, sequence=1}, "
-            + "{id=1, description=Female, active=true, type=org.crygier.graphql.model.starwars.Gender, sequence=2}"
-            + "]}}";
+                + "{id=0, description=Male, active=true, type=org.crygier.graphql.model.starwars.Gender, sequence=1}, "
+                + "{id=1, description=Female, active=true, type=org.crygier.graphql.model.starwars.Gender, sequence=2}"
+                + "]}}";
 
         //when:
         Object result = executor.execute(query).getData();
@@ -494,9 +494,9 @@ public class StarwarsQueryExecutorTests {
 
 
         String expected = "{Droid={name=R2-D2, friends=["
-            + "{name=Leia Organa, appearsIn=[A_NEW_HOPE, EMPIRE_STRIKES_BACK, RETURN_OF_THE_JEDI, THE_FORCE_AWAKENS], friends=[{name=C-3PO, __typename=Character}, {name=R2-D2, __typename=Character}, {name=Han Solo, __typename=Character}, {name=Luke Skywalker, __typename=Character}], __typename=Character}, "
-            + "{name=Han Solo, appearsIn=[A_NEW_HOPE, EMPIRE_STRIKES_BACK, RETURN_OF_THE_JEDI, THE_FORCE_AWAKENS], friends=[{name=R2-D2, __typename=Character}, {name=Leia Organa, __typename=Character}, {name=Luke Skywalker, __typename=Character}], __typename=Character}, "
-            + "{name=Luke Skywalker, appearsIn=[A_NEW_HOPE, EMPIRE_STRIKES_BACK, RETURN_OF_THE_JEDI, THE_FORCE_AWAKENS], friends=[{name=C-3PO, __typename=Character}, {name=R2-D2, __typename=Character}, {name=Leia Organa, __typename=Character}, {name=Han Solo, __typename=Character}], __typename=Character}"
+                + "{name=Leia Organa, appearsIn=[A_NEW_HOPE, EMPIRE_STRIKES_BACK, RETURN_OF_THE_JEDI, THE_FORCE_AWAKENS], friends=[{name=C-3PO, __typename=Character}, {name=R2-D2, __typename=Character}, {name=Han Solo, __typename=Character}, {name=Luke Skywalker, __typename=Character}], __typename=Character}, "
+            + "{name=Han Solo, appearsIn=[A_NEW_HOPE, EMPIRE_STRIKES_BACK, RETURN_OF_THE_JEDI, THE_FORCE_AWAKENS], friends=[{name=Leia Organa, __typename=Character}, {name=R2-D2, __typename=Character}, {name=Luke Skywalker, __typename=Character}], __typename=Character}, "
+            + "{name=Luke Skywalker, appearsIn=[A_NEW_HOPE, EMPIRE_STRIKES_BACK, RETURN_OF_THE_JEDI, THE_FORCE_AWAKENS], friends=[{name=C-3PO, __typename=Character}, {name=Leia Organa, __typename=Character}, {name=R2-D2, __typename=Character}, {name=Han Solo, __typename=Character}], __typename=Character}"
             + "], __typename=Droid}}";
 
         //when:
@@ -505,7 +505,7 @@ public class StarwarsQueryExecutorTests {
         //then:
         assertThat(result.toString()).isEqualTo(expected);
     }
-    
+
     @Test
     public void queryWithTypenameSimple() {
         //given:

--- a/graphql-jpa-query-schema/src/test/java/com/introproventures/graphql/jpa/query/schema/StarwarsSchemaBuildTest.java
+++ b/graphql-jpa-query-schema/src/test/java/com/introproventures/graphql/jpa/query/schema/StarwarsSchemaBuildTest.java
@@ -38,7 +38,7 @@ import graphql.schema.GraphQLSchema;
 
 @RunWith(SpringRunner.class)
 @SpringBootTest(
-    webEnvironment=WebEnvironment.NONE
+        webEnvironment = WebEnvironment.NONE
 )
 public class StarwarsSchemaBuildTest {
 
@@ -47,11 +47,11 @@ public class StarwarsSchemaBuildTest {
         @Bean
         public GraphQLJpaSchemaBuilder graphQLSchemaBuilder(EntityManager entityManager) {
             return new GraphQLJpaSchemaBuilder(entityManager)
-                .name("Starwars")
-                .description("Starwars Universe Schema");
+                    .name("Starwars")
+                    .description("Starwars Universe Schema");
         }
     }
-    
+
     @Autowired
     private GraphQLJpaSchemaBuilder builder;
 
@@ -66,28 +66,28 @@ public class StarwarsSchemaBuildTest {
 
         // then
         assertThat(schema)
-            .describedAs("Ensure the result is returned")
-            .isNotNull();
+                .describedAs("Ensure the result is returned")
+                .isNotNull();
 
         //then
         assertThat(schema.getQueryType().getFieldDefinition("Droid").getArgument("id"))
-            .describedAs( "Ensure that identity can be queried on")
-            .isNotNull();
-        
+                .describedAs("Ensure that identity can be queried on")
+                .isNotNull();
+
         //then
         assertThat(schema.getQueryType().getFieldDefinition("Droids").getArgument("where"))
-            .describedAs( "Ensure that collections can be queried on")
-            .isNotNull();
+                .describedAs("Ensure that collections can be queried on")
+                .isNotNull();
 
         //then
         assertThat(schema.getQueryType().getFieldDefinition("CodeLists").getArguments())
             .describedAs("Ensure Subobjects may be queried upon")
-            .hasSize(2);
-        
-        assertThat(((GraphQLInputObjectType)((GraphQLInputObjectType) schema.getQueryType()
-            .getFieldDefinition("CodeLists").getArgument("where").getType())
-            .getField("code").getType())
-            .getField("EQ").getType()
+            .hasSize(3);
+
+        assertThat(((GraphQLInputObjectType) ((GraphQLInputObjectType) schema.getQueryType()
+                .getFieldDefinition("CodeLists").getArgument("where").getType())
+                .getField("code").getType())
+                .getField("EQ").getType()
         ).isEqualTo(Scalars.GraphQLString);
     }
 
@@ -98,26 +98,26 @@ public class StarwarsSchemaBuildTest {
 
         // then
         assertThat(schema)
-            .describedAs("Ensure the schema is generated")
-            .isNotNull();
+                .describedAs("Ensure the schema is generated")
+                .isNotNull();
 
         //then
         assertThat(schema.getQueryType().getFieldDefinition("Droids").getArgument("page"))
-            .describedAs( "Ensure that query collection has page argument")
-            .isNotNull();
+                .describedAs("Ensure that query collection has page argument")
+                .isNotNull();
 
         //then
         assertThat(schema.getQueryType().getFieldDefinition("Droids").getArgument("where"))
-            .describedAs( "Ensure that query collection has where argument")
-            .isNotNull();
-        
+                .describedAs("Ensure that query collection has where argument")
+                .isNotNull();
+
         //then
         assertThat(schema.getQueryType()
             .getFieldDefinition("CodeLists").getArguments()
         )
-        .describedAs("Ensure query has two arguments")
-        .hasSize(2);
+        .describedAs("Ensure query has three arguments")
+        .hasSize(3);
         
     }
-    
+
 }

--- a/graphql-jpa-query-schema/src/test/java/com/introproventures/graphql/jpa/query/schema/model/book/Book.java
+++ b/graphql-jpa-query-schema/src/test/java/com/introproventures/graphql/jpa/query/schema/model/book/Book.java
@@ -23,6 +23,9 @@ import javax.persistence.Id;
 import javax.persistence.ManyToOne;
 
 import lombok.Data;
+import org.springframework.format.annotation.DateTimeFormat;
+
+import java.util.Date;
 
 @Data
 @Entity
@@ -37,4 +40,6 @@ public class Book {
 
 	@Enumerated(EnumType.STRING)
 	Genre genre;
+
+	Date publicationDate;
 }

--- a/graphql-jpa-query-schema/src/test/java/com/introproventures/graphql/jpa/query/schema/model/starwars/Human.java
+++ b/graphql-jpa-query-schema/src/test/java/com/introproventures/graphql/jpa/query/schema/model/starwars/Human.java
@@ -1,5 +1,6 @@
 /*
  * Copyright 2017 IntroPro Ventures Inc. and/or its affiliates.
+ * Copyright IBM Corporation 2018
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -21,12 +22,14 @@ import javax.persistence.FetchType;
 import javax.persistence.JoinColumn;
 import javax.persistence.ManyToOne;
 
+import com.introproventures.graphql.jpa.query.schema.security.Authorization;
 import lombok.Data;
 import lombok.EqualsAndHashCode;
 
 @Entity(name = "Human")
 @Data
 @EqualsAndHashCode(callSuper=true)
+@Authorization(role = "user")
 public class Human extends Character {
 
     String homePlanet;
@@ -37,6 +40,6 @@ public class Human extends Character {
 
     @ManyToOne
     @JoinColumn(name = "gender_code_id")
+    @Authorization (role = "admin")
     CodeList gender;
-
 }

--- a/graphql-jpa-query-schema/src/test/java/com/introproventures/graphql/jpa/query/schema/security/Authorization.java
+++ b/graphql-jpa-query-schema/src/test/java/com/introproventures/graphql/jpa/query/schema/security/Authorization.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright IBM Corporation 2018
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.introproventures.graphql.jpa.query.schema.security;
+
+import java.lang.annotation.*;
+
+import static java.lang.annotation.ElementType.FIELD;
+import static java.lang.annotation.ElementType.TYPE;
+
+/**
+ * Very simple authorization annotation for testing
+ */
+@Inherited
+@Retention(RetentionPolicy.RUNTIME)
+@Target(value = { ElementType.METHOD, FIELD, TYPE})
+public @interface Authorization {
+    String role();
+}

--- a/graphql-jpa-query-schema/src/test/java/com/introproventures/graphql/jpa/query/schema/security/AuthorizationStrategy.java
+++ b/graphql-jpa-query-schema/src/test/java/com/introproventures/graphql/jpa/query/schema/security/AuthorizationStrategy.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright IBM Corporation 2018
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.introproventures.graphql.jpa.query.schema.security;
+
+import graphql.schema.GraphQLDirective;
+
+import com.introproventures.graphql.jpa.query.schema.IQueryAuthorizationStrategy;
+import java.util.Map;
+
+public class AuthorizationStrategy implements IQueryAuthorizationStrategy {
+    @Override
+    public boolean isAuthorized(Object context, GraphQLDirective directive) {
+        if (directive == null)
+            return false;
+
+        User user = (User) ((Map<String, Object>) context).get("userContext");
+
+        if (user == null)
+            return false;
+
+        if (!user.getRoles().contains (directive.getArgument("role").getValue()))
+            return false;
+
+        return true;
+    }
+}
+

--- a/graphql-jpa-query-schema/src/test/java/com/introproventures/graphql/jpa/query/schema/security/GraphQLJpaSchemaWithExtensionsBuilder.java
+++ b/graphql-jpa-query-schema/src/test/java/com/introproventures/graphql/jpa/query/schema/security/GraphQLJpaSchemaWithExtensionsBuilder.java
@@ -1,0 +1,111 @@
+/*
+ * Copyright IBM Corporation 2018
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.introproventures.graphql.jpa.query.schema.security;
+
+import com.introproventures.graphql.jpa.query.schema.IQueryAuthorizationStrategy;
+import com.introproventures.graphql.jpa.query.schema.impl.GraphQLJpaSchemaBuilder;
+import com.introproventures.graphql.jpa.query.schema.security.Authorization;
+import graphql.introspection.Introspection;
+import graphql.schema.GraphQLArgument;
+import graphql.schema.GraphQLDirective;
+
+import javax.persistence.EntityManager;
+import javax.persistence.metamodel.Attribute;
+import javax.persistence.metamodel.ManagedType;
+import java.lang.reflect.Field;
+import java.util.ArrayList;
+import java.util.List;
+
+import static graphql.Scalars.GraphQLString;
+
+public class GraphQLJpaSchemaWithExtensionsBuilder extends GraphQLJpaSchemaBuilder {
+    public GraphQLJpaSchemaWithExtensionsBuilder(EntityManager entityManager) {
+        super(entityManager);
+        authorizationStrategy(new AuthorizationStrategy());
+    }
+
+    @Override
+    public List<GraphQLDirective> getAuthorizationDirectives(ManagedType<?> entityType) {
+        //Get the security annotations for the entity
+        Authorization authorization = getAuthorization(entityType);
+
+        //Generate the security directive and return it
+        List<GraphQLDirective> directives = getSecurityDirectives(authorization);
+
+        return directives;
+    }
+
+    private Authorization getAuthorization(ManagedType<?> entityType) {
+        Class<?> clazz = entityType.getJavaType();
+        while (clazz != null) {
+            Authorization authorization = clazz.getAnnotation(Authorization.class);
+            if (authorization != null)
+                return authorization;
+            clazz = clazz.getSuperclass();
+        }
+        return null;
+    }
+
+    private Authorization getAuthorization(Attribute<?, ?> attribute) {
+        Class<?> clazz = attribute.getDeclaringType().getJavaType();
+        Field field = getField(clazz, attribute.getName());
+
+        Authorization authorization = field.getAnnotation(Authorization.class);
+        return authorization;
+    }
+
+    private Field getField(Class clazz, String fieldName) {
+        while (clazz != null && fieldName != null) {
+            Field field = null;
+            try {
+                field = clazz.getDeclaredField(fieldName);
+            } catch (NoSuchFieldException e) {
+                clazz = clazz.getSuperclass();
+                continue;
+            }
+            if (field != null)
+                return field;
+
+        }
+
+        return null;
+    }
+
+    private List<GraphQLDirective> getSecurityDirectives(Authorization authorization) {
+        if (authorization == null)
+            return null;
+
+        List<GraphQLDirective> directiveList = new ArrayList<>(1);
+        GraphQLDirective directive = GraphQLDirective.newDirective().name(IQueryAuthorizationStrategy.AUTHORIZATION)
+                .argument(GraphQLArgument.newArgument().name("role").type(GraphQLString).value(authorization.role())
+                        .build())
+                .validLocation(Introspection.DirectiveLocation.FIELD_DEFINITION).build();
+        directiveList.add(directive);
+
+        return directiveList;
+    }
+
+    @Override
+    public List<GraphQLDirective> getAuthorizationDirectives(Attribute<?, ?> attribute) {
+        //Get the security annotations for the entity
+        Authorization authorization = getAuthorization(attribute);
+
+        //Generate the security directive and return it
+        List<GraphQLDirective> directives = getSecurityDirectives(authorization);
+        return directives;
+    }
+
+}

--- a/graphql-jpa-query-schema/src/test/java/com/introproventures/graphql/jpa/query/schema/security/User.java
+++ b/graphql-jpa-query-schema/src/test/java/com/introproventures/graphql/jpa/query/schema/security/User.java
@@ -1,0 +1,61 @@
+/*
+ * Copyright IBM Corporation 2018
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.introproventures.graphql.jpa.query.schema.security;
+
+import java.util.ArrayList;
+import java.util.List;
+
+public class User {
+    private String name;
+    private String userId;
+    private List<String> roles = new ArrayList<>(2);
+
+    public String getName() {
+        return name;
+    }
+
+    public String getUserId() {
+        return userId;
+    }
+
+    public List<String> getRoles() {
+        return roles;
+    }
+
+    public final static class Builder {
+        private User user;
+        public Builder() {
+            user = new User();
+        }
+
+        public Builder name(String name) {
+            user.name = name;
+            return this;
+        }
+
+        public Builder userId(String userId) {
+            user.userId = userId;
+            return this;
+        }
+
+        public Builder withRole(String role) {
+            user.roles.add(role);
+            return this;
+        }
+
+        public User build() { return user; }
+    }
+}

--- a/graphql-jpa-query-schema/src/test/resources/data.sql
+++ b/graphql-jpa-query-schema/src/test/resources/data.sql
@@ -108,12 +108,12 @@ insert into thing (id, type) values
     
 -- Books
 insert into author (id, name) values (1, 'Leo Tolstoy');
-insert into book (id, title, author_id, genre) values (2, 'War and Peace', 1, 'NOVEL');
-insert into book (id, title, author_id, genre) values (3, 'Anna Karenina', 1, 'NOVEL');
+insert into book (id, title, author_id, genre, publication_date) values (2, 'War and Peace', 1, 'NOVEL', '1869-01-01');
+insert into book (id, title, author_id, genre, publication_date) values (3, 'Anna Karenina', 1, 'NOVEL', '1877-04-01');
 insert into author (id, name) values (4, 'Anton Chekhov');
-insert into book (id, title, author_id, genre) values (5, 'The Cherry Orchard', 4, 'PLAY');
-insert into book (id, title, author_id, genre) values (6, 'The Seagull', 4, 'PLAY');
-insert into book (id, title, author_id, genre) values (7, 'Three Sisters', 4, 'PLAY');
+insert into book (id, title, author_id, genre, publication_date) values (5, 'The Cherry Orchard', 4, 'PLAY', '1904-01-17');
+insert into book (id, title, author_id, genre, publication_date) values (6, 'The Seagull', 4, 'PLAY', '1896-10-17');
+insert into book (id, title, author_id, genre, publication_date) values (7, 'Three Sisters', 4, 'PLAY', '1900-01-01');
 insert into author_phone_numbers(phone_number, author_id) values
 	('1-123-1234', 1),
 	('1-123-5678', 1),

--- a/pom.xml
+++ b/pom.xml
@@ -25,7 +25,7 @@
 		<project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
 
 		<java.version>1.8</java.version>
-		<graphql-java.version>6.0</graphql-java.version>
+		<graphql-java.version>9.0</graphql-java.version>
 	</properties>
 
 	<modules>


### PR DESCRIPTION
* Added support for blobs and SQL date/timestamp types
* Added support for non-enum element collections
* Added support for BETWEEN / NOT BETWEEN predicates
* Added distinct operation to paged requests, as blob fields cannot be in a distinct SQL query - default is true
* Added authorization checking for entities and attributes
* Added mechanism for determining entity names and attributes to expose in the query - by default, it uses the class name and field name, respectively
* Added alternate data fetchers optimized towards Eclipselink batch fetching mechanisms.