### PR TITLE
feat: add JPA @EmbeddedId support

### DIFF
--- a/graphql-jpa-query-schema/src/main/java/com/introproventures/graphql/jpa/query/schema/impl/GraphQLJpaSchemaBuilder.java
+++ b/graphql-jpa-query-schema/src/main/java/com/introproventures/graphql/jpa/query/schema/impl/GraphQLJpaSchemaBuilder.java
@@ -42,12 +42,16 @@ import javax.persistence.metamodel.PluralAttribute;
 import javax.persistence.metamodel.SingularAttribute;
 import javax.persistence.metamodel.Type;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 import com.introproventures.graphql.jpa.query.annotation.GraphQLDescription;
 import com.introproventures.graphql.jpa.query.annotation.GraphQLIgnore;
 import com.introproventures.graphql.jpa.query.schema.GraphQLSchemaBuilder;
 import com.introproventures.graphql.jpa.query.schema.JavaScalars;
 import com.introproventures.graphql.jpa.query.schema.NamingStrategy;
 import com.introproventures.graphql.jpa.query.schema.impl.PredicateFilter.Criteria;
+
 import graphql.Assert;
 import graphql.Scalars;
 import graphql.schema.Coercing;
@@ -65,8 +69,6 @@ import graphql.schema.GraphQLSchema;
 import graphql.schema.GraphQLType;
 import graphql.schema.GraphQLTypeReference;
 import graphql.schema.PropertyDataFetcher;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 /**
  * JPA specific schema builder implementation of {code #GraphQLSchemaBuilder} interface
@@ -386,13 +388,13 @@ public class GraphQLJpaSchemaBuilder implements GraphQLSchemaBuilder {
            .field(GraphQLInputObjectField.newInputObjectField()
                 .name(Criteria.BETWEEN.name())
                 .description("Between criteria")
-                .type(new GraphQLList(getAttributeType(attribute)))
+                .type(new GraphQLList(getAttributeInputType(attribute)))
                 .build()
            )
            .field(GraphQLInputObjectField.newInputObjectField()
                 .name(Criteria.NOT_BETWEEN.name())
                 .description("Not Between criteria")
-                .type(new GraphQLList(getAttributeType(attribute)))
+                .type(new GraphQLList(getAttributeInputType(attribute)))
                 .build()
            );
 

--- a/graphql-jpa-query-schema/src/main/java/com/introproventures/graphql/jpa/query/schema/impl/GraphQLJpaSchemaBuilder.java
+++ b/graphql-jpa-query-schema/src/main/java/com/introproventures/graphql/jpa/query/schema/impl/GraphQLJpaSchemaBuilder.java
@@ -95,7 +95,8 @@ public class GraphQLJpaSchemaBuilder implements GraphQLSchemaBuilder {
     
     private Map<Class<?>, GraphQLType> classCache = new HashMap<>();
     private Map<EntityType<?>, GraphQLObjectType> entityCache = new HashMap<>();
-    private Map<EmbeddableType<?>, GraphQLObjectType> embeddableCache = new HashMap<>();
+    private Map<EmbeddableType<?>, GraphQLObjectType> embeddableOutputCache = new HashMap<>();
+    private Map<EmbeddableType<?>, GraphQLInputObjectType> embeddableInputCache = new HashMap<>();
     
     private static final Logger log = LoggerFactory.getLogger(GraphQLJpaSchemaBuilder.class);
 
@@ -292,13 +293,13 @@ public class GraphQLJpaSchemaBuilder implements GraphQLSchemaBuilder {
             .field(GraphQLInputObjectField.newInputObjectField()
                 .name(Criteria.EQ.name())
                 .description("Equals criteria")
-                .type((GraphQLInputType) getAttributeType(attribute))
+                .type(getAttributeInputType(attribute))
                 .build()
             )
             .field(GraphQLInputObjectField.newInputObjectField()
                 .name(Criteria.NE.name())
                 .description("Not Equals criteria")
-                .type((GraphQLInputType) getAttributeType(attribute))
+                .type(getAttributeInputType(attribute))
                 .build()
             );
        
@@ -307,25 +308,25 @@ public class GraphQLJpaSchemaBuilder implements GraphQLSchemaBuilder {
                     builder.field(GraphQLInputObjectField.newInputObjectField()
                         .name(Criteria.LE.name())
                         .description("Less then or Equals criteria")
-                        .type((GraphQLInputType) getAttributeType(attribute))
+                        .type(getAttributeInputType(attribute))
                         .build()
                     )
                     .field(GraphQLInputObjectField.newInputObjectField()
                         .name(Criteria.GE.name())
                         .description("Greater or Equals criteria")
-                        .type((GraphQLInputType) getAttributeType(attribute))
+                        .type(getAttributeInputType(attribute))
                         .build()
                     )
                     .field(GraphQLInputObjectField.newInputObjectField()
                         .name(Criteria.GT.name())
                         .description("Greater Then criteria")
-                        .type((GraphQLInputType) getAttributeType(attribute))
+                        .type(getAttributeInputType(attribute))
                         .build()
                     )
                     .field(GraphQLInputObjectField.newInputObjectField()
                         .name(Criteria.LT.name())
                         .description("Less Then criteria")
-                        .type((GraphQLInputType) getAttributeType(attribute))
+                        .type(getAttributeInputType(attribute))
                         .build()
                     );
                 }
@@ -334,25 +335,25 @@ public class GraphQLJpaSchemaBuilder implements GraphQLSchemaBuilder {
                     builder.field(GraphQLInputObjectField.newInputObjectField()
                         .name(Criteria.LIKE.name())
                         .description("Like criteria")
-                        .type((GraphQLInputType) getAttributeType(attribute))
+                        .type(getAttributeInputType(attribute))
                         .build()
                     )
                     .field(GraphQLInputObjectField.newInputObjectField()
                         .name(Criteria.CASE.name())
                         .description("Case sensitive match criteria")
-                        .type((GraphQLInputType) getAttributeType(attribute))
+                        .type(getAttributeInputType(attribute))
                         .build()
                     )
                     .field(GraphQLInputObjectField.newInputObjectField()
                         .name(Criteria.STARTS.name())
                         .description("Starts with criteria")
-                        .type((GraphQLInputType) getAttributeType(attribute))
+                        .type(getAttributeInputType(attribute))
                         .build()
                     )
                     .field(GraphQLInputObjectField.newInputObjectField()
                         .name(Criteria.ENDS.name())
                         .description("Ends with criteria")
-                        .type((GraphQLInputType) getAttributeType(attribute))
+                        .type(getAttributeInputType(attribute))
                         .build()
                     );
                 }
@@ -373,13 +374,13 @@ public class GraphQLJpaSchemaBuilder implements GraphQLSchemaBuilder {
             .field(GraphQLInputObjectField.newInputObjectField()
                 .name(Criteria.IN.name())
                 .description("In criteria")
-                .type(new GraphQLList(getAttributeType(attribute)))
+                .type(new GraphQLList(getAttributeInputType(attribute)))
                 .build()
             )
             .field(GraphQLInputObjectField.newInputObjectField()
                 .name(Criteria.NIN.name())
                 .description("Not In criteria")
-                .type(new GraphQLList(getAttributeType(attribute)))
+                .type(new GraphQLList(getAttributeInputType(attribute)))
                 .build()
             )
            .field(GraphQLInputObjectField.newInputObjectField()
@@ -404,39 +405,52 @@ public class GraphQLJpaSchemaBuilder implements GraphQLSchemaBuilder {
     }
     
     private GraphQLArgument getArgument(Attribute<?,?> attribute) {
-        GraphQLType type = getAttributeType(attribute);
+        GraphQLInputType type = getAttributeInputType(attribute);
         String description = getSchemaDescription(attribute.getJavaMember());
 
-        if (type instanceof GraphQLInputType) {
-            return GraphQLArgument.newArgument()
-                    .name(attribute.getName())
-                    .type((GraphQLInputType) type)
-                    .description(description)
-                    .build();
-        }
-
-        throw new IllegalArgumentException("Attribute " + attribute + " cannot be mapped as an Input Argument");
+        return GraphQLArgument.newArgument()
+                .name(attribute.getName())
+                .type((GraphQLInputType) type)
+                .description(description)
+                .build();
     }
     
-    private GraphQLObjectType getEmbeddableType(EmbeddableType<?> embeddableType) {
-        if (embeddableCache.containsKey(embeddableType))
-            return embeddableCache.get(embeddableType);        
+    private GraphQLType getEmbeddableType(EmbeddableType<?> embeddableType, boolean input) {
+        if (input && embeddableInputCache.containsKey(embeddableType))
+            return embeddableInputCache.get(embeddableType);
 
-        String embeddableTypeName = namingStrategy.singularize(embeddableType.getJavaType().getSimpleName())+"EmbeddableType";
+        if (!input && embeddableOutputCache.containsKey(embeddableType))
+            return embeddableOutputCache.get(embeddableType);
+        String embeddableTypeName = namingStrategy.singularize(embeddableType.getJavaType().getSimpleName())+ (input ? "Input" : "") +"EmbeddableType";
+        GraphQLType graphQLType=null;
+        if (input) {
+            graphQLType = GraphQLInputObjectType.newInputObject()
+                    .name(embeddableTypeName)
+                    .description(getSchemaDescription(embeddableType.getJavaType()))
+                    .fields(embeddableType.getAttributes().stream()
+                            .filter(this::isNotIgnored)
+                            .map(this::getInputObjectField)
+                            .collect(Collectors.toList())
+                    )
+                    .build();
+        } else {
+            graphQLType = GraphQLObjectType.newObject()
+                    .name(embeddableTypeName)
+                    .description(getSchemaDescription(embeddableType.getJavaType()))
+                    .fields(embeddableType.getAttributes().stream()
+                            .filter(this::isNotIgnored)
+                            .map(this::getObjectField)
+                            .collect(Collectors.toList())
+                    )
+                    .build();
+        }
+        if (input) {
+            embeddableInputCache.putIfAbsent(embeddableType, (GraphQLInputObjectType) graphQLType);
+        } else{
+            embeddableOutputCache.putIfAbsent(embeddableType, (GraphQLObjectType) graphQLType);
+        }
         
-        GraphQLObjectType objectType = GraphQLObjectType.newObject()
-                .name(embeddableTypeName)
-                .description(getSchemaDescription( embeddableType.getJavaType()))
-                .fields(embeddableType.getAttributes().stream()
-                    .filter(this::isNotIgnored)
-                    .map(this::getObjectField)
-                    .collect(Collectors.toList())
-                )
-                .build();
-        
-        embeddableCache.putIfAbsent(embeddableType, objectType);
-        
-        return objectType;
+        return graphQLType;
     }
     
 
@@ -462,52 +476,59 @@ public class GraphQLJpaSchemaBuilder implements GraphQLSchemaBuilder {
 
     @SuppressWarnings( { "rawtypes", "unchecked" } )
     private GraphQLFieldDefinition getObjectField(Attribute attribute) {
-        GraphQLType type = getAttributeType(attribute);
+        GraphQLOutputType type = getAttributeOutputType(attribute);
 
-        if (type instanceof GraphQLOutputType) {
-            List<GraphQLArgument> arguments = new ArrayList<>();
-            DataFetcher dataFetcher = PropertyDataFetcher.fetching(attribute.getName());
+        List<GraphQLArgument> arguments = new ArrayList<>();
+        DataFetcher dataFetcher = PropertyDataFetcher.fetching(attribute.getName());
 
-            // Only add the orderBy argument for basic attribute types
-            if (attribute instanceof SingularAttribute 
-                && attribute.getPersistentAttributeType() == Attribute.PersistentAttributeType.BASIC) {
-                arguments.add(GraphQLArgument.newArgument()
-                    .name(ORDER_BY_PARAM_NAME)
-                    .description("Specifies field sort direction in the query results.")
-                    .type(orderByDirectionEnum)
-                    .build()
-                );            
-            }
-            
-            // Get the fields that can be queried on (i.e. Simple Types, no Sub-Objects)
-            if (attribute instanceof SingularAttribute
-                && attribute.getPersistentAttributeType() != Attribute.PersistentAttributeType.BASIC) {
-                ManagedType foreignType = (ManagedType) ((SingularAttribute) attribute).getType();
-
-                // TODO fix page count query
-                arguments.add(getWhereArgument(foreignType));
-
-            } //  Get Sub-Objects fields queries via DataFetcher
-            else if (attribute instanceof PluralAttribute
-                && (attribute.getPersistentAttributeType() == Attribute.PersistentAttributeType.ONE_TO_MANY
-                    || attribute.getPersistentAttributeType() == Attribute.PersistentAttributeType.MANY_TO_MANY)) {
-                EntityType declaringType = (EntityType) ((PluralAttribute) attribute).getDeclaringType();
-                EntityType elementType =  (EntityType) ((PluralAttribute) attribute).getElementType();
-
-                arguments.add(getWhereArgument(elementType));
-                dataFetcher = new GraphQLJpaOneToManyDataFetcher(entityManager, declaringType, (PluralAttribute) attribute);
-            }
-
-            return GraphQLFieldDefinition.newFieldDefinition()
-                    .name(attribute.getName())
-                    .description(getSchemaDescription(attribute.getJavaMember()))
-                    .type((GraphQLOutputType) type)
-                    .dataFetcher(dataFetcher)
-                    .argument(arguments)
-                    .build();
+        // Only add the orderBy argument for basic attribute types
+        if (attribute instanceof SingularAttribute
+            && attribute.getPersistentAttributeType() == Attribute.PersistentAttributeType.BASIC) {
+            arguments.add(GraphQLArgument.newArgument()
+                .name(ORDER_BY_PARAM_NAME)
+                .description("Specifies field sort direction in the query results.")
+                .type(orderByDirectionEnum)
+                .build()
+            );
         }
 
-        throw new IllegalArgumentException("Attribute " + attribute + " cannot be mapped as an Output Argument");
+        // Get the fields that can be queried on (i.e. Simple Types, no Sub-Objects)
+        if (attribute instanceof SingularAttribute
+            && attribute.getPersistentAttributeType() != Attribute.PersistentAttributeType.BASIC) {
+            ManagedType foreignType = (ManagedType) ((SingularAttribute) attribute).getType();
+
+            // TODO fix page count query
+            arguments.add(getWhereArgument(foreignType));
+
+        } //  Get Sub-Objects fields queries via DataFetcher
+        else if (attribute instanceof PluralAttribute
+            && (attribute.getPersistentAttributeType() == Attribute.PersistentAttributeType.ONE_TO_MANY
+                || attribute.getPersistentAttributeType() == Attribute.PersistentAttributeType.MANY_TO_MANY)) {
+            EntityType declaringType = (EntityType) ((PluralAttribute) attribute).getDeclaringType();
+            EntityType elementType =  (EntityType) ((PluralAttribute) attribute).getElementType();
+
+            arguments.add(getWhereArgument(elementType));
+            dataFetcher = new GraphQLJpaOneToManyDataFetcher(entityManager, declaringType, (PluralAttribute) attribute);
+        }
+
+        return GraphQLFieldDefinition.newFieldDefinition()
+                .name(attribute.getName())
+                .description(getSchemaDescription(attribute.getJavaMember()))
+                .type(type)
+                .dataFetcher(dataFetcher)
+                .argument(arguments)
+                .build();
+    }
+
+    @SuppressWarnings( { "rawtypes", "unchecked" } )
+    private GraphQLInputObjectField getInputObjectField(Attribute attribute) {
+        GraphQLInputType type = getAttributeInputType(attribute);
+
+        return GraphQLInputObjectField.newInputObjectField()
+                .name(attribute.getName())
+                .description(getSchemaDescription(attribute.getJavaMember()))
+                .type(type)
+                .build();
     }
 
     private Stream<Attribute<?,?>> findBasicAttributes(Collection<Attribute<?,?>> attributes) {
@@ -515,14 +536,32 @@ public class GraphQLJpaSchemaBuilder implements GraphQLSchemaBuilder {
     }
 
     @SuppressWarnings( "rawtypes" )
-    private GraphQLType getAttributeType(Attribute<?,?> attribute) {
+    private GraphQLInputType getAttributeInputType(Attribute<?,?> attribute) {
+        try{
+            return (GraphQLInputType) getAttributeType(attribute, true);
+        } catch (ClassCastException e){
+            throw new IllegalArgumentException("Attribute " + attribute + " cannot be mapped as an Input Argument");
+        }
+    }
+
+    @SuppressWarnings( "rawtypes" )
+    private GraphQLOutputType getAttributeOutputType(Attribute<?,?> attribute) {
+        try {
+            return (GraphQLOutputType) getAttributeType(attribute, false);
+        } catch (ClassCastException e){
+            throw new IllegalArgumentException("Attribute " + attribute + " cannot be mapped as an Output Argument");
+        }
+    }
+
+    @SuppressWarnings( "rawtypes" )
+    private GraphQLType getAttributeType(Attribute<?,?> attribute, boolean input) {
 
         if (isBasic(attribute)) {
         	return getGraphQLTypeFromJavaType(attribute.getJavaType());
         } 
         else if (isEmbeddable(attribute)) {
         	EmbeddableType embeddableType = (EmbeddableType) ((SingularAttribute) attribute).getType();
-        	return getEmbeddableType(embeddableType);
+        	return getEmbeddableType(embeddableType, input);
         } 
         else if (isToMany(attribute)) {
             EntityType foreignType = (EntityType) ((PluralAttribute) attribute).getElementType();
@@ -572,7 +611,8 @@ public class GraphQLJpaSchemaBuilder implements GraphQLSchemaBuilder {
 
     protected final boolean isValidInput(Attribute<?,?> attribute) {
         return attribute.getPersistentAttributeType() == Attribute.PersistentAttributeType.BASIC ||
-                attribute.getPersistentAttributeType() == Attribute.PersistentAttributeType.ELEMENT_COLLECTION;
+                attribute.getPersistentAttributeType() == Attribute.PersistentAttributeType.ELEMENT_COLLECTION ||
+                attribute.getPersistentAttributeType() == Attribute.PersistentAttributeType.EMBEDDED;
     }
 
     private String getSchemaDescription(Member member) {

--- a/graphql-jpa-query-schema/src/test/java/com/introproventures/graphql/jpa/query/schema/GraphQLExecutorTests.java
+++ b/graphql-jpa-query-schema/src/test/java/com/introproventures/graphql/jpa/query/schema/GraphQLExecutorTests.java
@@ -362,7 +362,7 @@ public class GraphQLExecutorTests {
 
     // https://github.com/introproventures/graphql-jpa-query/issues/30
     @Test
-    public void queryForEntityWithEmeddableType() {
+    public void queryForEntityWithEmbeddedIdAndEmbeddedField() {
         //given
         String query = "{ Boat(boatId: {id: \"1\" country: \"EN\"}) { boatId {id country} engine { identification } } }";
         
@@ -376,7 +376,7 @@ public class GraphQLExecutorTests {
     }
 
     @Test
-    public void queryForEntityWithEmeddableTypeAndWhere() {
+    public void queryForEntityWithEmbeddedFieldWithWhere() {
         //given
         String query = "{ Boats { select { boatId {id country} engine(where: { identification: { EQ: \"12345\"}}) { identification } } } }";
 
@@ -461,9 +461,9 @@ public class GraphQLExecutorTests {
     
 
     @Test
-    public void queryForEntitiesWithEmeddableTypeAndWhereEmbeddableId() {
+    public void queryForEntitiesWithWithEmbeddedIdWithWhere() {
         //given
-        String query = "{ Boats(where: {boatId: {EQ: {id: \"1\" country: \"EN\"}}}) { select { boatId {id country} engine { identification } } } }";
+        String query = "{ Boats { select { boatId(where: { AND: {id: { LIKE: \"1\"} country: { EQ: \"EN\"}}}) {id country} engine { identification } } } }";
 
         String expected = "{Boats={select=[{boatId={id=1, country=EN}, engine={identification=12345}}]}}";
 
@@ -473,5 +473,5 @@ public class GraphQLExecutorTests {
         // then
         assertThat(result.toString()).isEqualTo(expected);
     }
-    
+
 }

--- a/graphql-jpa-query-schema/src/test/java/com/introproventures/graphql/jpa/query/schema/GraphQLExecutorTests.java
+++ b/graphql-jpa-query-schema/src/test/java/com/introproventures/graphql/jpa/query/schema/GraphQLExecutorTests.java
@@ -364,9 +364,9 @@ public class GraphQLExecutorTests {
     @Test
     public void queryForEntityWithEmeddableType() {
         //given
-        String query = "{ Boat(id: \"1\") { id engine { identification } } }";
+        String query = "{ Boat(boatId: {id: \"1\" country: \"EN\"}) { boatId {id country} engine { identification } } }";
         
-        String expected = "{Boat={id=1, engine={identification=12345}}}";
+        String expected = "{Boat={boatId={id=1, country=EN}, engine={identification=12345}}}";
 
         //when
         Object result = executor.execute(query).getData();
@@ -378,9 +378,9 @@ public class GraphQLExecutorTests {
     @Test
     public void queryForEntityWithEmeddableTypeAndWhere() {
         //given
-        String query = "{ Boats { select { id engine(where: { identification: { EQ: \"12345\"}}) { identification } } } }";
+        String query = "{ Boats { select { boatId {id country} engine(where: { identification: { EQ: \"12345\"}}) { identification } } } }";
 
-        String expected = "{Boats={select=[{id=1, engine={identification=12345}}]}}";
+        String expected = "{Boats={select=[{boatId={id=1, country=EN}, engine={identification=12345}}]}}";
 
         //when
         Object result = executor.execute(query).getData();
@@ -459,5 +459,7 @@ public class GraphQLExecutorTests {
         assertThat(result.toString()).isEqualTo(expected);
     }    
     
+
+
 
 }

--- a/graphql-jpa-query-schema/src/test/java/com/introproventures/graphql/jpa/query/schema/GraphQLExecutorTests.java
+++ b/graphql-jpa-query-schema/src/test/java/com/introproventures/graphql/jpa/query/schema/GraphQLExecutorTests.java
@@ -463,7 +463,7 @@ public class GraphQLExecutorTests {
     @Test
     public void queryForEntitiesWithWithEmbeddedIdWithWhere() {
         //given
-        String query = "{ Boats { select { boatId(where: { AND: {id: { LIKE: \"1\"} country: { EQ: \"EN\"}}}) {id country} engine { identification } } } }";
+        String query = "{ Boats { select { boatId(where: { id: { LIKE: \"1\"} country: { EQ: \"EN\"}}) {id country} engine { identification } } } }";
 
         String expected = "{Boats={select=[{boatId={id=1, country=EN}, engine={identification=12345}}]}}";
 

--- a/graphql-jpa-query-schema/src/test/java/com/introproventures/graphql/jpa/query/schema/GraphQLExecutorTests.java
+++ b/graphql-jpa-query-schema/src/test/java/com/introproventures/graphql/jpa/query/schema/GraphQLExecutorTests.java
@@ -460,6 +460,18 @@ public class GraphQLExecutorTests {
     }    
     
 
+    @Test
+    public void queryForEntitiesWithEmeddableTypeAndWhereEmbeddableId() {
+        //given
+        String query = "{ Boats(where: {boatId: {EQ: {id: \"1\" country: \"EN\"}}}) { select { boatId {id country} engine { identification } } } }";
 
+        String expected = "{Boats={select=[{boatId={id=1, country=EN}, engine={identification=12345}}]}}";
 
+        //when
+        Object result = executor.execute(query).getData();
+
+        // then
+        assertThat(result.toString()).isEqualTo(expected);
+    }
+    
 }

--- a/graphql-jpa-query-schema/src/test/java/com/introproventures/graphql/jpa/query/schema/model/embedded/Boat.java
+++ b/graphql-jpa-query-schema/src/test/java/com/introproventures/graphql/jpa/query/schema/model/embedded/Boat.java
@@ -1,19 +1,33 @@
 
 package com.introproventures.graphql.jpa.query.schema.model.embedded;
 
-import javax.persistence.Embedded;
-import javax.persistence.Entity;
-import javax.persistence.Id;
-
+import com.introproventures.graphql.jpa.query.annotation.GraphQLDescription;
 import lombok.Data;
+
+import javax.persistence.Embeddable;
+import javax.persistence.Embedded;
+import javax.persistence.EmbeddedId;
+import javax.persistence.Entity;
+import java.io.Serializable;
 
 @Entity(name = "Boat")
 @Data
 public class Boat  {
 
-    @Id
-    String id;
+	@Embeddable
+	@Data
+	public static class BoatId implements Serializable {
+		private static final long serialVersionUID = 1L;
+
+		String id;
+		String country;
+	}
+
+    @EmbeddedId
+	@GraphQLDescription("Primary Key for the Boat Class")
+    BoatId boatId;
 
     @Embedded
     Engine engine;
+
 }

--- a/graphql-jpa-query-schema/src/test/resources/data.sql
+++ b/graphql-jpa-query-schema/src/test/resources/data.sql
@@ -129,8 +129,8 @@ insert into Car (id, brand) values
 
 	
 -- Boat
-insert into Boat (id, identification) values
-	(1, '12345'),
-	(2, '23456'),
-	(3, '34567');
+insert into Boat (id, country, identification) values
+	(1, 'EN', '12345'),
+	(2, 'EN', '23456'),
+	(1, 'FR', '34567');
 	


### PR DESCRIPTION
This is a new feature PR to support JPA @EmbeddedId attribute mappings submitted by @ludovicmotte,

Given, the following entity class definition with `@EmbeddableId` :

```java
@Entity(name = "Boat")
@Data
public class Boat  {

    @Embeddable
    @Data
    public static class BoatId implements Serializable {
        private static final long serialVersionUID = 1L;

        String id;
        String country;
     }

    @EmbeddedId
    @GraphQLDescription("Primary Key for the Boat Class")
    BoatId boatId;

    @Embedded
    Engine engine;
}
```

Will generate schema to query entities using embedded id attributes:

Singular Query Field: 

```
query { 
   Boat( boatId: { id: "1" country: "EN" } ) { 
       boatId { 
         id country 
       } 
       engine { 
         identification 
      } 
   } 
}
```

Plural Query Field: 

```
query { 
  Boats { 
     select { 
        boatId( where: { id: { EQ: "1"} country: { EQ: "EN"}}) {
           id country
        } 
        engine { 
           identification 
        }
    } 
  } 
}
```






