### PR TITLE
fix: compound nested relationship criteria expressions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@ sudo: required
 
 jdk:
   - oraclejdk8
-  - openjdk11
+  # - openjdk11
 
 services:
   - docker

--- a/graphql-jpa-query-schema/src/test/java/com/introproventures/graphql/jpa/query/schema/GraphQLExecutorTests.java
+++ b/graphql-jpa-query-schema/src/test/java/com/introproventures/graphql/jpa/query/schema/GraphQLExecutorTests.java
@@ -726,11 +726,13 @@ public class GraphQLExecutorTests {
         String query = "query { " +
                 "  Authors(where: {" + 
                 "    books: {" + 
-                "      author: {name: {LIKE:\"Leo\"}}" + 
-                "      OR: {" + 
-                "        title: {LIKE: \"War\"}" + 
-                "        title: {LIKE: \"Anna\"}" + 
-                "      }" + 
+                "      author: {name: {LIKE:\"Leo\"}}" +
+//                "      AND: {" +
+                "        OR: {" + 
+                "          id: {EQ: 2}" + 
+                "          title: {LIKE: \"Anna\"}" + 
+                "        }" + 
+  //              "      }" +
                 "    }" + 
                 "  }) {" + 
                 "    select {" + 

--- a/graphql-jpa-query-schema/src/test/java/com/introproventures/graphql/jpa/query/schema/GraphQLExecutorTests.java
+++ b/graphql-jpa-query-schema/src/test/java/com/introproventures/graphql/jpa/query/schema/GraphQLExecutorTests.java
@@ -727,12 +727,12 @@ public class GraphQLExecutorTests {
                 "  Authors(where: {" + 
                 "    books: {" + 
                 "      author: {name: {LIKE:\"Leo\"}}" +
-//                "      AND: {" +
+                "      AND: {" +
                 "        OR: {" + 
                 "          id: {EQ: 2}" + 
                 "          title: {LIKE: \"Anna\"}" + 
                 "        }" + 
-  //              "      }" +
+                "      }" +
                 "    }" + 
                 "  }) {" + 
                 "    select {" + 


### PR DESCRIPTION
The PR fixes problem mapping GraphQL query with nested relation criteria expressions using nested AND: { OR: { expressions } } into JPQL, i.e.

```
query {
  Authors(where: {
    books: {
      author: { name: {LIKE:"Leo"} }
      AND: {
        OR: {
          id: {EQ: 2}
          title: {LIKE: "Anna"}
        }
      }
    }
  }) {
    select {
      id
      name
      books {
        id
        title
        genre
      }
    }
  }
}  
```
Should produce the following Hibernate query:

```
    select
        author0_.id as id1_0_0_,
        books1_.id as id1_2_1_,
        author0_.genre as genre2_0_0_,
        author0_.name as name3_0_0_,
        books1_.author_id as author_i6_2_1_,
        books1_.description as descript2_2_1_,
        books1_.genre as genre3_2_1_,
        books1_.publicationDate as publicat4_2_1_,
        books1_.title as title5_2_1_,
        books1_.author_id as author_i6_2_0__,
        books1_.id as id1_2_0__ 
    from
        Author author0_ 
    inner join
        Book books1_ 
            on author0_.id=books1_.author_id 
    inner join
        Author author2_ 
            on books1_.author_id=author2_.id 
    where
        (
            books1_.id=2 
            or lower(books1_.title) like ?
        ) 
        and (
            lower(author2_.name) like ?
        ) 
    order by
        author0_.id asc,
        books1_.id asc

```
