### PR TITLE
feat: add equals criteria support for custom attributes types

### DIFF
--- a/graphql-jpa-query-schema/src/main/java/com/introproventures/graphql/jpa/query/schema/impl/JpaPredicateBuilder.java
+++ b/graphql-jpa-query-schema/src/main/java/com/introproventures/graphql/jpa/query/schema/impl/JpaPredicateBuilder.java
@@ -415,12 +415,12 @@ class JpaPredicateBuilder {
                 return from.join(filter.getField()).in(value);
         } else if(type.isEnum()) {
         	return getEnumPredicate((Path<Enum<?>>) field, predicateFilter);
-        }
+        } // TODO need better detection mechanism
         else if (Object.class.isAssignableFrom(type)) {
             if (filter.getCriterias().contains(PredicateFilter.Criteria.LOCATE)) {
                 return cb.gt(cb.locate(from.<String>get(filter.getField()), value.toString()), 0); 
             }
-            else if (Object.class.isAssignableFrom(type) && filter.getCriterias().contains(PredicateFilter.Criteria.EQ)) {
+            else if (filter.getCriterias().contains(PredicateFilter.Criteria.EQ)) {
                 Object object = value;
                 
                 try {

--- a/graphql-jpa-query-schema/src/main/java/com/introproventures/graphql/jpa/query/schema/impl/JpaPredicateBuilder.java
+++ b/graphql-jpa-query-schema/src/main/java/com/introproventures/graphql/jpa/query/schema/impl/JpaPredicateBuilder.java
@@ -16,6 +16,7 @@
 
 package com.introproventures.graphql.jpa.query.schema.impl;
 
+import java.lang.reflect.Constructor;
 import java.math.BigDecimal;
 import java.math.BigInteger;
 import java.util.Collection;
@@ -31,6 +32,7 @@ import javax.persistence.criteria.Path;
 import javax.persistence.criteria.Predicate;
 
 import com.introproventures.graphql.jpa.query.schema.impl.PredicateFilter.Criteria;
+import graphql.language.NullValue;
 
 /**
  * Supported types to build predicates for
@@ -414,8 +416,25 @@ class JpaPredicateBuilder {
         } else if(type.isEnum()) {
         	return getEnumPredicate((Path<Enum<?>>) field, predicateFilter);
         }
-        else if (filter.getCriterias().contains(PredicateFilter.Criteria.LOCATE)) {
-            return cb.gt(cb.locate(from.<String>get(filter.getField()), value.toString()), 0); 
+        else if (Object.class.isAssignableFrom(type)) {
+            if (filter.getCriterias().contains(PredicateFilter.Criteria.LOCATE)) {
+                return cb.gt(cb.locate(from.<String>get(filter.getField()), value.toString()), 0); 
+            }
+            else if (Object.class.isAssignableFrom(type) && filter.getCriterias().contains(PredicateFilter.Criteria.EQ)) {
+                Object object = value;
+                
+                try {
+                    Constructor<?> constructor = type.getConstructor(Object.class);
+                    if(constructor != null) {
+                        Object arg = NullValue.class.isInstance(value) ? null : value;
+                        object = constructor.newInstance(arg);
+                    }
+                } catch (Exception e) {
+                    e.printStackTrace();
+                }
+                
+                return cb.equal(from.get(filter.getField()), object);
+            } 
         }
 
         throw new IllegalArgumentException("Unsupported field type " + type + " for field " + predicateFilter.getField());

--- a/graphql-jpa-query-schema/src/test/java/com/introproventures/graphql/jpa/query/converter/GraphQLJpaConverterTests.java
+++ b/graphql-jpa-query-schema/src/test/java/com/introproventures/graphql/jpa/query/converter/GraphQLJpaConverterTests.java
@@ -339,6 +339,7 @@ public class GraphQLJpaConverterTests {
         //given
         String query = "query {" + 
                 " TaskVariables(where: {" 
+                +     "name: {EQ: \"variable1\"}" 
                 +     "value: {EQ: \"data\"}" 
                 + "}) {" + 
                 "    select {" + 
@@ -362,6 +363,7 @@ public class GraphQLJpaConverterTests {
         //given
         String query = "query {" + 
                 " TaskVariables(where: {" 
+                +     "name: {EQ: \"variable2\"}" 
                 +     "value: {EQ: true}" 
                 + "}) {" + 
                 "    select {" + 
@@ -385,6 +387,7 @@ public class GraphQLJpaConverterTests {
         //given
         String query = "query {" + 
                 " TaskVariables(where: {" 
+                +     "name: {EQ: \"variable3\"}" 
                 +     "value: {EQ: null}" 
                 + "}) {" + 
                 "    select {" + 
@@ -408,6 +411,7 @@ public class GraphQLJpaConverterTests {
         //given
         String query = "query {" + 
                 " TaskVariables(where: {" 
+                +     "name: {EQ: \"variable6\"}" 
                 +     "value: {EQ: 12345}" 
                 + "}) {" + 
                 "    select {" + 
@@ -431,6 +435,7 @@ public class GraphQLJpaConverterTests {
         //given
         String query = "query {" + 
                 " TaskVariables(where: {" 
+                +     "name: {EQ: \"variable5\"}" 
                 +     "value: {EQ: 1.2345}" 
                 + "}) {" + 
                 "    select {" + 

--- a/graphql-jpa-query-schema/src/test/java/com/introproventures/graphql/jpa/query/converter/GraphQLJpaConverterTests.java
+++ b/graphql-jpa-query-schema/src/test/java/com/introproventures/graphql/jpa/query/converter/GraphQLJpaConverterTests.java
@@ -36,11 +36,8 @@ import com.introproventures.graphql.jpa.query.converter.model.TaskVariableEntity
 import com.introproventures.graphql.jpa.query.converter.model.VariableValue;
 import com.introproventures.graphql.jpa.query.schema.GraphQLExecutor;
 import com.introproventures.graphql.jpa.query.schema.GraphQLSchemaBuilder;
-import com.introproventures.graphql.jpa.query.schema.JavaScalars;
-import com.introproventures.graphql.jpa.query.schema.JavaScalars.GraphQLObjectCoercing;
 import com.introproventures.graphql.jpa.query.schema.impl.GraphQLJpaExecutor;
 import com.introproventures.graphql.jpa.query.schema.impl.GraphQLJpaSchemaBuilder;
-import graphql.schema.GraphQLScalarType;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -67,12 +64,9 @@ public class GraphQLJpaConverterTests {
 
         @Bean
         public GraphQLSchemaBuilder graphQLSchemaBuilder(final EntityManager entityManager) {
-            JavaScalars.register(JsonNode.class, new GraphQLScalarType("Json", "Json type", new GraphQLObjectCoercing()));    
-            JavaScalars.register(VariableValue.class, new GraphQLScalarType("VariableValue", "VariableValue Type", new GraphQLObjectCoercing()));    
-            
             return new GraphQLJpaSchemaBuilder(entityManager)
-                .name("HashMapSchema")
-                .description("Json Entity test schema");
+                .name("CustomAttributeConverterSchema")
+                .description("Custom Attribute Converter Schema");
         }
         
     }

--- a/graphql-jpa-query-schema/src/test/java/com/introproventures/graphql/jpa/query/converter/GraphQLJpaConverterTests.java
+++ b/graphql-jpa-query-schema/src/test/java/com/introproventures/graphql/jpa/query/converter/GraphQLJpaConverterTests.java
@@ -32,6 +32,7 @@ import javax.transaction.Transactional;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.introproventures.graphql.jpa.query.converter.model.JsonEntity;
+import com.introproventures.graphql.jpa.query.converter.model.TaskVariableEntity;
 import com.introproventures.graphql.jpa.query.converter.model.VariableValue;
 import com.introproventures.graphql.jpa.query.schema.GraphQLExecutor;
 import com.introproventures.graphql.jpa.query.schema.GraphQLSchemaBuilder;
@@ -66,7 +67,6 @@ public class GraphQLJpaConverterTests {
 
         @Bean
         public GraphQLSchemaBuilder graphQLSchemaBuilder(final EntityManager entityManager) {
-            
             JavaScalars.register(JsonNode.class, new GraphQLScalarType("Json", "Json type", new GraphQLObjectCoercing()));    
             JavaScalars.register(VariableValue.class, new GraphQLScalarType("VariableValue", "VariableValue Type", new GraphQLObjectCoercing()));    
             
@@ -113,6 +113,27 @@ public class GraphQLJpaConverterTests {
                                                                                  new String[] {"1","2","3","4","5"}));
         criteria.select(json)
                 .where(builder.equal(json.get("attributes"), value));
+        
+        // when:
+        List<?> result = entityManager.createQuery(criteria).getResultList();
+
+        // then:
+        assertThat(result).isNotEmpty();
+        assertThat(result).hasSize(1);
+    }
+
+    @Test
+    @Transactional
+    public void criteriaTester2() {
+        CriteriaBuilder builder = entityManager.getCriteriaBuilder();
+        CriteriaQuery<TaskVariableEntity> criteria = builder.createQuery(TaskVariableEntity.class);
+        Root<TaskVariableEntity> taskVariable = criteria.from(TaskVariableEntity.class);
+        
+        Boolean object = new Boolean(true); 
+
+        VariableValue<Boolean> variableValue = new VariableValue<>(object);
+        criteria.select(taskVariable)
+                .where(builder.equal(taskVariable.get("value"), variableValue));
         
         // when:
         List<?> result = entityManager.createQuery(criteria).getResultList();
@@ -239,7 +260,7 @@ public class GraphQLJpaConverterTests {
     @Test
     public void queryTaskVariablesWhereSearchCriteriaVariableBinding() {
         //given
-        String query = "query($value: VariableValue!) {" + 
+        String query = "query($value: Object!) {" + 
                 "  TaskVariables(where: {" 
                 +     "value: {LOCATE: $value }" 
                 + "}) {" + 
@@ -266,7 +287,7 @@ public class GraphQLJpaConverterTests {
     @Test
     public void queryProcessVariablesWhereSearchCriteriaVariableBindings() {
         //given
-        String query = "query($value: VariableValue!)  {" + 
+        String query = "query($value: Object!)  {" + 
                 " ProcessVariables(where: {" 
                 +     "value: {LOCATE: $value}" 
                 + "}) {" + 
@@ -312,5 +333,121 @@ public class GraphQLJpaConverterTests {
         // then
         assertThat(result.toString()).isEqualTo(expected);
     }
+
+    @Test
+    public void queryProcessVariablesWhereWithEQStringSearchCriteria() {
+        //given
+        String query = "query {" + 
+                " TaskVariables(where: {" 
+                +     "value: {EQ: \"data\"}" 
+                + "}) {" + 
+                "    select {" + 
+                "      name" + 
+                "      value" + 
+                "    }" + 
+                "  }" + 
+                "}";
+        
+        String expected = "{TaskVariables={select=[{name=variable1, value=data}]}}";
+
+        //when
+        Object result = executor.execute(query).getData();
+
+        // then
+        assertThat(result.toString()).isEqualTo(expected);
+    }    
+    
+    @Test
+    public void queryProcessVariablesWhereWithEQBooleanSearchCriteria() {
+        //given
+        String query = "query {" + 
+                " TaskVariables(where: {" 
+                +     "value: {EQ: true}" 
+                + "}) {" + 
+                "    select {" + 
+                "      name" + 
+                "      value" + 
+                "    }" + 
+                "  }" + 
+                "}";
+        
+        String expected = "{TaskVariables={select=[{name=variable2, value=true}]}}";
+
+        //when
+        Object result = executor.execute(query).getData();
+
+        // then
+        assertThat(result.toString()).isEqualTo(expected);
+    }    
+ 
+    @Test
+    public void queryProcessVariablesWhereWithEQNullSearchCriteria() {
+        //given
+        String query = "query {" + 
+                " TaskVariables(where: {" 
+                +     "value: {EQ: null}" 
+                + "}) {" + 
+                "    select {" + 
+                "      name" + 
+                "      value" + 
+                "    }" + 
+                "  }" + 
+                "}";
+        
+        String expected = "{TaskVariables={select=[{name=variable3, value=null}]}}";
+
+        //when
+        Object result = executor.execute(query).getData();
+
+        // then
+        assertThat(result.toString()).isEqualTo(expected);
+    }    
+
+    @Test
+    public void queryProcessVariablesWhereWithEQIntSearchCriteria() {
+        //given
+        String query = "query {" + 
+                " TaskVariables(where: {" 
+                +     "value: {EQ: 12345}" 
+                + "}) {" + 
+                "    select {" + 
+                "      name" + 
+                "      value" + 
+                "    }" + 
+                "  }" + 
+                "}";
+        
+        String expected = "{TaskVariables={select=[{name=variable6, value=12345}]}}";
+
+        //when
+        Object result = executor.execute(query).getData();
+
+        // then
+        assertThat(result.toString()).isEqualTo(expected);
+    }
+    
+    @Test
+    public void queryProcessVariablesWhereWithEQDoubleSearchCriteria() {
+        //given
+        String query = "query {" + 
+                " TaskVariables(where: {" 
+                +     "value: {EQ: 1.2345}" 
+                + "}) {" + 
+                "    select {" + 
+                "      name" + 
+                "      value" + 
+                "    }" + 
+                "  }" + 
+                "}";
+        
+        String expected = "{TaskVariables={select=[{name=variable5, value=1.2345}]}}";
+
+        //when
+        Object result = executor.execute(query).getData();
+
+        // then
+        assertThat(result.toString()).isEqualTo(expected);
+    }    
+    
     
 }

--- a/graphql-jpa-query-schema/src/test/java/com/introproventures/graphql/jpa/query/converter/GraphQLJpaConverterTests.java
+++ b/graphql-jpa-query-schema/src/test/java/com/introproventures/graphql/jpa/query/converter/GraphQLJpaConverterTests.java
@@ -260,7 +260,7 @@ public class GraphQLJpaConverterTests {
     @Test
     public void queryTaskVariablesWhereSearchCriteriaVariableBinding() {
         //given
-        String query = "query($value: Object!) {" + 
+        String query = "query($value: VariableValue!) {" + 
                 "  TaskVariables(where: {" 
                 +     "value: {LOCATE: $value }" 
                 + "}) {" + 
@@ -287,7 +287,7 @@ public class GraphQLJpaConverterTests {
     @Test
     public void queryProcessVariablesWhereSearchCriteriaVariableBindings() {
         //given
-        String query = "query($value: Object!)  {" + 
+        String query = "query($value: VariableValue!)  {" + 
                 " ProcessVariables(where: {" 
                 +     "value: {LOCATE: $value}" 
                 + "}) {" + 

--- a/graphql-jpa-query-schema/src/test/resources/GraphQLJpaConverterTests.sql
+++ b/graphql-jpa-query-schema/src/test/resources/GraphQLJpaConverterTests.sql
@@ -9,7 +9,8 @@ insert into PROCESS_VARIABLE (create_time, execution_id, last_updated_time, name
 insert into TASK_VARIABLE (create_time, execution_id, last_updated_time, name, process_instance_id, task_id, type, value) values
   (CURRENT_TIMESTAMP, 'execution_id', CURRENT_TIMESTAMP, 'variable1', 0, '1', 'string', '{"value":"data"}'),
   (CURRENT_TIMESTAMP, 'execution_id', CURRENT_TIMESTAMP, 'variable2', 0, '1', 'boolean', '{"value":true}'),
-  (CURRENT_TIMESTAMP, 'execution_id', CURRENT_TIMESTAMP, 'variable3', 0, '2', 'string', '{"value":null}'),
+  (CURRENT_TIMESTAMP, 'execution_id', CURRENT_TIMESTAMP, 'variable3', 0, '2', 'null', '{"value":null}'),
   (CURRENT_TIMESTAMP, 'execution_id', CURRENT_TIMESTAMP, 'variable4', 0, '2', 'json', '{"value":{"key":"data"}}'),
-  (CURRENT_TIMESTAMP, 'execution_id', CURRENT_TIMESTAMP, 'variable5', 1, '4', 'double', '{"value":1.0}'),
-  (CURRENT_TIMESTAMP, 'execution_id', CURRENT_TIMESTAMP, 'variable6', 1, '4', 'json', '{"value":[1,2,3,4,5]}');	
+  (CURRENT_TIMESTAMP, 'execution_id', CURRENT_TIMESTAMP, 'variable5', 1, '4', 'double', '{"value":1.2345}'),
+  (CURRENT_TIMESTAMP, 'execution_id', CURRENT_TIMESTAMP, 'variable6', 1, '4', 'int', '{"value":12345}'),
+  (CURRENT_TIMESTAMP, 'execution_id', CURRENT_TIMESTAMP, 'variable7', 1, '4', 'json', '{"value":[1,2,3,4,5]}');	


### PR DESCRIPTION
This PR adds support for `EQ` predicate with custom attribute types annotated with `@Convert`, i.e.

Given entity class with custom attribute:

```java
@Entity("TaskVariable")
public TaskVariableEntity {

    @Id
    @GeneratedValue(strategy = GenerationType.IDENTITY)
    private Long id;

    private String type;

    private String name;

    @Convert(converter = VariableValueJsonConverter.class)
    @Column(columnDefinition="text")
    private VariableValue<?> value;
}
```
And custom attribute value implementation with provided constructor having single Object argument :

```java
public class VariableValue<T> {

    private T value;

    public VariableValue() {
    }
    // Required constructor
    public VariableValue(T value) {
        this.value = value;
    }

    public T getValue() {
        return value;
    }
}    
```

And AttributeConverter class:

```java
public class VariableValueJsonConverter implements AttributeConverter<VariableValue<?>, String> {

    private static ObjectMapper objectMapper = new ObjectMapper()
            .disable(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES);

    public VariableValueJsonConverter() {
    }

    @Override
    public String convertToDatabaseColumn(VariableValue<?> variableValue) {
        try {
            return objectMapper.writeValueAsString(variableValue);
        } catch (JsonProcessingException e) {
            throw new QueryException("Unable to serialize variable.", e);
        }
    }

    @Override
    public VariableValue<?> convertToEntityAttribute(String dbData) {
        try {
            return objectMapper.readValue(dbData, VariableValue.class);
        } catch (IOException e) {
            throw new QueryException("Unable to deserialize variable.", e);
        }
    }
    
}
```

With the following values stored as Json:

```
insert into TASK_VARIABLE (name, type, value) values
  ('variable1', 'string', '{"value":"data"}'),
  ('variable2', 'boolean', '{"value":true}'),
  ('variable3', 'object', '{"value":null}'),
  ('variable4', 'json', '{"value":{"key":"data"}}'),
  ('variable5', 'double', '{"value":1.2345}'),
  ('variable6', 'int', '{"value":12345}'),
  ('variable7', 'json', '{"value":[1,2,3,4,5]}');	
```
When the following query with EQ predicate for value attribute is excuted:

```
query {
  TaskVariables(where: {
    name: {EQ: "variable2"}
    value: {EQ: true}
  }) {
    select {
       name
       value
    }
  }
}
```
Then the result is as follows:

```json
{
  "data": {
    "TaskVariables": {
      "select": [
        {
          "name": "variable2",
          "value": true
        }
      ]
    }
  }
}
```
See tests for other examples: https://github.com/introproventures/graphql-jpa-query/pull/133/files#diff-6d177f64d7dab4deb5f58343b51bd18aR332