### PR TITLE
feat: add IN | NIN predicate for custom attribute types

### DIFF
--- a/graphql-jpa-query-schema/src/test/java/com/introproventures/graphql/jpa/query/converter/GraphQLJpaConverterTests.java
+++ b/graphql-jpa-query-schema/src/test/java/com/introproventures/graphql/jpa/query/converter/GraphQLJpaConverterTests.java
@@ -449,4 +449,109 @@ public class GraphQLJpaConverterTests {
     }    
     
     
+    @Test
+    public void queryProcessVariablesWhereWithINSingleValueSearchCriteria() {
+        //given
+        String query = "query {" + 
+                " TaskVariables(where: {" 
+                +     "value: {IN: 1.2345}" 
+                + "}) {" + 
+                "    select {" + 
+                "      name" + 
+                "      value" + 
+                "    }" + 
+                "  }" + 
+                "}";
+        
+        String expected = "{TaskVariables={select=[{name=variable5, value=1.2345}]}}";
+
+        //when
+        Object result = executor.execute(query).getData();
+
+        // then
+        assertThat(result.toString()).isEqualTo(expected);
+    }    
+        
+    @Test
+    public void queryProcessVariablesWhereWithINListValueSearchCriteria() {
+        //given
+        String query = "query {" + 
+                " TaskVariables(where: {" 
+                +     "value: {IN: [1.2345]}" 
+                + "}) {" + 
+                "    select {" + 
+                "      name" + 
+                "      value" + 
+                "    }" + 
+                "  }" + 
+                "}";
+        
+        String expected = "{TaskVariables={select=[{name=variable5, value=1.2345}]}}";
+
+        //when
+        Object result = executor.execute(query).getData();
+
+        // then
+        assertThat(result.toString()).isEqualTo(expected);
+    }        
+    
+    @Test
+    public void queryProcessVariablesWhereWithNINListValueSearchCriteria() {
+        //given
+        String query = "query {" + 
+                " TaskVariables(where: {" 
+                +     "value: {NIN: [null]}" 
+                + "}) {" + 
+                "    select {" + 
+                "      name" + 
+                "      value" + 
+                "    }" + 
+                "  }" + 
+                "}";
+        
+        String expected = "{TaskVariables={select=["
+                + "{name=variable1, value=data}, "
+                + "{name=variable2, value=true}, "
+                + "{name=variable4, value={key=data}}, "
+                + "{name=variable5, value=1.2345}, "
+                + "{name=variable6, value=12345}, "
+                + "{name=variable7, value=[1, 2, 3, 4, 5]}]}}";
+
+        //when
+        Object result = executor.execute(query).getData();
+
+        // then
+        assertThat(result.toString()).isEqualTo(expected);
+    }
+    
+    @Test
+    public void queryProcessVariablesWhereWithNINSingleValueSearchCriteria() {
+        //given
+        String query = "query {" + 
+                " TaskVariables(where: {" 
+                +     "value: {NIN: null}" 
+                + "}) {" + 
+                "    select {" + 
+                "      name" + 
+                "      value" + 
+                "    }" + 
+                "  }" + 
+                "}";
+        
+        String expected = "{TaskVariables={select=["
+                + "{name=variable1, value=data}, "
+                + "{name=variable2, value=true}, "
+                + "{name=variable4, value={key=data}}, "
+                + "{name=variable5, value=1.2345}, "
+                + "{name=variable6, value=12345}, "
+                + "{name=variable7, value=[1, 2, 3, 4, 5]}]}}";
+
+        //when
+        Object result = executor.execute(query).getData();
+
+        // then
+        assertThat(result.toString()).isEqualTo(expected);
+    }          
+     
+    
 }

--- a/graphql-jpa-query-schema/src/test/java/com/introproventures/graphql/jpa/query/converter/GraphQLJpaConverterTests.java
+++ b/graphql-jpa-query-schema/src/test/java/com/introproventures/graphql/jpa/query/converter/GraphQLJpaConverterTests.java
@@ -553,5 +553,33 @@ public class GraphQLJpaConverterTests {
         assertThat(result.toString()).isEqualTo(expected);
     }          
      
-    
+    @Test
+    public void queryProcessVariablesWhereWithINListTypedValueSearchCriteria() {
+        //given
+        String query = "query {" + 
+                " TaskVariables(where: {" 
+                +     "value: {IN: [null, true, \"data\", 12345, 1.2345]}" 
+                + "}) {" + 
+                "    select {" + 
+                "      name" + 
+                "      value" + 
+                "    }" + 
+                "  }" + 
+                "}";
+        
+        String expected = "{TaskVariables={select=["
+                + "{name=variable1, value=data}, "
+                + "{name=variable2, value=true}, "
+                + "{name=variable3, value=null}, "
+                + "{name=variable5, value=1.2345}, "
+                + "{name=variable6, value=12345}"
+                + "]}}";
+
+        //when
+        Object result = executor.execute(query).getData();
+
+        // then
+        assertThat(result.toString()).isEqualTo(expected);
+    }          
+         
 }


### PR DESCRIPTION
This PR add support for IN, NIN predicates in criteria expressions for custom attributes, i.e.

```
query {
  TaskVariables(where: { 
    value: {IN: [null, true, "data", 12345, 1.2345]} 
  }) {
    select {
      name
      value
    }
  }
}
```

```
query {
  TaskVariables(where: { 
    value: {NIN: true} 
  }) {
    select {
      name
      value
    }
  }
}
```