### PR TITLE
fix: add missing equal criteria expression for string arguments

### DIFF
--- a/graphql-jpa-query-schema/src/main/java/com/introproventures/graphql/jpa/query/schema/impl/JpaPredicateBuilder.java
+++ b/graphql-jpa-query-schema/src/main/java/com/introproventures/graphql/jpa/query/schema/impl/JpaPredicateBuilder.java
@@ -112,11 +112,13 @@ class JpaPredicateBuilder {
                 compareValue = compareValue.toLowerCase();
             }
 
-            if (filter.getCriterias().contains(PredicateFilter.Criteria.NE)) {
+            if (filter.getCriterias().contains(PredicateFilter.Criteria.EQ)) {
+                return cb.equal(fieldValue, compareValue);
+            } 
+            else if (filter.getCriterias().contains(PredicateFilter.Criteria.NE)) {
                 return cb.notEqual(fieldValue, compareValue);
             }
-
-            if (filter.getCriterias().contains(PredicateFilter.Criteria.LIKE)) {
+            else if (filter.getCriterias().contains(PredicateFilter.Criteria.LIKE)) {
                 compareValue = "%" + compareValue + "%";
             }
             else if (filter.getCriterias().contains(PredicateFilter.Criteria.ENDS)) {


### PR DESCRIPTION
This PR adds missing equal SQL predicate for string arguments in where criteria expressions