### PR TITLE
feat: support nested relationships in where criteria expressions 

### DIFF
--- a/graphql-jpa-query-example-merge/src/main/java/com/introproventures/graphql/jpa/query/example/books/Author.java
+++ b/graphql-jpa-query-example-merge/src/main/java/com/introproventures/graphql/jpa/query/example/books/Author.java
@@ -16,7 +16,7 @@
 
 package com.introproventures.graphql.jpa.query.example.books;
 
-import java.util.Collection;
+import java.util.Set;
 
 import javax.persistence.Entity;
 import javax.persistence.FetchType;
@@ -34,5 +34,5 @@ public class Author {
 	String name;
 
 	@OneToMany(mappedBy="author", fetch=FetchType.LAZY)
-	Collection<Book> books;
+	Set<Book> books;
 }

--- a/graphql-jpa-query-example-merge/src/main/java/com/introproventures/graphql/jpa/query/example/books/Book.java
+++ b/graphql-jpa-query-example-merge/src/main/java/com/introproventures/graphql/jpa/query/example/books/Book.java
@@ -23,8 +23,6 @@ import javax.persistence.FetchType;
 import javax.persistence.Id;
 import javax.persistence.ManyToOne;
 
-import com.introproventures.graphql.jpa.query.annotation.GraphQLIgnoreFilter;
-import com.introproventures.graphql.jpa.query.annotation.GraphQLIgnoreOrder;
 import lombok.Data;
 
 @Data
@@ -33,8 +31,6 @@ public class Book {
 	@Id
 	Long id;
 
-	@GraphQLIgnoreOrder
-	@GraphQLIgnoreFilter
 	String title;
 
 	@ManyToOne(fetch=FetchType.LAZY)

--- a/graphql-jpa-query-example-merge/src/main/java/com/introproventures/graphql/jpa/query/example/books/Book.java
+++ b/graphql-jpa-query-example-merge/src/main/java/com/introproventures/graphql/jpa/query/example/books/Book.java
@@ -24,9 +24,11 @@ import javax.persistence.Id;
 import javax.persistence.ManyToOne;
 
 import lombok.Data;
+import lombok.EqualsAndHashCode;
 
 @Data
 @Entity
+@EqualsAndHashCode(exclude="author")
 public class Book {
 	@Id
 	Long id;

--- a/graphql-jpa-query-example-merge/src/main/java/com/introproventures/graphql/jpa/query/example/starwars/Droid.java
+++ b/graphql-jpa-query-example-merge/src/main/java/com/introproventures/graphql/jpa/query/example/starwars/Droid.java
@@ -17,6 +17,9 @@
 package com.introproventures.graphql.jpa.query.example.starwars;
 
 import javax.persistence.Entity;
+import javax.persistence.FetchType;
+import javax.persistence.JoinColumn;
+import javax.persistence.ManyToOne;
 
 import com.introproventures.graphql.jpa.query.annotation.GraphQLDescription;
 
@@ -30,6 +33,8 @@ import lombok.EqualsAndHashCode;
 public class Droid extends Character {
 
     @GraphQLDescription("Documents the primary purpose this droid serves")
-    String primaryFunction;
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "primary_function")
+    DroidFunction primaryFunction;
 
 }

--- a/graphql-jpa-query-example-merge/src/main/java/com/introproventures/graphql/jpa/query/example/starwars/DroidFunction.java
+++ b/graphql-jpa-query-example-merge/src/main/java/com/introproventures/graphql/jpa/query/example/starwars/DroidFunction.java
@@ -1,14 +1,16 @@
 package com.introproventures.graphql.jpa.query.example.starwars;
 
+import javax.persistence.Entity;
+import javax.persistence.Id;
+import javax.persistence.Table;
+
 import com.introproventures.graphql.jpa.query.annotation.GraphQLDescription;
 import lombok.Data;
 import lombok.EqualsAndHashCode;
 
-import javax.persistence.Entity;
-import javax.persistence.Id;
 
-
-@Entity(name = "droid_function")
+@Entity(name = "droidFunction")
+@Table(name = "droid_function")
 @GraphQLDescription("Represents the functions a droid can have")
 @Data
 @EqualsAndHashCode()

--- a/graphql-jpa-query-example-merge/src/main/resources/starwars.sql
+++ b/graphql-jpa-query-example-merge/src/main/resources/starwars.sql
@@ -4,10 +4,15 @@ insert into CodeList (id, type, code, description, sequence, active, parent_id) 
   (0, 'org.crygier.graphql.model.starwars.Gender', 'Male', 'Male', 1, true, null),
   (1, 'org.crygier.graphql.model.starwars.Gender', 'Female', 'Female', 2, true, null);
 
+-- Insert Droid Functions
+insert into droid_function(id, function) values
+( '1000', 'Protocol'),
+( '1001', 'Astromech');
+
 -- Insert Droids
-insert into Character (id, name, primaryFunction, dtype) values
-    ('2000', 'C-3PO', 'Protocol', 'Droid'),
-    ('2001', 'R2-D2', 'Astromech', 'Droid');
+insert into character (id, name, primary_function, dtype) values
+    ('2000', 'C-3PO', '1000', 'Droid'),
+    ('2001', 'R2-D2', '1001', 'Droid');
 
 -- Insert Humans
 insert into character (id, name, homePlanet, favorite_droid_id, dtype, gender_code_id) values

--- a/graphql-jpa-query-example/src/main/java/com/introproventures/graphql/jpa/query/example/model/DroidFunction.java
+++ b/graphql-jpa-query-example/src/main/java/com/introproventures/graphql/jpa/query/example/model/DroidFunction.java
@@ -1,4 +1,4 @@
-package com.introproventures.graphql.jpa.query.example.model;
+package com.introproventures.graphql.jpa.query.example.starwars;
 
 import com.introproventures.graphql.jpa.query.annotation.GraphQLDescription;
 import lombok.Data;

--- a/graphql-jpa-query-example/src/main/java/com/introproventures/graphql/jpa/query/example/model/DroidFunction.java
+++ b/graphql-jpa-query-example/src/main/java/com/introproventures/graphql/jpa/query/example/model/DroidFunction.java
@@ -1,0 +1,25 @@
+package com.introproventures.graphql.jpa.query.example.model;
+
+import com.introproventures.graphql.jpa.query.annotation.GraphQLDescription;
+import lombok.Data;
+import lombok.EqualsAndHashCode;
+
+import javax.persistence.Entity;
+import javax.persistence.Id;
+
+
+@Entity(name = "droid_function")
+@GraphQLDescription("Represents the functions a droid can have")
+@Data
+@EqualsAndHashCode()
+public class DroidFunction {
+
+    @Id
+    @GraphQLDescription("Primary Key for the DroidFunction Class")
+    String id;
+    
+    String function;
+    
+    
+
+}

--- a/graphql-jpa-query-example/src/main/java/com/introproventures/graphql/jpa/query/example/starwars/Droid.java
+++ b/graphql-jpa-query-example/src/main/java/com/introproventures/graphql/jpa/query/example/starwars/Droid.java
@@ -17,9 +17,11 @@
 package com.introproventures.graphql.jpa.query.example.starwars;
 
 import javax.persistence.Entity;
+import javax.persistence.FetchType;
+import javax.persistence.JoinColumn;
+import javax.persistence.ManyToOne;
 
 import com.introproventures.graphql.jpa.query.annotation.GraphQLDescription;
-
 import lombok.Data;
 import lombok.EqualsAndHashCode;
 
@@ -29,7 +31,13 @@ import lombok.EqualsAndHashCode;
 @EqualsAndHashCode(callSuper=true)
 public class Droid extends Character {
 
-    @GraphQLDescription("Documents the primary purpose this droid serves")
-    String primaryFunction;
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "primary_function")
+    DroidFunction primaryFunction;
 
+    //description moved to getter to test it gets picked up
+    @GraphQLDescription("Documents the primary purpose this droid serves")
+    public DroidFunction getPrimaryFunction() {
+        return(primaryFunction);
+    }
 }

