### PR TITLE
#102 fix NullPointerException when searching for Transient annotation

### DIFF
--- a/graphql-jpa-query-schema/src/main/java/com/introproventures/graphql/jpa/query/schema/impl/IntrospectionUtils.java
+++ b/graphql-jpa-query-schema/src/main/java/com/introproventures/graphql/jpa/query/schema/impl/IntrospectionUtils.java
@@ -84,6 +84,7 @@ public class IntrospectionUtils {
     	            					  .isAnnotationPresent(annotation);
 
     	        } catch (NoSuchFieldException e) {
+    	        	if(delegate.getReadMethod() == null) return false;
     				answer = delegate.getReadMethod()
     								  .isAnnotationPresent(annotation);
     	        }

--- a/graphql-jpa-query-schema/src/test/java/com/introproventures/graphql/jpa/query/schema/StarwarsSchemaBuildTest.java
+++ b/graphql-jpa-query-schema/src/test/java/com/introproventures/graphql/jpa/query/schema/StarwarsSchemaBuildTest.java
@@ -182,5 +182,14 @@ public class StarwarsSchemaBuildTest {
                 .describedAs( "Ensure that CodeList.parent has the expected description")
                 .isEqualTo("The CodeList's parent CodeList");
     }
+
+    @Test
+    public void testBuildSchema(){
+        //given
+        GraphQLSchema schema = builder.build();
+
+        //then
+        assertThat(schema).isNotNull();
+    }
     
 }

--- a/graphql-jpa-query-schema/src/test/java/com/introproventures/graphql/jpa/query/schema/impl/IntrospectionUtilsTest.java
+++ b/graphql-jpa-query-schema/src/test/java/com/introproventures/graphql/jpa/query/schema/impl/IntrospectionUtilsTest.java
@@ -50,6 +50,13 @@ public class IntrospectionUtilsTest {
         assertThat(IntrospectionUtils.isTransient(entity, "info")).isFalse();
         assertThat(IntrospectionUtils.isTransient(entity, "title")).isFalse();
     }
-    
-    
+
+    @Test
+    public void testByPassSetMethod() throws Exception {
+        // given
+        Class<CalculatedEntity> entity = CalculatedEntity.class;
+
+        // then
+        assertThat(IntrospectionUtils.isTransient(entity,"something")).isFalse();
+    }
 }

--- a/graphql-jpa-query-schema/src/test/java/com/introproventures/graphql/jpa/query/schema/model/book/Book.java
+++ b/graphql-jpa-query-schema/src/test/java/com/introproventures/graphql/jpa/query/schema/model/book/Book.java
@@ -47,5 +47,9 @@ public class Book {
 	@Enumerated(EnumType.STRING)
 	Genre genre;
 	
-    Date publicationDate;	
+    Date publicationDate;
+
+    public void setSth(int i){
+    	return;
+	}
 }

--- a/graphql-jpa-query-schema/src/test/java/com/introproventures/graphql/jpa/query/schema/model/book/Book.java
+++ b/graphql-jpa-query-schema/src/test/java/com/introproventures/graphql/jpa/query/schema/model/book/Book.java
@@ -47,9 +47,5 @@ public class Book {
 	@Enumerated(EnumType.STRING)
 	Genre genre;
 	
-    Date publicationDate;
-
-    public void setSth(int i){
-    	return;
-	}
+    Date publicationDate;	
 }

--- a/graphql-jpa-query-schema/src/test/java/com/introproventures/graphql/jpa/query/schema/model/calculated/CalculatedEntity.java
+++ b/graphql-jpa-query-schema/src/test/java/com/introproventures/graphql/jpa/query/schema/model/calculated/CalculatedEntity.java
@@ -45,4 +45,6 @@ public class CalculatedEntity {
     public String getHideFieldFunction() {
         return "getHideFieldFunction";
     }
+
+    public void setSomething(int a){}
 }


### PR DESCRIPTION
fix Issues #102 

When ever the `Entity` has methods that is `public` and have method name starting with `set` , building schema will fail. This version make a small change ( bypass check for read properties  ) so that build can pass.  
```
@Data
@Entity
public class Book {
	@Id
	Long id;

	@GraphQLIgnoreOrder
	@GraphQLIgnoreFilter
	String title;

	@ManyToOne(fetch=FetchType.LAZY)
	Author author;

	@Enumerated(EnumType.STRING)
	Genre genre;

	/**
	 * Method that have name start with "set" and have at least one arguments will Lead to Error on build time
	 * *Method* that doesn't have a argument won't give error
         * *Method* that does not public won't give error
	 * @param i
	 */
	public void setSth(int i){
		return;
	}

}
```