### PR TITLE
Fix generated CriteriaExpression not working with UUIDs

### DIFF
--- a/graphql-jpa-query-schema/src/main/java/com/introproventures/graphql/jpa/query/schema/impl/JpaPredicateBuilder.java
+++ b/graphql-jpa-query-schema/src/main/java/com/introproventures/graphql/jpa/query/schema/impl/JpaPredicateBuilder.java
@@ -264,7 +264,7 @@ class JpaPredicateBuilder {
         return null;
     }
 
-    private Predicate getUuidPredicate(Path<? extends UUID> field, PredicateFilter filter) {
+    private Predicate getUuidPredicate(Path<UUID> field, PredicateFilter filter) {
         if (filter.getValue() == null) {
             return null;
         }

--- a/graphql-jpa-query-schema/src/main/java/com/introproventures/graphql/jpa/query/schema/impl/JpaPredicateBuilder.java
+++ b/graphql-jpa-query-schema/src/main/java/com/introproventures/graphql/jpa/query/schema/impl/JpaPredicateBuilder.java
@@ -22,6 +22,8 @@ import java.util.Collection;
 import java.util.Date;
 import java.util.EnumSet;
 import java.util.Set;
+import java.util.UUID;
+
 
 import javax.persistence.criteria.CriteriaBuilder;
 import javax.persistence.criteria.Expression;
@@ -30,6 +32,7 @@ import javax.persistence.criteria.Path;
 import javax.persistence.criteria.Predicate;
 
 import com.introproventures.graphql.jpa.query.schema.impl.PredicateFilter.Criteria;
+
 
 /**
  * Supported types to build predicates for
@@ -262,6 +265,19 @@ class JpaPredicateBuilder {
         return null;
     }
 
+    private Predicate getUuidPredicate(Path<? extends UUID> field, PredicateFilter filter) {
+        if(filter.getValue() == null || !(filter.getValue() instanceof UUID)) {
+            return null;
+        }
+        if(filter.getCriterias().contains(PredicateFilter.Criteria.EQ)) {
+            return cb.equal(field, filter.getValue());
+        }
+        if(filter.getCriterias().contains(PredicateFilter.Criteria.NE)) {
+            return cb.notEqual(field, filter.getValue());
+        }
+        return null;
+    }
+
     @SuppressWarnings("unchecked")
     private Predicate getTypedPredicate(From<?,?> from, Path<?> field, PredicateFilter filter) {
         Class<?> type = field.getJavaType();
@@ -302,6 +318,9 @@ class JpaPredicateBuilder {
         }
         else if (type.equals(Boolean.class)) {
             return getBooleanPredicate(field, predicateFilter);
+        }
+        else if (type.equals(UUID.class)) {
+            return getUuidPredicate((Path<UUID>) field, predicateFilter);
         }
         else if(Collection.class.isAssignableFrom(type)) {
             if(field.getModel() == null)

--- a/graphql-jpa-query-schema/src/test/java/com/introproventures/graphql/jpa/query/schema/GraphQLExecutorTests.java
+++ b/graphql-jpa-query-schema/src/test/java/com/introproventures/graphql/jpa/query/schema/GraphQLExecutorTests.java
@@ -19,6 +19,7 @@ package com.introproventures.graphql.jpa.query.schema;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import java.util.HashMap;
+import java.util.UUID;
 
 import javax.persistence.EntityManager;
 
@@ -132,6 +133,21 @@ public class GraphQLExecutorTests {
 
         //when:
         Object result = executor.execute(query, new HashMap() {{put("id", null);}}).getData();
+
+        //then:
+        assertThat(result.toString()).isEqualTo(expected);
+    }
+
+    @SuppressWarnings( { "rawtypes", "unchecked", "serial" } )
+    @Test
+    public void queryForThingByIdViaWhere() {
+        //given:
+
+        String query = "query { Things(where: {id: {EQ: \"2d1ebc5b-7d27-4197-9cf0-e84451c5bbb1\"}}) { select { id }}}";
+        String expected = "{Things={select=[{id=2d1ebc5b-7d27-4197-9cf0-e84451c5bbb1}]}}";
+
+        //when:
+        Object result = executor.execute(query).getData();
 
         //then:
         assertThat(result.toString()).isEqualTo(expected);

--- a/graphql-jpa-query-schema/src/test/java/com/introproventures/graphql/jpa/query/schema/GraphQLExecutorTests.java
+++ b/graphql-jpa-query-schema/src/test/java/com/introproventures/graphql/jpa/query/schema/GraphQLExecutorTests.java
@@ -168,6 +168,30 @@ public class GraphQLExecutorTests {
         assertThat(result.toString()).isEqualTo(expected);
     }
 
+    @SuppressWarnings( { "rawtypes", "unchecked", "serial" } )
+    @Test
+    public void queryForThingByIdViaWhereNE() {
+        //given:
+
+        String query = "query { Things(where: {id: {NE: \"2d1ebc5b-7d27-4197-9cf0-e84451c5bbb2\"}}) { select { id }}}";
+        String expected = "{Things={select=[{id=2d1ebc5b-7d27-4197-9cf0-e84451c5bbb1}]}}";
+
+        //when:
+        Object result = executor.execute(query).getData();
+
+        //then:
+        assertThat(result.toString()).isEqualTo(expected);
+
+        query = "query { Things(where: {id: {NE: \"2d1ebc5b-7d27-4197-9cf0-e84451c5bbb1\"}}) { select { id }}}";
+        expected = "{Things={select=[]}}";
+
+        //when:
+        result = executor.execute(query).getData();
+
+        //then:
+        assertThat(result.toString()).isEqualTo(expected);
+    }
+
     @Test
     public void queryWithAlias() {
         //given:

--- a/graphql-jpa-query-schema/src/test/java/com/introproventures/graphql/jpa/query/schema/GraphQLExecutorTests.java
+++ b/graphql-jpa-query-schema/src/test/java/com/introproventures/graphql/jpa/query/schema/GraphQLExecutorTests.java
@@ -152,7 +152,22 @@ public class GraphQLExecutorTests {
         //then:
         assertThat(result.toString()).isEqualTo(expected);
     }
-    
+
+    @SuppressWarnings( { "rawtypes", "unchecked", "serial" } )
+    @Test
+    public void queryForThingByIdViaWhereIN() {
+        //given:
+
+        String query = "query { Things(where: {id: {IN: [\"2d1ebc5b-7d27-4197-9cf0-e84451c5bbb1\", \"2d1ebc5b-7d27-4197-9cf0-e84451c5bbb1\" ]}}) { select { id }}}";
+        String expected = "{Things={select=[{id=2d1ebc5b-7d27-4197-9cf0-e84451c5bbb1}]}}";
+
+        //when:
+        Object result = executor.execute(query).getData();
+
+        //then:
+        assertThat(result.toString()).isEqualTo(expected);
+    }
+
     @Test
     public void queryWithAlias() {
         //given:


### PR DESCRIPTION
Currently UUIDs only work as primary key attributes. Using them in a CriteriaExpression runs into the following issue however. For Example running:

<details><summary>Kotlin Entity</summary>
<p>

```Event.kt
@Entity
class Event(
    @Id
    val id: UUID? = null,
) {

}
```
</p>
</details>

<details><summary>Query</summary>
<p>

```
{
  Events(where: {id: {EQ: "11781ee7-591f-4a7f-819d-07e12eedbe65"}}) {
    select {
      id
    }
  }
}
```
</p>
</details>

<details><summary>Result</summary>
<p>

```response.json
{
  "data": {},
  "errors": [
    {
      "message": "Exception while fetching data (/Events) : Unsupported field type class java.util.UUID for field id",
      "path": [
        "Events"
      ],
      "exception": {
        "stackTrace": [
          {
            "methodName": "getTypedPredicate",
            "fileName": "JpaPredicateBuilder.java",
            "lineNumber": 327,
            "className": "com.introproventures.graphql.jpa.query.schema.impl.JpaPredicateBuilder",
            "nativeMethod": false
          },
          {
            "methodName": "getPredicate",
            "fileName": "JpaPredicateBuilder.java",
            "lineNumber": 341,
            "className": "com.introproventures.graphql.jpa.query.schema.impl.JpaPredicateBuilder",
            "nativeMethod": false
          },
          {
            "methodName": "lambda$getFieldPredicate$21",
            "fileName": "QraphQLJpaBaseDataFetcher.java",
            "lineNumber": 393,
            "className": "com.introproventures.graphql.jpa.query.schema.impl.QraphQLJpaBaseDataFetcher",
            "nativeMethod": false
          },
          {
            "methodName": "accept",
            "fileName": "ReferencePipeline.java",
            "lineNumber": 193,
            "className": "java.util.stream.ReferencePipeline$3$1",
            "nativeMethod": false
          },
          {
            "methodName": "forEach",
            "fileName": "ArrayList.java",
            "lineNumber": 1255,
            "className": "java.util.ArrayList",
            "nativeMethod": false
          },
          {
            "methodName": "end",
            "fileName": "SortedOps.java",
            "lineNumber": 390,
            "className": "java.util.stream.SortedOps$RefSortingSink",
            "nativeMethod": false
          },
          {
            "methodName": "end",
            "fileName": "Sink.java",
            "lineNumber": 258,
            "className": "java.util.stream.Sink$ChainedReference",
            "nativeMethod": false
          },
          {
            "methodName": "end",
            "fileName": "Sink.java",
            "lineNumber": 258,
            "className": "java.util.stream.Sink$ChainedReference",
            "nativeMethod": false
          },
          {
            "methodName": "copyInto",
            "fileName": "AbstractPipeline.java",
            "lineNumber": 482,
            "className": "java.util.stream.AbstractPipeline",
            "nativeMethod": false
          },
          {
            "methodName": "wrapAndCopyInto",
            "fileName": "AbstractPipeline.java",
            "lineNumber": 471,
            "className": "java.util.stream.AbstractPipeline",
            "nativeMethod": false
          },
          {
            "methodName": "evaluateSequential",
            "fileName": "ForEachOps.java",
            "lineNumber": 151,
            "className": "java.util.stream.ForEachOps$ForEachOp",
            "nativeMethod": false
          },
          {
            "methodName": "evaluateSequential",
            "fileName": "ForEachOps.java",
            "lineNumber": 174,
            "className": "java.util.stream.ForEachOps$ForEachOp$OfRef",
            "nativeMethod": false
          },
          {
            "methodName": "evaluate",
            "fileName": "AbstractPipeline.java",
            "lineNumber": 234,
            "className": "java.util.stream.AbstractPipeline",
            "nativeMethod": false
          },
          {
            "methodName": "forEach",
            "fileName": "ReferencePipeline.java",
            "lineNumber": 418,
            "className": "java.util.stream.ReferencePipeline",
            "nativeMethod": false
          },
          {
            "methodName": "getFieldPredicate",
            "fileName": "QraphQLJpaBaseDataFetcher.java",
            "lineNumber": 395,
            "className": "com.introproventures.graphql.jpa.query.schema.impl.QraphQLJpaBaseDataFetcher",
            "nativeMethod": false
          },
          {
            "methodName": "lambda$getArgumentPredicate$13",
            "fileName": "QraphQLJpaBaseDataFetcher.java",
            "lineNumber": 349,
            "className": "com.introproventures.graphql.jpa.query.schema.impl.QraphQLJpaBaseDataFetcher",
            "nativeMethod": false
          },
          {
            "methodName": "accept",
            "fileName": "ReferencePipeline.java",
            "lineNumber": 193,
            "className": "java.util.stream.ReferencePipeline$3$1",
            "nativeMethod": false
          },
          {
            "methodName": "accept",
            "fileName": "ReferencePipeline.java",
            "lineNumber": 175,
            "className": "java.util.stream.ReferencePipeline$2$1",
            "nativeMethod": false
          },
          {
            "methodName": "forEachRemaining",
            "fileName": "ArrayList.java",
            "lineNumber": 1380,
            "className": "java.util.ArrayList$ArrayListSpliterator",
            "nativeMethod": false
          },
          {
            "methodName": "copyInto",
            "fileName": "AbstractPipeline.java",
            "lineNumber": 481,
            "className": "java.util.stream.AbstractPipeline",
            "nativeMethod": false
          },
          {
            "methodName": "wrapAndCopyInto",
            "fileName": "AbstractPipeline.java",
            "lineNumber": 471,
            "className": "java.util.stream.AbstractPipeline",
            "nativeMethod": false
          },
          {
            "methodName": "evaluateSequential",
            "fileName": "ForEachOps.java",
            "lineNumber": 151,
            "className": "java.util.stream.ForEachOps$ForEachOp",
            "nativeMethod": false
          },
          {
            "methodName": "evaluateSequential",
            "fileName": "ForEachOps.java",
            "lineNumber": 174,
            "className": "java.util.stream.ForEachOps$ForEachOp$OfRef",
            "nativeMethod": false
          },
          {
            "methodName": "evaluate",
            "fileName": "AbstractPipeline.java",
            "lineNumber": 234,
            "className": "java.util.stream.AbstractPipeline",
            "nativeMethod": false
          },
          {
            "methodName": "forEach",
            "fileName": "ReferencePipeline.java",
            "lineNumber": 418,
            "className": "java.util.stream.ReferencePipeline",
            "nativeMethod": false
          },
          {
            "methodName": "getArgumentPredicate",
            "fileName": "QraphQLJpaBaseDataFetcher.java",
            "lineNumber": 353,
            "className": "com.introproventures.graphql.jpa.query.schema.impl.QraphQLJpaBaseDataFetcher",
            "nativeMethod": false
          },
          {
            "methodName": "getWherePredicate",
            "fileName": "QraphQLJpaBaseDataFetcher.java",
            "lineNumber": 305,
            "className": "com.introproventures.graphql.jpa.query.schema.impl.QraphQLJpaBaseDataFetcher",
            "nativeMethod": false
          },
          {
            "methodName": "getPredicate",
            "fileName": "GraphQLJpaQueryDataFetcher.java",
            "lineNumber": 135,
            "className": "com.introproventures.graphql.jpa.query.schema.impl.GraphQLJpaQueryDataFetcher",
            "nativeMethod": false
          },
          {
            "methodName": "lambda$getQuery$0",
            "fileName": "QraphQLJpaBaseDataFetcher.java",
            "lineNumber": 122,
            "className": "com.introproventures.graphql.jpa.query.schema.impl.QraphQLJpaBaseDataFetcher",
            "nativeMethod": false
          },
          {
            "methodName": "accept",
            "fileName": "ReferencePipeline.java",
            "lineNumber": 193,
            "className": "java.util.stream.ReferencePipeline$3$1",
            "nativeMethod": false
          },
          {
            "methodName": "forEachRemaining",
            "fileName": "ArrayList.java",
            "lineNumber": 1380,
            "className": "java.util.ArrayList$ArrayListSpliterator",
            "nativeMethod": false
          },
          {
            "methodName": "copyInto",
            "fileName": "AbstractPipeline.java",
            "lineNumber": 481,
            "className": "java.util.stream.AbstractPipeline",
            "nativeMethod": false
          },
          {
            "methodName": "wrapAndCopyInto",
            "fileName": "AbstractPipeline.java",
            "lineNumber": 471,
            "className": "java.util.stream.AbstractPipeline",
            "nativeMethod": false
          },
          {
            "methodName": "evaluateSequential",
            "fileName": "ReduceOps.java",
            "lineNumber": 708,
            "className": "java.util.stream.ReduceOps$ReduceOp",
            "nativeMethod": false
          },
          {
            "methodName": "evaluate",
            "fileName": "AbstractPipeline.java",
            "lineNumber": 234,
            "className": "java.util.stream.AbstractPipeline",
            "nativeMethod": false
          },
          {
            "methodName": "collect",
            "fileName": "ReferencePipeline.java",
            "lineNumber": 499,
            "className": "java.util.stream.ReferencePipeline",
            "nativeMethod": false
          },
          {
            "methodName": "getQuery",
            "fileName": "QraphQLJpaBaseDataFetcher.java",
            "lineNumber": 124,
            "className": "com.introproventures.graphql.jpa.query.schema.impl.QraphQLJpaBaseDataFetcher",
            "nativeMethod": false
          },
          {
            "methodName": "get",
            "fileName": "GraphQLJpaQueryDataFetcher.java",
            "lineNumber": 101,
            "className": "com.introproventures.graphql.jpa.query.schema.impl.GraphQLJpaQueryDataFetcher",
            "nativeMethod": false
          },
          {
            "methodName": "fetchField",
            "fileName": "ExecutionStrategy.java",
            "lineNumber": 219,
            "className": "graphql.execution.ExecutionStrategy",
            "nativeMethod": false
          },
          {
            "methodName": "resolveField",
            "fileName": "ExecutionStrategy.java",
            "lineNumber": 165,
            "className": "graphql.execution.ExecutionStrategy",
            "nativeMethod": false
          },
          {
            "methodName": "execute",
            "fileName": "AsyncExecutionStrategy.java",
            "lineNumber": 55,
            "className": "graphql.execution.AsyncExecutionStrategy",
            "nativeMethod": false
          },
          {
            "methodName": "executeOperation",
            "fileName": "Execution.java",
            "lineNumber": 154,
            "className": "graphql.execution.Execution",
            "nativeMethod": false
          },
          {
            "methodName": "execute",
            "fileName": "Execution.java",
            "lineNumber": 98,
            "className": "graphql.execution.Execution",
            "nativeMethod": false
          },
          {
            "methodName": "execute",
            "fileName": "GraphQL.java",
            "lineNumber": 546,
            "className": "graphql.GraphQL",
            "nativeMethod": false
          },
          {
            "methodName": "parseValidateAndExecute",
            "fileName": "GraphQL.java",
            "lineNumber": 488,
            "className": "graphql.GraphQL",
            "nativeMethod": false
          },
          {
            "methodName": "executeAsync",
            "fileName": "GraphQL.java",
            "lineNumber": 463,
            "className": "graphql.GraphQL",
            "nativeMethod": false
          },
          {
            "methodName": "execute",
            "fileName": "GraphQL.java",
            "lineNumber": 394,
            "className": "graphql.GraphQL",
            "nativeMethod": false
          },
          {
            "methodName": "execute",
            "fileName": "GraphQL.java",
            "lineNumber": 265,
            "className": "graphql.GraphQL",
            "nativeMethod": false
          },
          {
            "methodName": "execute",
            "fileName": "GraphQLJpaExecutor.java",
            "lineNumber": 79,
            "className": "com.introproventures.graphql.jpa.query.schema.impl.GraphQLJpaExecutor",
            "nativeMethod": false
          },
          {
            "methodName": "invoke",
            "fileName": "<generated>",
            "lineNumber": -1,
            "className": "com.introproventures.graphql.jpa.query.schema.impl.GraphQLJpaExecutor$$FastClassBySpringCGLIB$$3c8ebb24",
            "nativeMethod": false
          },
          {
            "methodName": "invoke",
            "fileName": "MethodProxy.java",
            "lineNumber": 204,
            "className": "org.springframework.cglib.proxy.MethodProxy",
            "nativeMethod": false
          },
          {
            "methodName": "invokeJoinpoint",
            "fileName": "CglibAopProxy.java",
            "lineNumber": 746,
            "className": "org.springframework.aop.framework.CglibAopProxy$CglibMethodInvocation",
            "nativeMethod": false
          },
          {
            "methodName": "proceed",
            "fileName": "ReflectiveMethodInvocation.java",
            "lineNumber": 163,
            "className": "org.springframework.aop.framework.ReflectiveMethodInvocation",
            "nativeMethod": false
          },
          {
            "methodName": "invokeWithinTransaction",
            "fileName": "TransactionAspectSupport.java",
            "lineNumber": 294,
            "className": "org.springframework.transaction.interceptor.TransactionAspectSupport",
            "nativeMethod": false
          },
          {
            "methodName": "invoke",
            "fileName": "TransactionInterceptor.java",
            "lineNumber": 98,
            "className": "org.springframework.transaction.interceptor.TransactionInterceptor",
            "nativeMethod": false
          },
          {
            "methodName": "proceed",
            "fileName": "ReflectiveMethodInvocation.java",
            "lineNumber": 185,
            "className": "org.springframework.aop.framework.ReflectiveMethodInvocation",
            "nativeMethod": false
          },
          {
            "methodName": "intercept",
            "fileName": "CglibAopProxy.java",
            "lineNumber": 688,
            "className": "org.springframework.aop.framework.CglibAopProxy$DynamicAdvisedInterceptor",
            "nativeMethod": false
          },
          {
            "methodName": "execute",
            "fileName": "<generated>",
            "lineNumber": -1,
            "className": "com.introproventures.graphql.jpa.query.schema.impl.GraphQLJpaExecutor$$EnhancerBySpringCGLIB$$e3b56126",
            "nativeMethod": false
          },
          {
            "methodName": "postJson",
            "fileName": "GraphQLController.java",
            "lineNumber": 87,
            "className": "com.introproventures.graphql.jpa.query.web.GraphQLController",
            "nativeMethod": false
          },
          {
            "methodName": "invoke0",
            "fileName": "NativeMethodAccessorImpl.java",
            "lineNumber": -2,
            "className": "sun.reflect.NativeMethodAccessorImpl",
            "nativeMethod": true
          },
          {
            "methodName": "invoke",
            "fileName": "NativeMethodAccessorImpl.java",
            "lineNumber": 62,
            "className": "sun.reflect.NativeMethodAccessorImpl",
            "nativeMethod": false
          },
          {
            "methodName": "invoke",
            "fileName": "DelegatingMethodAccessorImpl.java",
            "lineNumber": 43,
            "className": "sun.reflect.DelegatingMethodAccessorImpl",
            "nativeMethod": false
          },
          {
            "methodName": "invoke",
            "fileName": "Method.java",
            "lineNumber": 498,
            "className": "java.lang.reflect.Method",
            "nativeMethod": false
          },
          {
            "methodName": "doInvoke",
            "fileName": "InvocableHandlerMethod.java",
            "lineNumber": 209,
            "className": "org.springframework.web.method.support.InvocableHandlerMethod",
            "nativeMethod": false
          },
          {
            "methodName": "invokeForRequest",
            "fileName": "InvocableHandlerMethod.java",
            "lineNumber": 136,
            "className": "org.springframework.web.method.support.InvocableHandlerMethod",
            "nativeMethod": false
          },
          {
            "methodName": "invokeAndHandle",
            "fileName": "ServletInvocableHandlerMethod.java",
            "lineNumber": 102,
            "className": "org.springframework.web.servlet.mvc.method.annotation.ServletInvocableHandlerMethod",
            "nativeMethod": false
          },
          {
            "methodName": "invokeHandlerMethod",
            "fileName": "RequestMappingHandlerAdapter.java",
            "lineNumber": 877,
            "className": "org.springframework.web.servlet.mvc.method.annotation.RequestMappingHandlerAdapter",
            "nativeMethod": false
          },
          {
            "methodName": "handleInternal",
            "fileName": "RequestMappingHandlerAdapter.java",
            "lineNumber": 783,
            "className": "org.springframework.web.servlet.mvc.method.annotation.RequestMappingHandlerAdapter",
            "nativeMethod": false
          },
          {
            "methodName": "handle",
            "fileName": "AbstractHandlerMethodAdapter.java",
            "lineNumber": 87,
            "className": "org.springframework.web.servlet.mvc.method.AbstractHandlerMethodAdapter",
            "nativeMethod": false
          },
          {
            "methodName": "doDispatch",
            "fileName": "DispatcherServlet.java",
            "lineNumber": 991,
            "className": "org.springframework.web.servlet.DispatcherServlet",
            "nativeMethod": false
          },
          {
            "methodName": "doService",
            "fileName": "DispatcherServlet.java",
            "lineNumber": 925,
            "className": "org.springframework.web.servlet.DispatcherServlet",
            "nativeMethod": false
          },
          {
            "methodName": "processRequest",
            "fileName": "FrameworkServlet.java",
            "lineNumber": 974,
            "className": "org.springframework.web.servlet.FrameworkServlet",
            "nativeMethod": false
          },
          {
            "methodName": "doPost",
            "fileName": "FrameworkServlet.java",
            "lineNumber": 877,
            "className": "org.springframework.web.servlet.FrameworkServlet",
            "nativeMethod": false
          },
          {
            "methodName": "service",
            "fileName": "HttpServlet.java",
            "lineNumber": 661,
            "className": "javax.servlet.http.HttpServlet",
            "nativeMethod": false
          },
          {
            "methodName": "service",
            "fileName": "FrameworkServlet.java",
            "lineNumber": 851,
            "className": "org.springframework.web.servlet.FrameworkServlet",
            "nativeMethod": false
          },
          {
            "methodName": "service",
            "fileName": "HttpServlet.java",
            "lineNumber": 742,
            "className": "javax.servlet.http.HttpServlet",
            "nativeMethod": false
          },
          {
            "methodName": "internalDoFilter",
            "fileName": "ApplicationFilterChain.java",
            "lineNumber": 231,
            "className": "org.apache.catalina.core.ApplicationFilterChain",
            "nativeMethod": false
          },
          {
            "methodName": "doFilter",
            "fileName": "ApplicationFilterChain.java",
            "lineNumber": 166,
            "className": "org.apache.catalina.core.ApplicationFilterChain",
            "nativeMethod": false
          },
          {
            "methodName": "doFilter",
            "fileName": "WsFilter.java",
            "lineNumber": 52,
            "className": "org.apache.tomcat.websocket.server.WsFilter",
            "nativeMethod": false
          },
          {
            "methodName": "internalDoFilter",
            "fileName": "ApplicationFilterChain.java",
            "lineNumber": 193,
            "className": "org.apache.catalina.core.ApplicationFilterChain",
            "nativeMethod": false
          },
          {
            "methodName": "doFilter",
            "fileName": "ApplicationFilterChain.java",
            "lineNumber": 166,
            "className": "org.apache.catalina.core.ApplicationFilterChain",
            "nativeMethod": false
          },
          {
            "methodName": "doFilter",
            "fileName": "FilterChainProxy.java",
            "lineNumber": 320,
            "className": "org.springframework.security.web.FilterChainProxy$VirtualFilterChain",
            "nativeMethod": false
          },
          {
            "methodName": "invoke",
            "fileName": "FilterSecurityInterceptor.java",
            "lineNumber": 127,
            "className": "org.springframework.security.web.access.intercept.FilterSecurityInterceptor",
            "nativeMethod": false
          },
          {
            "methodName": "doFilter",
            "fileName": "FilterSecurityInterceptor.java",
            "lineNumber": 91,
            "className": "org.springframework.security.web.access.intercept.FilterSecurityInterceptor",
            "nativeMethod": false
          },
          {
            "methodName": "doFilter",
            "fileName": "FilterChainProxy.java",
            "lineNumber": 334,
            "className": "org.springframework.security.web.FilterChainProxy$VirtualFilterChain",
            "nativeMethod": false
          },
          {
            "methodName": "doFilter",
            "fileName": "ExceptionTranslationFilter.java",
            "lineNumber": 119,
            "className": "org.springframework.security.web.access.ExceptionTranslationFilter",
            "nativeMethod": false
          },
          {
            "methodName": "doFilter",
            "fileName": "FilterChainProxy.java",
            "lineNumber": 334,
            "className": "org.springframework.security.web.FilterChainProxy$VirtualFilterChain",
            "nativeMethod": false
          },
          {
            "methodName": "doFilter",
            "fileName": "SessionManagementFilter.java",
            "lineNumber": 137,
            "className": "org.springframework.security.web.session.SessionManagementFilter",
            "nativeMethod": false
          },
          {
            "methodName": "doFilter",
            "fileName": "FilterChainProxy.java",
            "lineNumber": 334,
            "className": "org.springframework.security.web.FilterChainProxy$VirtualFilterChain",
            "nativeMethod": false
          },
          {
            "methodName": "doFilter",
            "fileName": "AnonymousAuthenticationFilter.java",
            "lineNumber": 111,
            "className": "org.springframework.security.web.authentication.AnonymousAuthenticationFilter",
            "nativeMethod": false
          },
          {
            "methodName": "doFilter",
            "fileName": "FilterChainProxy.java",
            "lineNumber": 334,
            "className": "org.springframework.security.web.FilterChainProxy$VirtualFilterChain",
            "nativeMethod": false
          },
          {
            "methodName": "doFilter",
            "fileName": "SecurityContextHolderAwareRequestFilter.java",
            "lineNumber": 170,
            "className": "org.springframework.security.web.servletapi.SecurityContextHolderAwareRequestFilter",
            "nativeMethod": false
          },
          {
            "methodName": "doFilter",
            "fileName": "FilterChainProxy.java",
            "lineNumber": 334,
            "className": "org.springframework.security.web.FilterChainProxy$VirtualFilterChain",
            "nativeMethod": false
          },
          {
            "methodName": "doFilter",
            "fileName": "RequestCacheAwareFilter.java",
            "lineNumber": 63,
            "className": "org.springframework.security.web.savedrequest.RequestCacheAwareFilter",
            "nativeMethod": false
          },
          {
            "methodName": "doFilter",
            "fileName": "FilterChainProxy.java",
            "lineNumber": 334,
            "className": "org.springframework.security.web.FilterChainProxy$VirtualFilterChain",
            "nativeMethod": false
          },
          {
            "methodName": "doFilter",
            "fileName": "LogoutFilter.java",
            "lineNumber": 116,
            "className": "org.springframework.security.web.authentication.logout.LogoutFilter",
            "nativeMethod": false
          },
          {
            "methodName": "doFilter",
            "fileName": "FilterChainProxy.java",
            "lineNumber": 334,
            "className": "org.springframework.security.web.FilterChainProxy$VirtualFilterChain",
            "nativeMethod": false
          },
          {
            "methodName": "doFilterInternal",
            "fileName": "HeaderWriterFilter.java",
            "lineNumber": 66,
            "className": "org.springframework.security.web.header.HeaderWriterFilter",
            "nativeMethod": false
          },
          {
            "methodName": "doFilter",
            "fileName": "OncePerRequestFilter.java",
            "lineNumber": 107,
            "className": "org.springframework.web.filter.OncePerRequestFilter",
            "nativeMethod": false
          },
          {
            "methodName": "doFilter",
            "fileName": "FilterChainProxy.java",
            "lineNumber": 334,
            "className": "org.springframework.security.web.FilterChainProxy$VirtualFilterChain",
            "nativeMethod": false
          },
          {
            "methodName": "doFilter",
            "fileName": "SecurityContextPersistenceFilter.java",
            "lineNumber": 105,
            "className": "org.springframework.security.web.context.SecurityContextPersistenceFilter",
            "nativeMethod": false
          },
          {
            "methodName": "doFilter",
            "fileName": "FilterChainProxy.java",
            "lineNumber": 334,
            "className": "org.springframework.security.web.FilterChainProxy$VirtualFilterChain",
            "nativeMethod": false
          },
          {
            "methodName": "doFilterInternal",
            "fileName": "WebAsyncManagerIntegrationFilter.java",
            "lineNumber": 56,
            "className": "org.springframework.security.web.context.request.async.WebAsyncManagerIntegrationFilter",
            "nativeMethod": false
          },
          {
            "methodName": "doFilter",
            "fileName": "OncePerRequestFilter.java",
            "lineNumber": 107,
            "className": "org.springframework.web.filter.OncePerRequestFilter",
            "nativeMethod": false
          },
          {
            "methodName": "doFilter",
            "fileName": "FilterChainProxy.java",
            "lineNumber": 334,
            "className": "org.springframework.security.web.FilterChainProxy$VirtualFilterChain",
            "nativeMethod": false
          },
          {
            "methodName": "doFilterInternal",
            "fileName": "FilterChainProxy.java",
            "lineNumber": 215,
            "className": "org.springframework.security.web.FilterChainProxy",
            "nativeMethod": false
          },
          {
            "methodName": "doFilter",
            "fileName": "FilterChainProxy.java",
            "lineNumber": 178,
            "className": "org.springframework.security.web.FilterChainProxy",
            "nativeMethod": false
          },
          {
            "methodName": "invokeDelegate",
            "fileName": "DelegatingFilterProxy.java",
            "lineNumber": 357,
            "className": "org.springframework.web.filter.DelegatingFilterProxy",
            "nativeMethod": false
          },
          {
            "methodName": "doFilter",
            "fileName": "DelegatingFilterProxy.java",
            "lineNumber": 270,
            "className": "org.springframework.web.filter.DelegatingFilterProxy",
            "nativeMethod": false
          },
          {
            "methodName": "internalDoFilter",
            "fileName": "ApplicationFilterChain.java",
            "lineNumber": 193,
            "className": "org.apache.catalina.core.ApplicationFilterChain",
            "nativeMethod": false
          },
          {
            "methodName": "doFilter",
            "fileName": "ApplicationFilterChain.java",
            "lineNumber": 166,
            "className": "org.apache.catalina.core.ApplicationFilterChain",
            "nativeMethod": false
          },
          {
            "methodName": "doFilterInternal",
            "fileName": "RequestContextFilter.java",
            "lineNumber": 99,
            "className": "org.springframework.web.filter.RequestContextFilter",
            "nativeMethod": false
          },
          {
            "methodName": "doFilter",
            "fileName": "OncePerRequestFilter.java",
            "lineNumber": 107,
            "className": "org.springframework.web.filter.OncePerRequestFilter",
            "nativeMethod": false
          },
          {
            "methodName": "internalDoFilter",
            "fileName": "ApplicationFilterChain.java",
            "lineNumber": 193,
            "className": "org.apache.catalina.core.ApplicationFilterChain",
            "nativeMethod": false
          },
          {
            "methodName": "doFilter",
            "fileName": "ApplicationFilterChain.java",
            "lineNumber": 166,
            "className": "org.apache.catalina.core.ApplicationFilterChain",
            "nativeMethod": false
          },
          {
            "methodName": "doFilterInternal",
            "fileName": "HttpPutFormContentFilter.java",
            "lineNumber": 109,
            "className": "org.springframework.web.filter.HttpPutFormContentFilter",
            "nativeMethod": false
          },
          {
            "methodName": "doFilter",
            "fileName": "OncePerRequestFilter.java",
            "lineNumber": 107,
            "className": "org.springframework.web.filter.OncePerRequestFilter",
            "nativeMethod": false
          },
          {
            "methodName": "internalDoFilter",
            "fileName": "ApplicationFilterChain.java",
            "lineNumber": 193,
            "className": "org.apache.catalina.core.ApplicationFilterChain",
            "nativeMethod": false
          },
          {
            "methodName": "doFilter",
            "fileName": "ApplicationFilterChain.java",
            "lineNumber": 166,
            "className": "org.apache.catalina.core.ApplicationFilterChain",
            "nativeMethod": false
          },
          {
            "methodName": "doFilterInternal",
            "fileName": "HiddenHttpMethodFilter.java",
            "lineNumber": 93,
            "className": "org.springframework.web.filter.HiddenHttpMethodFilter",
            "nativeMethod": false
          },
          {
            "methodName": "doFilter",
            "fileName": "OncePerRequestFilter.java",
            "lineNumber": 107,
            "className": "org.springframework.web.filter.OncePerRequestFilter",
            "nativeMethod": false
          },
          {
            "methodName": "internalDoFilter",
            "fileName": "ApplicationFilterChain.java",
            "lineNumber": 193,
            "className": "org.apache.catalina.core.ApplicationFilterChain",
            "nativeMethod": false
          },
          {
            "methodName": "doFilter",
            "fileName": "ApplicationFilterChain.java",
            "lineNumber": 166,
            "className": "org.apache.catalina.core.ApplicationFilterChain",
            "nativeMethod": false
          },
          {
            "methodName": "doFilterInternal",
            "fileName": "CharacterEncodingFilter.java",
            "lineNumber": 200,
            "className": "org.springframework.web.filter.CharacterEncodingFilter",
            "nativeMethod": false
          },
          {
            "methodName": "doFilter",
            "fileName": "OncePerRequestFilter.java",
            "lineNumber": 107,
            "className": "org.springframework.web.filter.OncePerRequestFilter",
            "nativeMethod": false
          },
          {
            "methodName": "internalDoFilter",
            "fileName": "ApplicationFilterChain.java",
            "lineNumber": 193,
            "className": "org.apache.catalina.core.ApplicationFilterChain",
            "nativeMethod": false
          },
          {
            "methodName": "doFilter",
            "fileName": "ApplicationFilterChain.java",
            "lineNumber": 166,
            "className": "org.apache.catalina.core.ApplicationFilterChain",
            "nativeMethod": false
          },
          {
            "methodName": "invoke",
            "fileName": "StandardWrapperValve.java",
            "lineNumber": 198,
            "className": "org.apache.catalina.core.StandardWrapperValve",
            "nativeMethod": false
          },
          {
            "methodName": "invoke",
            "fileName": "StandardContextValve.java",
            "lineNumber": 96,
            "className": "org.apache.catalina.core.StandardContextValve",
            "nativeMethod": false
          },
          {
            "methodName": "invoke",
            "fileName": "AuthenticatorBase.java",
            "lineNumber": 496,
            "className": "org.apache.catalina.authenticator.AuthenticatorBase",
            "nativeMethod": false
          },
          {
            "methodName": "invoke",
            "fileName": "StandardHostValve.java",
            "lineNumber": 140,
            "className": "org.apache.catalina.core.StandardHostValve",
            "nativeMethod": false
          },
          {
            "methodName": "invoke",
            "fileName": "ErrorReportValve.java",
            "lineNumber": 81,
            "className": "org.apache.catalina.valves.ErrorReportValve",
            "nativeMethod": false
          },
          {
            "methodName": "invoke",
            "fileName": "StandardEngineValve.java",
            "lineNumber": 87,
            "className": "org.apache.catalina.core.StandardEngineValve",
            "nativeMethod": false
          },
          {
            "methodName": "service",
            "fileName": "CoyoteAdapter.java",
            "lineNumber": 342,
            "className": "org.apache.catalina.connector.CoyoteAdapter",
            "nativeMethod": false
          },
          {
            "methodName": "service",
            "fileName": "Http11Processor.java",
            "lineNumber": 803,
            "className": "org.apache.coyote.http11.Http11Processor",
            "nativeMethod": false
          },
          {
            "methodName": "process",
            "fileName": "AbstractProcessorLight.java",
            "lineNumber": 66,
            "className": "org.apache.coyote.AbstractProcessorLight",
            "nativeMethod": false
          },
          {
            "methodName": "process",
            "fileName": "AbstractProtocol.java",
            "lineNumber": 790,
            "className": "org.apache.coyote.AbstractProtocol$ConnectionHandler",
            "nativeMethod": false
          },
          {
            "methodName": "doRun",
            "fileName": "NioEndpoint.java",
            "lineNumber": 1468,
            "className": "org.apache.tomcat.util.net.NioEndpoint$SocketProcessor",
            "nativeMethod": false
          },
          {
            "methodName": "run",
            "fileName": "SocketProcessorBase.java",
            "lineNumber": 49,
            "className": "org.apache.tomcat.util.net.SocketProcessorBase",
            "nativeMethod": false
          },
          {
            "methodName": "runWorker",
            "fileName": "ThreadPoolExecutor.java",
            "lineNumber": 1149,
            "className": "java.util.concurrent.ThreadPoolExecutor",
            "nativeMethod": false
          },
          {
            "methodName": "run",
            "fileName": "ThreadPoolExecutor.java",
            "lineNumber": 624,
            "className": "java.util.concurrent.ThreadPoolExecutor$Worker",
            "nativeMethod": false
          },
          {
            "methodName": "run",
            "fileName": "TaskThread.java",
            "lineNumber": 61,
            "className": "org.apache.tomcat.util.threads.TaskThread$WrappingRunnable",
            "nativeMethod": false
          },
          {
            "methodName": "run",
            "fileName": "Thread.java",
            "lineNumber": 748,
            "className": "java.lang.Thread",
            "nativeMethod": false
          }
        ],
        "localizedMessage": "Unsupported field type class java.util.UUID for field id",
        "message": "Unsupported field type class java.util.UUID for field id",
        "suppressed": []
      },
      "locations": [
        {
          "line": 2,
          "column": 3
        }
      ],
      "errorType": "DataFetchingException"
    }
  ]
}
```
</p>
</details>