--- a/graphql-jpa-query-example/src/main/java/com/introproventures/graphql/jpa/query/example/starwars/DroidFunction.java
+++ b/graphql-jpa-query-example/src/main/java/com/introproventures/graphql/jpa/query/example/starwars/DroidFunction.java
@@ -1,0 +1,25 @@
+package com.introproventures.graphql.jpa.query.example.starwars;
+
+import com.introproventures.graphql.jpa.query.annotation.GraphQLDescription;
+import lombok.Data;
+import lombok.EqualsAndHashCode;
+
+import javax.persistence.Entity;
+import javax.persistence.Id;
+
+
+@Entity(name = "droid_function")
+@GraphQLDescription("Represents the functions a droid can have")
+@Data
+@EqualsAndHashCode()
+public class DroidFunction {
+
+    @Id
+    @GraphQLDescription("Primary Key for the DroidFunction Class")
+    String id;
+    
+    String function;
+    
+    
+
+}

--- a/graphql-jpa-query-example/src/main/java/com/introproventures/graphql/jpa/query/example/starwars/DroidFunction.java
+++ b/graphql-jpa-query-example/src/main/java/com/introproventures/graphql/jpa/query/example/starwars/DroidFunction.java
@@ -1,14 +1,16 @@
 package com.introproventures.graphql.jpa.query.example.starwars;
 
+import javax.persistence.Entity;
+import javax.persistence.Id;
+import javax.persistence.Table;
+
 import com.introproventures.graphql.jpa.query.annotation.GraphQLDescription;
 import lombok.Data;
 import lombok.EqualsAndHashCode;
 
-import javax.persistence.Entity;
-import javax.persistence.Id;
 
-
-@Entity(name = "droid_function")
+@Entity(name = "droidFunction")
+@Table(name = "droid_function")
 @GraphQLDescription("Represents the functions a droid can have")
 @Data
 @EqualsAndHashCode()

