### PR TITLE
fix: enable default distinct  configuration property

### DIFF
--- a/graphql-jpa-query-autoconfigure/src/main/java/com/introproventures/graphql/jpa/query/autoconfigure/GraphQLJpaQueryProperties.java
+++ b/graphql-jpa-query-autoconfigure/src/main/java/com/introproventures/graphql/jpa/query/autoconfigure/GraphQLJpaQueryProperties.java
@@ -44,7 +44,7 @@ public class GraphQLJpaQueryProperties {
     /**
      * Enable or disable distinct distinct sql query fetcher.
      */
-    private boolean isDefaultDistinct = false;
+    private boolean isDefaultDistinct = true;
 
     /**
      * Enable or disable QraphQL module services.
@@ -105,7 +105,7 @@ public class GraphQLJpaQueryProperties {
     /**
      * @return the distinctFetcher
      */
-    public boolean isDefautltDistinct() {
+    public boolean isDefaultDistinct() {
         return isDefaultDistinct;
     }
 

--- a/graphql-jpa-query-autoconfigure/src/main/resources/com/introproventures/graphql/jpa/query/boot/autoconfigure/default.properties
+++ b/graphql-jpa-query-autoconfigure/src/main/resources/com/introproventures/graphql/jpa/query/boot/autoconfigure/default.properties
@@ -1,6 +1,6 @@
 spring.graphql.jpa.query.name=Query
-spring.graphql.jpa.query.description=
+spring.graphql.jpa.query.description=Query root
 spring.graphql.jpa.query.useDistinctParameter=false
-spring.graphql.jpa.query.defaultDistinct=false
+spring.graphql.jpa.query.defaultDistinct=true
 spring.graphql.jpa.query.enabled=true
 spring.graphql.jpa.query.path=/graphql

--- a/graphql-jpa-query-autoconfigure/src/test/java/com/introproventures/graphql/jpa/query/autoconfigure/GraphQLSchemaAutoConfigurationTest.java
+++ b/graphql-jpa-query-autoconfigure/src/test/java/com/introproventures/graphql/jpa/query/autoconfigure/GraphQLSchemaAutoConfigurationTest.java
@@ -4,6 +4,11 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 import java.util.Map;
 
+import graphql.GraphQL;
+import graphql.Scalars;
+import graphql.schema.GraphQLFieldDefinition;
+import graphql.schema.GraphQLObjectType;
+import graphql.schema.GraphQLSchema;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -13,18 +18,15 @@ import org.springframework.boot.test.context.SpringBootTest.WebEnvironment;
 import org.springframework.stereotype.Component;
 import org.springframework.test.context.junit4.SpringRunner;
 
-import graphql.GraphQL;
-import graphql.Scalars;
-import graphql.schema.GraphQLFieldDefinition;
-import graphql.schema.GraphQLObjectType;
-import graphql.schema.GraphQLSchema;
-
 @RunWith(SpringRunner.class)
 @SpringBootTest(webEnvironment=WebEnvironment.NONE)
 public class GraphQLSchemaAutoConfigurationTest {
     
     @Autowired
     private GraphQLSchema graphQLSchema;
+
+    @Autowired
+    private GraphQLJpaQueryProperties graphQLJpaQueryProperties;
     
     @SpringBootApplication
     static class Application {
@@ -96,5 +98,12 @@ public class GraphQLSchemaAutoConfigurationTest {
     }
     
 
+    @Test
+    public void configurationProperties() {
+        // given
+        assertThat(graphQLJpaQueryProperties.isDefaultDistinct()).isTrue();
+        assertThat(graphQLJpaQueryProperties.isUseDistinctParameter()).isFalse();
+    }
+        
 
 }

--- a/graphql-jpa-query-example-merge/src/main/java/com/introproventures/graphql/jpa/query/example/books/BooksSchemaConfiguration.java
+++ b/graphql-jpa-query-example-merge/src/main/java/com/introproventures/graphql/jpa/query/example/books/BooksSchemaConfiguration.java
@@ -90,7 +90,7 @@ public class BooksSchemaConfiguration {
                     new GraphQLJpaSchemaBuilder(entityManager)
                         .name("GraphQLBooks")
                         .useDistinctParameter(properties.isUseDistinctParameter())
-                        .setDefaultDistinct(properties.isDefautltDistinct())
+                        .setDefaultDistinct(properties.isDefaultDistinct())
                         .build()
             );
         }

--- a/graphql-jpa-query-example-merge/src/main/resources/application.yml
+++ b/graphql-jpa-query-example-merge/src/main/resources/application.yml
@@ -10,9 +10,9 @@ spring:
       query:
         name: Query
         description: Combined GraphQL Jpa Query for Starwars and Books Example
-        useDistinctParameter: true
+        use-distinct-parameter: true
         enabled: true
-        path: graphql
+        path: /graphql
         
 starwars:
   hikari:

--- a/graphql-jpa-query-schema/src/main/java/com/introproventures/graphql/jpa/query/schema/impl/GraphQLJpaQueryDataFetcher.java
+++ b/graphql-jpa-query-schema/src/main/java/com/introproventures/graphql/jpa/query/schema/impl/GraphQLJpaQueryDataFetcher.java
@@ -47,7 +47,7 @@ import graphql.schema.GraphQLObjectType;
  */
 class GraphQLJpaQueryDataFetcher extends QraphQLJpaBaseDataFetcher {
 
-    private boolean defaultDistinct = false;
+    private boolean defaultDistinct = true;
 	
     private static final String HIBERNATE_QUERY_PASS_DISTINCT_THROUGH = "hibernate.query.passDistinctThrough";
     private static final String ORG_HIBERNATE_CACHEABLE = "org.hibernate.cacheable";


### PR DESCRIPTION
This PR fixes GraphQLJPAQueryProperites.isDefaultDistinct typo and enables default distinct resolution configuration. 