### PR TITLE
feat: Provide default GraphQLObjectCoercing fallback for non-existing Java classes

### DIFF
--- a/graphql-jpa-query-schema/src/main/java/com/introproventures/graphql/jpa/query/schema/JavaScalars.java
+++ b/graphql-jpa-query-schema/src/main/java/com/introproventures/graphql/jpa/query/schema/JavaScalars.java
@@ -115,7 +115,7 @@ public class JavaScalars {
     }
 
     public static GraphQLScalarType of(Class<?> key) {
-        return scalarsRegistry.get(key);
+        return scalarsRegistry.getOrDefault(key, scalarsRegistry.get(Object.class));
     }
 
     public static JavaScalars register(Class<?> key, GraphQLScalarType value) {

--- a/graphql-jpa-query-schema/src/main/java/com/introproventures/graphql/jpa/query/schema/JavaScalars.java
+++ b/graphql-jpa-query-schema/src/main/java/com/introproventures/graphql/jpa/query/schema/JavaScalars.java
@@ -115,7 +115,14 @@ public class JavaScalars {
     }
 
     public static GraphQLScalarType of(Class<?> key) {
-        return scalarsRegistry.getOrDefault(key, scalarsRegistry.get(Object.class));
+        return scalarsRegistry.computeIfAbsent(key, JavaScalars::computeGraphQLScalarType);
+    }
+    
+    protected static GraphQLScalarType computeGraphQLScalarType(Class<?> key) {
+        String typeName = key.getSimpleName();
+        String description = typeName+" Scalar Object Type";
+        
+        return new GraphQLScalarType(typeName, description, new GraphQLObjectCoercing());
     }
 
     public static JavaScalars register(Class<?> key, GraphQLScalarType value) {

--- a/graphql-jpa-query-schema/src/test/java/com/introproventures/graphql/jpa/query/schema/JavaScalarsTest.java
+++ b/graphql-jpa-query-schema/src/test/java/com/introproventures/graphql/jpa/query/schema/JavaScalarsTest.java
@@ -24,12 +24,16 @@ import java.time.LocalDateTime;
 import java.time.LocalTime;
 import java.time.Month;
 import java.time.ZoneId;
+import java.util.Map;
 import java.util.concurrent.TimeUnit;
 
+import com.introproventures.graphql.jpa.query.converter.model.VariableValue;
+import com.introproventures.graphql.jpa.query.schema.JavaScalars.GraphQLObjectCoercing;
 import graphql.language.StringValue;
 import graphql.schema.Coercing;
 import graphql.schema.CoercingParseValueException;
 import graphql.schema.CoercingSerializeException;
+import graphql.schema.GraphQLScalarType;
 import org.junit.Test;
 
 public class JavaScalarsTest {
@@ -174,11 +178,37 @@ public class JavaScalarsTest {
         Coercing<?,?> coercing = JavaScalars.of(LocalTime.class).getCoercing();
 
         //then
-        //then
         coercing.parseValue("");
         coercing.parseValue("not a time");
         coercing.parseValue(new Object());
         
         fail("Should throw CoercingParseValueException");
     }
+    
+    @Test
+    public void testNonExistingJavaScalarShouldDefaultToObjectCoercing() {
+        //given
+        GraphQLScalarType scalarType = JavaScalars.of(VariableValue.class);
+
+        //then
+        Coercing<?,?> coercing = scalarType.getCoercing();
+
+        assertThat(coercing).isInstanceOf(GraphQLObjectCoercing.class);
+        assertThat(scalarType.getName()).isEqualTo("VariableValue");
+    }
+    
+    @Test
+    public void testRegisterJavaScalarWithObjectCoercing() {
+        //given
+        JavaScalars.register(Map.class, new GraphQLScalarType("Map", "Map Object Type", new GraphQLObjectCoercing()));
+
+        //when
+        GraphQLScalarType scalarType = JavaScalars.of(Map.class);
+        
+        //then
+        Coercing<?,?> coercing = scalarType.getCoercing();
+
+        assertThat(coercing).isInstanceOf(GraphQLObjectCoercing.class);
+        assertThat(scalarType.getName()).isEqualTo("Map");
+    }    
 }


### PR DESCRIPTION
This PR adds support for generating Java Scalar type with default GraphQLObjectCoercing fallback for non-registered Java classes in JavaScalars type registry, i.e.

```java
// given
Class<?> clazz = VariableValue.class;

// when
GraphQLScalarType scalarType = JavaScalars.of(clazz);

// then
assertThat(scalarType.getCoercing()).isInstanceOf(GraphQLObjectCoercing.class);
assertThat(scalarType.getName()).isEqualTo("VariableValue");
```