--- a/graphql-jpa-query-example/src/main/resources/data.sql
+++ b/graphql-jpa-query-example/src/main/resources/data.sql
@@ -3,10 +3,15 @@ insert into code_list (id, type, code, description, sequence, active, parent_id)
   (0, 'org.crygier.graphql.model.starwars.Gender', 'Male', 'Male', 1, true, null),
   (1, 'org.crygier.graphql.model.starwars.Gender', 'Female', 'Female', 2, true, null);
 
+-- Insert Droid Functions
+insert into droid_function(id, function) values
+( '1000', 'Protocol'),
+( '1001', 'Astromech');
+
 -- Insert Droids
 insert into character (id, name, primary_function, dtype) values
-    ('2000', 'C-3PO', 'Protocol', 'Droid'),
-    ('2001', 'R2-D2', 'Astromech', 'Droid');
+    ('2000', 'C-3PO', '1000', 'Droid'),
+    ('2001', 'R2-D2', '1001', 'Droid');
 
 -- Insert Humans
 insert into character (id, name, home_planet, favorite_droid_id, dtype, gender_code_id) values

--- a/graphql-jpa-query-schema/src/main/java/com/introproventures/graphql/jpa/query/schema/impl/GraphQLJpaOneToManyDataFetcher.java
+++ b/graphql-jpa-query-schema/src/main/java/com/introproventures/graphql/jpa/query/schema/impl/GraphQLJpaOneToManyDataFetcher.java
@@ -136,7 +136,7 @@ class GraphQLJpaOneToManyDataFetcher extends GraphQLJpaQueryDataFetcher {
         // optionally add default ordering 
         mayBeAddDefaultOrderBy(query, join, cb);
         
-        return entityManager.createQuery(query.distinct(true));
+        return entityManager.createQuery(query.distinct(isDistinct));
         
     }
     

--- a/graphql-jpa-query-schema/src/main/java/com/introproventures/graphql/jpa/query/schema/impl/GraphQLJpaSchemaBuilder.java
+++ b/graphql-jpa-query-schema/src/main/java/com/introproventures/graphql/jpa/query/schema/impl/GraphQLJpaSchemaBuilder.java
@@ -116,7 +116,7 @@ public class GraphQLJpaSchemaBuilder implements GraphQLSchemaBuilder {
     private String description = "GraphQL Schema for all entities in this JPA application";
 
     private boolean isUseDistinctParameter = false;
-    private boolean isDefaultDistinct = false;
+    private boolean isDefaultDistinct = true;
 
     public GraphQLJpaSchemaBuilder(EntityManager entityManager) {
         this.entityManager = entityManager;
@@ -264,18 +264,11 @@ public class GraphQLJpaSchemaBuilder implements GraphQLSchemaBuilder {
                                                .collect(Collectors.toList())
             )
             .fields(managedType.getAttributes().stream()
-                                               .filter(this::isToOne)
+                                               .filter(Attribute::isAssociation)
                                                .filter(this::isNotIgnored)
                                                .filter(this::isNotIgnoredFilter)
                                                .map(this::getInputObjectField)
                                                .collect(Collectors.toList())
-            )
-            .fields(managedType.getAttributes().stream()
-                                                .filter(this::isToMany)
-                                                .filter(this::isNotIgnored)
-                                                .filter(this::isNotIgnoredFilter)
-                                                .map(this::getInputObjectField)
-                                                .collect(Collectors.toList())
             )
             .build();
         
@@ -333,7 +326,7 @@ public class GraphQLJpaSchemaBuilder implements GraphQLSchemaBuilder {
                 .collect(Collectors.toList())
             )
             .fields(managedType.getAttributes().stream()
-                .filter(this::isToOne)
+                .filter(this::isValidAssociation)    
                 .filter(this::isNotIgnored)
                 .filter(this::isNotIgnoredFilter)
                 .map(this::getWhereInputRelationField)
@@ -770,6 +763,11 @@ public class GraphQLJpaSchemaBuilder implements GraphQLSchemaBuilder {
                 attribute.getPersistentAttributeType() == Attribute.PersistentAttributeType.EMBEDDED;
     }
 
+    protected final boolean isValidAssociation(Attribute<?,?> attribute) {
+        return isOneToMany(attribute) || isToOne(attribute);
+    }
+
+    
     
     private String getSchemaDescription(Member member) {
         if (member instanceof AnnotatedElement) {

--- a/graphql-jpa-query-schema/src/main/java/com/introproventures/graphql/jpa/query/schema/impl/GraphQLJpaSchemaBuilder.java
+++ b/graphql-jpa-query-schema/src/main/java/com/introproventures/graphql/jpa/query/schema/impl/GraphQLJpaSchemaBuilder.java
@@ -62,6 +62,7 @@ import graphql.schema.GraphQLEnumType;
 import graphql.schema.GraphQLFieldDefinition;
 import graphql.schema.GraphQLInputObjectField;
 import graphql.schema.GraphQLInputObjectType;
+import graphql.schema.GraphQLInputObjectType.Builder;
 import graphql.schema.GraphQLInputType;
 import graphql.schema.GraphQLList;
 import graphql.schema.GraphQLObjectType;
@@ -294,7 +295,7 @@ public class GraphQLJpaSchemaBuilder implements GraphQLSchemaBuilder {
         return inputObjectCache.computeIfAbsent(managedType, this::computeWhereInputType);
     }
     
-    private GraphQLInputObjectType computeWhereInputType(ManagedType<?> managedType) {
+    private String resolveWhereInputTypeName(ManagedType<?> managedType) {
         String typeName="";
         if (managedType instanceof EmbeddableType){
             typeName = managedType.getJavaType().getSimpleName()+"EmbeddableType";
@@ -302,9 +303,14 @@ public class GraphQLJpaSchemaBuilder implements GraphQLSchemaBuilder {
             typeName = ((EntityType<?>)managedType).getName();
         }
 
-        String type = namingStrategy.pluralize(typeName)+"RelationCriteriaExpression";
+        return namingStrategy.pluralize(typeName)+"RelationCriteriaExpression";
         
-        GraphQLInputObjectType whereInputObject = GraphQLInputObjectType.newInputObject()
+    }
+    
+    private GraphQLInputObjectType computeWhereInputType(ManagedType<?> managedType) {
+        String type=resolveWhereInputTypeName(managedType);
+        
+         Builder whereInputObject = GraphQLInputObjectType.newInputObject()
             .name(type)
             .description("Where logical AND specification of the provided list of criteria expressions")
             .field(GraphQLInputObjectField.newInputObjectField()
@@ -326,11 +332,31 @@ public class GraphQLJpaSchemaBuilder implements GraphQLSchemaBuilder {
                 .map(this::getWhereInputField)
                 .collect(Collectors.toList())
             )
-            .build();
+            .fields(managedType.getAttributes().stream()
+                .filter(this::isToOne)
+                .filter(this::isNotIgnored)
+                .filter(this::isNotIgnoredFilter)
+                .map(this::getWhereInputRelationField)
+                .collect(Collectors.toList())
+            );
         
-        return whereInputObject;
+        return whereInputObject.build();
         
     }    
+    
+    private GraphQLInputObjectField getWhereInputRelationField(Attribute<?,?> attribute) {
+        ManagedType<?> foreignType = getForeignType(attribute);
+        
+        String type = resolveWhereInputTypeName(foreignType);
+        String description = getSchemaDescription(attribute.getJavaMember());
+
+        return GraphQLInputObjectField.newInputObjectField()
+            .name(attribute.getName())
+            .description(description)
+            .type(new GraphQLTypeReference(type))
+            .build(); 
+    }
+    
 
     private GraphQLInputObjectField getWhereInputField(Attribute<?,?> attribute) {
         GraphQLInputType type = getWhereAttributeType(attribute);
@@ -375,8 +401,8 @@ public class GraphQLJpaSchemaBuilder implements GraphQLSchemaBuilder {
                 .description("Equals criteria")
                 .type(getAttributeInputType(attribute))
                 .build()
-            )
-            .field(GraphQLInputObjectField.newInputObjectField()
+           )
+           .field(GraphQLInputObjectField.newInputObjectField()
                 .name(Criteria.NE.name())
                 .description("Not Equals criteria")
                 .type(getAttributeInputType(attribute))
@@ -610,7 +636,7 @@ public class GraphQLJpaSchemaBuilder implements GraphQLSchemaBuilder {
         }
 
         // Get the fields that can be queried on (i.e. Simple Types, no Sub-Objects)
-        if (attribute instanceof SingularAttribute
+        if (attribute instanceof SingularAttribute 
             && attribute.getPersistentAttributeType() != Attribute.PersistentAttributeType.BASIC) {
             ManagedType foreignType = getForeignType(attribute);
 
@@ -622,7 +648,7 @@ public class GraphQLJpaSchemaBuilder implements GraphQLSchemaBuilder {
             && (attribute.getPersistentAttributeType() == Attribute.PersistentAttributeType.ONE_TO_MANY
                 || attribute.getPersistentAttributeType() == Attribute.PersistentAttributeType.MANY_TO_MANY)) {
             EntityType declaringType = (EntityType) ((PluralAttribute) attribute).getDeclaringType();
-            EntityType elementType =  (EntityType) ((PluralAttribute) attribute).getElementType();
+            ManagedType elementType = getForeignType(attribute);
 
             arguments.add(getWhereArgument(elementType));
             dataFetcher = new GraphQLJpaOneToManyDataFetcher(entityManager, declaringType, (PluralAttribute) attribute);
@@ -638,7 +664,10 @@ public class GraphQLJpaSchemaBuilder implements GraphQLSchemaBuilder {
     }
 
     protected ManagedType<?> getForeignType(Attribute<?,?> attribute) {
-        return (ManagedType<?>) ((SingularAttribute<?,?>) attribute).getType();
+        if(SingularAttribute.class.isInstance(attribute))
+            return (ManagedType<?>) ((SingularAttribute<?,?>) attribute).getType();
+        else
+            return (EntityType<?>) ((PluralAttribute<?, ?, ?>) attribute).getElementType();
     }
     
     @SuppressWarnings( { "rawtypes" } )

--- a/graphql-jpa-query-schema/src/main/java/com/introproventures/graphql/jpa/query/schema/impl/QraphQLJpaBaseDataFetcher.java
+++ b/graphql-jpa-query-schema/src/main/java/com/introproventures/graphql/jpa/query/schema/impl/QraphQLJpaBaseDataFetcher.java
@@ -38,6 +38,7 @@ import javax.persistence.Subgraph;
 import javax.persistence.TypedQuery;
 import javax.persistence.criteria.CriteriaBuilder;
 import javax.persistence.criteria.CriteriaQuery;
+import javax.persistence.criteria.Fetch;
 import javax.persistence.criteria.From;
 import javax.persistence.criteria.Join;
 import javax.persistence.criteria.JoinType;
@@ -52,7 +53,6 @@ import javax.persistence.metamodel.SingularAttribute;
 
 import com.introproventures.graphql.jpa.query.annotation.GraphQLDefaultOrderBy;
 import com.introproventures.graphql.jpa.query.schema.impl.PredicateFilter.Criteria;
-
 import graphql.GraphQLException;
 import graphql.execution.ValuesResolver;
 import graphql.language.Argument;
@@ -178,14 +178,14 @@ class QraphQLJpaBaseDataFetcher implements DataFetcher<Object> {
                             if (attribute.getPersistentAttributeType() == Attribute.PersistentAttributeType.MANY_TO_ONE
                                 || attribute.getPersistentAttributeType() == Attribute.PersistentAttributeType.ONE_TO_ONE
                             ) {
-                                reuseJoin(from, selectedField.getName(), false);
+                                Join<?,?> join = reuseJoin(from, selectedField.getName(), false);
                             }
                         }
                     } else  {
-                        // We must add plural attributes with explicit join to avoid Hibernate error: 
+                        // We must add plural attributes with explicit fetch to avoid Hibernate error: 
                         // "query specified join fetching, but the owner of the fetched association was not present in the select list"
-                        // TODO Let's try detect many-to-many relation and reuse outer join
-                        reuseJoin(from, selectedField.getName(), false);
+                        // TODO Let's try detect optional relation and apply join type
+                        Join<?,?> join = reuseJoin(from, selectedField.getName(), false);
                     }
                 }
             }
@@ -396,7 +396,12 @@ class QraphQLJpaBaseDataFetcher implements DataFetcher<Object> {
 
                 arguments.put(logical.name(), environment.getArgument(fieldName));
                 
-                return getArgumentPredicate(cb, reuseJoin(path, fieldName, false),  
+                
+                Join<?,?> join = reuseJoin(path, fieldName, false);
+                
+//                join.getParent().fetch(fieldName);
+                
+                return getArgumentPredicate(cb, join,  
                                             wherePredicateEnvironment(environment, fieldDefinition, arguments),
                                             new Argument(logical.name(), expressionValue));
                }
@@ -525,6 +530,19 @@ class QraphQLJpaBaseDataFetcher implements DataFetcher<Object> {
         }
         return outer ? path.join(fieldName, JoinType.LEFT) : path.join(fieldName);
     }
+    
+    // trying to find already existing joins to reuse
+    private Fetch<?,?> reuseFetches(From<?, ?> path, String fieldName, boolean outer) {
+
+        for (Fetch<?,?> join : path.getFetches()) {
+            if (join.getAttribute().getName().equals(fieldName)) {
+                if ((join.getJoinType() == JoinType.LEFT) == outer) {
+                    return join;
+                }
+            }
+        }
+        return outer ? path.fetch(fieldName, JoinType.LEFT) : path.fetch(fieldName);
+    }    
 
     @SuppressWarnings( { "unchecked", "rawtypes" } )
     protected Object convertValue(DataFetchingEnvironment environment, Argument argument, Value value) {

--- a/graphql-jpa-query-schema/src/test/java/com/introproventures/graphql/jpa/query/schema/GraphQLExecutorTests.java
+++ b/graphql-jpa-query-schema/src/test/java/com/introproventures/graphql/jpa/query/schema/GraphQLExecutorTests.java
@@ -20,9 +20,11 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 import java.util.Arrays;
 import java.util.HashMap;
-import java.util.Map;
 import java.util.List;
+import java.util.Map;
+
 import javax.persistence.EntityManager;
+
 import com.introproventures.graphql.jpa.query.schema.impl.GraphQLJpaExecutor;
 import com.introproventures.graphql.jpa.query.schema.impl.GraphQLJpaSchemaBuilder;
 import graphql.ErrorType;
@@ -570,6 +572,45 @@ public class GraphQLExecutorTests {
         assertThat(result.toString()).isEqualTo(expected);
     }        
     
+    @Test
+    public void queryForAuthorssWithWhereBooksManyToOneRelationCriteria() {
+        //given
+        String query = "query { " +
+                "  Authors(where: {" + 
+                "    books: {" + 
+                "      author: {" + 
+                "        name: {LIKE: \"Leo\"}" + 
+                "      }" + 
+                "    }" + 
+                "  }) {" + 
+                "    select {" + 
+                "      id" + 
+                "      name" + 
+                "      books {" + 
+                "        id" + 
+                "        title" + 
+                "        genre" + 
+                "        author {" + 
+                "          name" + 
+                "        }" + 
+                "      }" + 
+                "    }" + 
+                "  }" +
+                "}";
+
+        String expected = "{Authors={select=[{"
+                +   "id=1, name=Leo Tolstoy, books=[{id=2, title=War and Peace, genre=NOVEL, author={name=Leo Tolstoy}}, "
+                +   "{id=3, title=Anna Karenina, genre=NOVEL, author={name=Leo Tolstoy}}"
+                + "]}"
+                + "]}}";
+
+        //when
+        Object result = executor.execute(query).getData();
+
+        // then
+        assertThat(result.toString()).isEqualTo(expected);
+    }        
+        
 
     @Test
     public void queryWithWhereInsideOneToManyRelationsImplicitAND() {

--- a/graphql-jpa-query-schema/src/test/java/com/introproventures/graphql/jpa/query/schema/GraphQLExecutorTests.java
+++ b/graphql-jpa-query-schema/src/test/java/com/introproventures/graphql/jpa/query/schema/GraphQLExecutorTests.java
@@ -602,9 +602,10 @@ public class GraphQLExecutorTests {
                 "}";
 
         String expected = "{Authors={select=[{"
-                +   "id=1, name=Leo Tolstoy, books=[{id=2, title=War and Peace, genre=NOVEL, author={name=Leo Tolstoy}}, "
-                +   "{id=3, title=Anna Karenina, genre=NOVEL, author={name=Leo Tolstoy}}"
-                + "]}"
+                +   "id=1, name=Leo Tolstoy, books=["
+                +       "{id=2, title=War and Peace, genre=NOVEL, author={name=Leo Tolstoy}}, "
+                +       "{id=3, title=Anna Karenina, genre=NOVEL, author={name=Leo Tolstoy}}"
+                +   "]}"
                 + "]}}";
 
         //when

--- a/graphql-jpa-query-schema/src/test/java/com/introproventures/graphql/jpa/query/schema/StarwarsQueryExecutorTests.java
+++ b/graphql-jpa-query-schema/src/test/java/com/introproventures/graphql/jpa/query/schema/StarwarsQueryExecutorTests.java
@@ -102,9 +102,9 @@ public class StarwarsQueryExecutorTests {
     @Test
     public void queryForDroidByName() {
         //given:
-        String query = "query { Droids( where: { name: { EQ: \"C-3PO\"}}) { select {name, primaryFunction } } }";
+        String query = "query { Droids( where: { name: { EQ: \"C-3PO\"}}) { select {name, primaryFunction {function} } } }";
 
-        String expected = "{Droids={select=[{name=C-3PO, primaryFunction=Protocol}]}}";
+        String expected = "{Droids={select=[{name=C-3PO, primaryFunction={function=Protocol}}]}}";
 
         //when:
         Object result = executor.execute(query).getData();

--- a/graphql-jpa-query-schema/src/test/java/com/introproventures/graphql/jpa/query/schema/StarwarsQueryExecutorTests.java
+++ b/graphql-jpa-query-schema/src/test/java/com/introproventures/graphql/jpa/query/schema/StarwarsQueryExecutorTests.java
@@ -661,7 +661,7 @@ public class StarwarsQueryExecutorTests {
                 "      name" + 
                 "      favoriteDroid {" + 
                 "        name" + 
-                "        primaryFunction" + 
+                "        primaryFunction { function }" + 
                 "        appearsIn" + 
                 "      }" + 
                 "      friends {" + 
@@ -698,7 +698,7 @@ public class StarwarsQueryExecutorTests {
                 "      favoriteDroid {" + 
                 "        id" + 
                 "        name" + 
-                "        primaryFunction" + 
+                "        primaryFunction { function }" + 
                 "      }" + 
                 "      friends(where: {name: {LIKE: \"Leia\"}}) {" + 
                 "        id" + 
@@ -709,7 +709,7 @@ public class StarwarsQueryExecutorTests {
                 "}";
 
         String expected = "{Humans={select=["
-                + "{id=1000, name=Luke Skywalker, favoriteDroid={id=2000, name=C-3PO, primaryFunction=Protocol}, friends=[{id=1003, name=Leia Organa}]}"
+                + "{id=1000, name=Luke Skywalker, favoriteDroid={id=2000, name=C-3PO, primaryFunction={function=Protocol}}, friends=[{id=1003, name=Leia Organa}]}"
                 + "]}}";
 
         //when:

--- a/graphql-jpa-query-schema/src/test/java/com/introproventures/graphql/jpa/query/schema/StarwarsQueryExecutorTests.java
+++ b/graphql-jpa-query-schema/src/test/java/com/introproventures/graphql/jpa/query/schema/StarwarsQueryExecutorTests.java
@@ -751,4 +751,79 @@ public class StarwarsQueryExecutorTests {
         assertThat(result.toString()).isEqualTo(expected);
     }    
     
+    
+    @Test
+    public void queryFilterManyToOne() {
+        //given:
+        String query = "query { Droids { select { name  primaryFunction(where: {function: {EQ:\"Astromech\"}}) { function }}}}";
+
+        String expected = "{Droids={" +
+                            "select=[{" +
+                              "name=R2-D2, " +
+                              "primaryFunction={function=Astromech}" +
+                            "}]" + 
+                          "}}";
+
+        //when:
+        Object result = executor.execute(query).getData();
+
+        //then:
+        assertThat(result.toString()).isEqualTo(expected);
+    }
+    
+    
+    @Test
+    public void queryFilterNestedManyToOne() {
+        //given:
+        String query = "query {" +
+                "    Humans {" +
+                "        select {" +
+                "            id" +
+                "            name" +
+                "            homePlanet" +
+                "            favoriteDroid {" +
+                "                name" +
+                "                primaryFunction(where:{function:{EQ:\"Astromech\"}}) {" +
+                "                      function" +
+                "                }" +
+                "            }" +
+                "        }" +
+                "    }" +
+                "}";
+
+        String expected = "{Humans={" +
+                            "select=[" +
+                                "{" +
+                                    "id=1000, " +
+                                    "name=Luke Skywalker, " +
+                                    "homePlanet=Tatooine, " +
+                                    "favoriteDroid={" +
+                                        "name=C-3PO, " +
+                                        "primaryFunction={" +
+                                            "function=Protocol" +
+                                        "}" +
+                                    "}" +
+                                /*"}, " +
+                                "{" +
+                                    "id=1001, " +
+                                    "name=Darth Vader, " +
+                                    "homePlanet=Tatooine, " +
+                                    "favoriteDroid={" +
+                                        "name=R2-D2, " +
+                                        "primaryFunction={" +
+                                            "function=Astromech" +
+                                        "}" +
+                                    "}" +
+                                */
+                                "}" +
+                            "]" +
+                        "}}";
+
+        //when:
+        Object result = executor.execute(query).getData();
+
+        //then:
+        assertThat(result.toString()).isEqualTo(expected);
+    }
+
 }

--- a/graphql-jpa-query-schema/src/test/java/com/introproventures/graphql/jpa/query/schema/StarwarsQueryExecutorTests.java
+++ b/graphql-jpa-query-schema/src/test/java/com/introproventures/graphql/jpa/query/schema/StarwarsQueryExecutorTests.java
@@ -793,7 +793,7 @@ public class StarwarsQueryExecutorTests {
 
         String expected = "{Humans={" +
                             "select=[" +
-                                "{" +
+                                /*"{" +
                                     "id=1000, " +
                                     "name=Luke Skywalker, " +
                                     "homePlanet=Tatooine, " +
@@ -803,7 +803,8 @@ public class StarwarsQueryExecutorTests {
                                             "function=Protocol" +
                                         "}" +
                                     "}" +
-                                /*"}, " +
+                                "}, " +
+                                */
                                 "{" +
                                     "id=1001, " +
                                     "name=Darth Vader, " +
@@ -814,7 +815,6 @@ public class StarwarsQueryExecutorTests {
                                             "function=Astromech" +
                                         "}" +
                                     "}" +
-                                */
                                 "}" +
                             "]" +
                         "}}";

--- a/graphql-jpa-query-schema/src/test/java/com/introproventures/graphql/jpa/query/schema/model/book/Author.java
+++ b/graphql-jpa-query-schema/src/test/java/com/introproventures/graphql/jpa/query/schema/model/book/Author.java
@@ -16,7 +16,6 @@
 
 package com.introproventures.graphql.jpa.query.schema.model.book;
 
-import java.util.Collection;
 import java.util.HashSet;
 import java.util.Set;
 
@@ -30,6 +29,7 @@ import javax.persistence.FetchType;
 import javax.persistence.Id;
 import javax.persistence.JoinColumn;
 import javax.persistence.OneToMany;
+import javax.persistence.OrderBy;
 
 import lombok.EqualsAndHashCode;
 import lombok.Getter;
@@ -48,7 +48,8 @@ public class Author {
 	String name;
 
 	@OneToMany(mappedBy="author", fetch=FetchType.LAZY)
-	Collection<Book> books;
+    @OrderBy("id ASC")
+	Set<Book> books;
 	
 	@ElementCollection(fetch=FetchType.LAZY) 
 	@CollectionTable(name = "author_phone_numbers", joinColumns = @JoinColumn(name = "author_id")) 

--- a/graphql-jpa-query-schema/src/test/java/com/introproventures/graphql/jpa/query/schema/model/book/Book.java
+++ b/graphql-jpa-query-schema/src/test/java/com/introproventures/graphql/jpa/query/schema/model/book/Book.java
@@ -28,9 +28,11 @@ import javax.persistence.ManyToOne;
 import com.introproventures.graphql.jpa.query.annotation.GraphQLIgnoreFilter;
 import com.introproventures.graphql.jpa.query.annotation.GraphQLIgnoreOrder;
 import lombok.Data;
+import lombok.EqualsAndHashCode;
 
 @Data
 @Entity
+@EqualsAndHashCode(exclude="author")
 public class Book {
 	@Id
 	Long id;

--- a/graphql-jpa-query-schema/src/test/java/com/introproventures/graphql/jpa/query/schema/model/starwars/Droid.java
+++ b/graphql-jpa-query-schema/src/test/java/com/introproventures/graphql/jpa/query/schema/model/starwars/Droid.java
@@ -17,6 +17,9 @@
 package com.introproventures.graphql.jpa.query.schema.model.starwars;
 
 import javax.persistence.Entity;
+import javax.persistence.FetchType;
+import javax.persistence.JoinColumn;
+import javax.persistence.ManyToOne;
 
 import com.introproventures.graphql.jpa.query.annotation.GraphQLDescription;
 
@@ -29,11 +32,13 @@ import lombok.EqualsAndHashCode;
 @EqualsAndHashCode(callSuper=true)
 public class Droid extends Character {
 
-    String primaryFunction;
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "primary_function")
+    DroidFunction primaryFunction;
 
     //description moved to getter to test it gets picked up
     @GraphQLDescription("Documents the primary purpose this droid serves")
-    public String getPrimaryFunction() {
+    public DroidFunction getPrimaryFunction() {
         return(primaryFunction);
     }
 }

--- a/graphql-jpa-query-schema/src/test/java/com/introproventures/graphql/jpa/query/schema/model/starwars/DroidFunction.java
+++ b/graphql-jpa-query-schema/src/test/java/com/introproventures/graphql/jpa/query/schema/model/starwars/DroidFunction.java
@@ -1,0 +1,25 @@
+package com.introproventures.graphql.jpa.query.schema.model.starwars;
+
+import com.introproventures.graphql.jpa.query.annotation.GraphQLDescription;
+import lombok.Data;
+import lombok.EqualsAndHashCode;
+
+import javax.persistence.Entity;
+import javax.persistence.Id;
+
+
+@Entity(name = "droid_function")
+@GraphQLDescription("Represents the functions a droid can have")
+@Data
+@EqualsAndHashCode()
+public class DroidFunction {
+
+    @Id
+    @GraphQLDescription("Primary Key for the DroidFunction Class")
+    String id;
+    
+    String function;
+    
+    
+
+}

--- a/graphql-jpa-query-schema/src/test/resources/data.sql
+++ b/graphql-jpa-query-schema/src/test/resources/data.sql
@@ -3,10 +3,15 @@ insert into code_list (id, type, code, description, sequence, active, parent_id)
   (0, 'org.crygier.graphql.model.starwars.Gender', 'Male', 'Male', 1, true, null),
   (1, 'org.crygier.graphql.model.starwars.Gender', 'Female', 'Female', 2, true, null);
 
+-- Insert Droid Functions
+insert into droid_function(id, function) values
+( '1000', 'Protocol'),
+( '1001', 'Astromech');
+
 -- Insert Droids
 insert into character (id, name, primary_function, dtype) values
-    ('2000', 'C-3PO', 'Protocol', 'Droid'),
-    ('2001', 'R2-D2', 'Astromech', 'Droid');
+    ('2000', 'C-3PO', '1000', 'Droid'),
+    ('2001', 'R2-D2', '1001', 'Droid');
 
 -- Insert Humans
 insert into character (id, name, home_planet, favorite_droid_id, dtype, gender_code_id) values


### PR DESCRIPTION
Given the following query:

```
  Authors(where: {
    books: {
      author: {
        name: {LIKE: "Leo"}
      }
    }
  }) {
    select {
      id
      name
      books {
        id
        title
        genre
      }
    }
  }
```

Expected result:

```
{
  "data": {
    "Authors": {
      "select": [
        {
          "id": 1,
          "name": "Leo Tolstoy",
          "books": [
            {
              "id": 2,
              "title": "War and Peace",
              "genre": "NOVEL",
            },
            {
              "id": 3,
              "title": "Anna Karenina",
              "genre": "NOVEL",
            }
          ]
        }
      ]
    }
  }
}
```
And collection filtering in nested relationships :

```
  Books(where: {
    title:{LIKE: "War"}
    author: {
      name:{LIKE: "Leo"}
      books: {title: {LIKE: "Anna"}}
    }
  }) {
    select {
      id
      title
      genre
      author {
        id
        name
        books {
          id
          title
          genre
        }
      }
    }
  }
```

Will return:

```
{
  "data": {
    "Books": {
      "select": [
        {
          "id": 2,
          "title": "War and Peace",
          "genre": "NOVEL",
          "author": {
            "id": 1,
            "name": "Leo Tolstoy",
            "books": [
              {
                "id": 3,
                "title": "Anna Karenina",
                "genre": "NOVEL"
              }
            ]
          }
        }
      ]
    }
  }
}
```


Fixes https://github.com/introproventures/graphql-jpa-query/issues/97

Fixes https://github.com/introproventures/graphql-jpa-query/issues/77


