### PR TITLE
fix: build join fetch from selection graph

### DIFF
--- a/graphql-jpa-query-schema/src/test/java/com/introproventures/graphql/jpa/query/schema/GraphQLExecutorListCriteriaTests.java
+++ b/graphql-jpa-query-schema/src/test/java/com/introproventures/graphql/jpa/query/schema/GraphQLExecutorListCriteriaTests.java
@@ -90,8 +90,10 @@ public class GraphQLExecutorListCriteriaTests {
                 "}";
 
         String expected = "{Authors={select=["
-                + "{id=1, name=Leo Tolstoy, books=[{id=2, title=War and Peace, genre=NOVEL}]}"
-                + "]}}";
+                + "{id=1, name=Leo Tolstoy, books=["
+                +   "{id=2, title=War and Peace, genre=NOVEL}, "
+                +   "{id=3, title=Anna Karenina, genre=NOVEL}]"
+                + "}]}}";
 
         //when:
         Object result = executor.execute(query).getData();

--- a/graphql-jpa-query-schema/src/test/java/com/introproventures/graphql/jpa/query/schema/GraphQLExecutorTests.java
+++ b/graphql-jpa-query-schema/src/test/java/com/introproventures/graphql/jpa/query/schema/GraphQLExecutorTests.java
@@ -638,8 +638,13 @@ public class GraphQLExecutorTests {
                 "  }" +
                 "}";
 
-        String expected = "{Authors={select=["
-                + "{id=1, name=Leo Tolstoy, books=[{id=2, title=War and Peace, genre=NOVEL}]}"
+        String expected = "{Authors={select=[{"
+                +   "id=1, "
+                +   "name=Leo Tolstoy, "
+                +   "books=["
+                +       "{id=2, title=War and Peace, genre=NOVEL}, "
+                +       "{id=3, title=Anna Karenina, genre=NOVEL}"
+                +   "]}"
                 + "]}}";
 
         //when:
@@ -674,7 +679,9 @@ public class GraphQLExecutorTests {
                 "}";
 
         String expected = "{Authors={select=["
-                + "{id=1, name=Leo Tolstoy, books=[{id=2, title=War and Peace, genre=NOVEL}]}"
+                + "{id=1, name=Leo Tolstoy, books=["
+                +   "{id=2, title=War and Peace, genre=NOVEL}, "
+                +   "{id=3, title=Anna Karenina, genre=NOVEL}]}"
                 + "]}}";
 
         //when:
@@ -830,15 +837,14 @@ public class GraphQLExecutorTests {
 
         String expected = "{Books={select=[{"
                 + "id=2, "
-                + "title=War and Peace, "
-                + "genre=NOVEL, "
+                + "title=War and Peace, genre=NOVEL, "
                 + "author={"
                 +   "id=1, "
                 +   "name=Leo Tolstoy, "
                 +   "books=["
-                +       "{id=3, title=Anna Karenina, genre=NOVEL}"
-                +   "]"
-                + "}"
+                +       "{id=3, title=Anna Karenina, genre=NOVEL}, "
+                +       "{id=2, title=War and Peace, genre=NOVEL}"
+                +   "]}"
                 + "}]}}";
 
         //when:

--- a/graphql-jpa-query-schema/src/test/java/com/introproventures/graphql/jpa/query/schema/StarwarsQueryExecutorTests.java
+++ b/graphql-jpa-query-schema/src/test/java/com/introproventures/graphql/jpa/query/schema/StarwarsQueryExecutorTests.java
@@ -402,10 +402,10 @@ public class StarwarsQueryExecutorTests {
 
 
         String expected = "{Humans={select=["
-            + "{name=Luke Skywalker, appearsIn=[A_NEW_HOPE, EMPIRE_STRIKES_BACK, RETURN_OF_THE_JEDI, THE_FORCE_AWAKENS]}, "
-            + "{name=Han Solo, appearsIn=[A_NEW_HOPE, EMPIRE_STRIKES_BACK, RETURN_OF_THE_JEDI, THE_FORCE_AWAKENS]}, "
-            + "{name=Leia Organa, appearsIn=[A_NEW_HOPE, EMPIRE_STRIKES_BACK, RETURN_OF_THE_JEDI, THE_FORCE_AWAKENS]}"
-            + "]}}";
+                + "{name=Luke Skywalker, appearsIn=[A_NEW_HOPE, THE_FORCE_AWAKENS, EMPIRE_STRIKES_BACK, RETURN_OF_THE_JEDI]}, "
+                + "{name=Han Solo, appearsIn=[A_NEW_HOPE, THE_FORCE_AWAKENS, EMPIRE_STRIKES_BACK, RETURN_OF_THE_JEDI]}, "
+                + "{name=Leia Organa, appearsIn=[A_NEW_HOPE, THE_FORCE_AWAKENS, EMPIRE_STRIKES_BACK, RETURN_OF_THE_JEDI]}"
+                + "]}}";
 
         //when:
         Object result = executor.execute(query).getData();
@@ -741,30 +741,39 @@ public class StarwarsQueryExecutorTests {
                 "}";
 
         String expected = "{Humans={select=["
-                + "{id=1000, name=Luke Skywalker, favoriteDroid={name=C-3PO}, friends=["
-                +   "{name=C-3PO, appearsIn=[A_NEW_HOPE]}, "
-                +   "{name=Han Solo, appearsIn=[A_NEW_HOPE]}, "
-                +   "{name=Leia Organa, appearsIn=[A_NEW_HOPE]}, "
-                +   "{name=R2-D2, appearsIn=[A_NEW_HOPE]}"
-                + "]}, "
-                + "{id=1001, name=Darth Vader, favoriteDroid={name=R2-D2}, friends=["
-                +   "{name=Wilhuff Tarkin, appearsIn=[A_NEW_HOPE]}"
-                + "]}, "
-                + "{id=1002, name=Han Solo, favoriteDroid=null, friends=["
-                +   "{name=Leia Organa, appearsIn=[A_NEW_HOPE]}, "
-                +   "{name=Luke Skywalker, appearsIn=[A_NEW_HOPE]}, "
-                +   "{name=R2-D2, appearsIn=[A_NEW_HOPE]}"
-                + "]}, "
-                + "{id=1003, name=Leia Organa, favoriteDroid=null, friends=["
-                +   "{name=C-3PO, appearsIn=[A_NEW_HOPE]}, "
-                +   "{name=Han Solo, appearsIn=[A_NEW_HOPE]}, "
-                +   "{name=Luke Skywalker, appearsIn=[A_NEW_HOPE]}, "
-                +   "{name=R2-D2, appearsIn=[A_NEW_HOPE]}"
-                + "]}, "
-                + "{id=1004, name=Wilhuff Tarkin, favoriteDroid=null, friends=["
-                +   "{name=Darth Vader, appearsIn=[A_NEW_HOPE]}"
-                + "]}"
-                + "]}}";
+                + "{id=1000, name=Luke Skywalker, favoriteDroid={name=C-3PO}, "
+                +   "friends=["
+                +       "{name=C-3PO, appearsIn=[A_NEW_HOPE, EMPIRE_STRIKES_BACK, RETURN_OF_THE_JEDI, THE_FORCE_AWAKENS]}, "
+                +       "{name=Han Solo, appearsIn=[A_NEW_HOPE, EMPIRE_STRIKES_BACK, RETURN_OF_THE_JEDI, THE_FORCE_AWAKENS]}, "
+                +       "{name=Leia Organa, appearsIn=[A_NEW_HOPE, EMPIRE_STRIKES_BACK, RETURN_OF_THE_JEDI, THE_FORCE_AWAKENS]}, "
+                +       "{name=R2-D2, appearsIn=[A_NEW_HOPE, EMPIRE_STRIKES_BACK, RETURN_OF_THE_JEDI, THE_FORCE_AWAKENS]}"
+                +   "]"
+                + "}, "
+                + "{id=1001, name=Darth Vader, favoriteDroid={name=R2-D2}, "
+                +   "friends=["
+                +       "{name=Wilhuff Tarkin, appearsIn=[A_NEW_HOPE]}"
+                +   "]"
+                + "}, "
+                + "{id=1002, name=Han Solo, favoriteDroid=null, "
+                +   "friends=["
+                +       "{name=Leia Organa, appearsIn=[A_NEW_HOPE, EMPIRE_STRIKES_BACK, RETURN_OF_THE_JEDI, THE_FORCE_AWAKENS]}, "
+                +       "{name=Luke Skywalker, appearsIn=[A_NEW_HOPE, EMPIRE_STRIKES_BACK, RETURN_OF_THE_JEDI, THE_FORCE_AWAKENS]}, "
+                +       "{name=R2-D2, appearsIn=[A_NEW_HOPE, EMPIRE_STRIKES_BACK, RETURN_OF_THE_JEDI, THE_FORCE_AWAKENS]}"
+                +   "]"
+                + "}, "
+                + "{id=1003, name=Leia Organa, favoriteDroid=null, "
+                +   "friends=["
+                +       "{name=C-3PO, appearsIn=[A_NEW_HOPE, EMPIRE_STRIKES_BACK, RETURN_OF_THE_JEDI, THE_FORCE_AWAKENS]}, "
+                +       "{name=Han Solo, appearsIn=[A_NEW_HOPE, EMPIRE_STRIKES_BACK, RETURN_OF_THE_JEDI, THE_FORCE_AWAKENS]}, "
+                +       "{name=Luke Skywalker, appearsIn=[A_NEW_HOPE, EMPIRE_STRIKES_BACK, RETURN_OF_THE_JEDI, THE_FORCE_AWAKENS]}, "
+                +       "{name=R2-D2, appearsIn=[A_NEW_HOPE, EMPIRE_STRIKES_BACK, RETURN_OF_THE_JEDI, THE_FORCE_AWAKENS]}"
+                +   "]"
+                + "}, "
+                + "{id=1004, name=Wilhuff Tarkin, favoriteDroid=null, "
+                +   "friends=["
+                +       "{name=Darth Vader, appearsIn=[A_NEW_HOPE, EMPIRE_STRIKES_BACK, RETURN_OF_THE_JEDI]}"
+                +   "]"
+                + "}]}}";
 
         //when:
         Object result = executor.execute(query).getData();
@@ -1030,9 +1039,9 @@ public class StarwarsQueryExecutorTests {
                 +   "}"
                 + "}, "
                 + "friends=["
+                +   "{name=Leia Organa}, "
                 +   "{name=C-3PO}, "
                 +   "{name=Han Solo}, "
-                +   "{name=Leia Organa}, "
                 +   "{name=R2-D2}"
                 + "]}"
                 + "]}}";
@@ -1067,14 +1076,16 @@ public class StarwarsQueryExecutorTests {
                 "  }" +
                 "}";
 
-        String expected = "{Humans={select=["
-                +   "{id=1000, name=Luke Skywalker, favoriteDroid={name=C-3PO}, friends=["
-                +     "{name=C-3PO, appearsIn=[A_NEW_HOPE]}, "
-                +     "{name=Han Solo, appearsIn=[A_NEW_HOPE]}, "
-                +     "{name=Leia Organa, appearsIn=[A_NEW_HOPE]}, "
-                +     "{name=R2-D2, appearsIn=[A_NEW_HOPE]}"
-                +   "]}"
-                + "]}}";
+        String expected = "{Humans={select=[{"
+                +   "id=1000, name=Luke Skywalker, "
+                +   "favoriteDroid={name=C-3PO}, "
+                +   "friends=["
+                +       "{name=C-3PO, appearsIn=[A_NEW_HOPE, EMPIRE_STRIKES_BACK, RETURN_OF_THE_JEDI, THE_FORCE_AWAKENS]}, "
+                +       "{name=Han Solo, appearsIn=[A_NEW_HOPE, EMPIRE_STRIKES_BACK, RETURN_OF_THE_JEDI, THE_FORCE_AWAKENS]}, "
+                +       "{name=Leia Organa, appearsIn=[A_NEW_HOPE, EMPIRE_STRIKES_BACK, RETURN_OF_THE_JEDI, THE_FORCE_AWAKENS]}, "
+                +       "{name=R2-D2, appearsIn=[A_NEW_HOPE, EMPIRE_STRIKES_BACK, RETURN_OF_THE_JEDI, THE_FORCE_AWAKENS]}"
+                +   "]"
+                + "}]}}";
 
         //when:
         Object result = executor.execute(query).getData();
@@ -1158,11 +1169,11 @@ public class StarwarsQueryExecutorTests {
                 "}";
 
         String expected = "{Characters={select=["
-                + "{id=1000, name=Luke Skywalker, appearsIn=[A_NEW_HOPE, EMPIRE_STRIKES_BACK, RETURN_OF_THE_JEDI, THE_FORCE_AWAKENS]}, "
-                + "{id=1002, name=Han Solo, appearsIn=[A_NEW_HOPE, EMPIRE_STRIKES_BACK, RETURN_OF_THE_JEDI, THE_FORCE_AWAKENS]}, "
-                + "{id=1003, name=Leia Organa, appearsIn=[A_NEW_HOPE, EMPIRE_STRIKES_BACK, RETURN_OF_THE_JEDI, THE_FORCE_AWAKENS]}, "
-                + "{id=2000, name=C-3PO, appearsIn=[A_NEW_HOPE, EMPIRE_STRIKES_BACK, RETURN_OF_THE_JEDI, THE_FORCE_AWAKENS]}, "
-                + "{id=2001, name=R2-D2, appearsIn=[A_NEW_HOPE, EMPIRE_STRIKES_BACK, RETURN_OF_THE_JEDI, THE_FORCE_AWAKENS]}"
+                + "{id=1000, name=Luke Skywalker, appearsIn=[A_NEW_HOPE, THE_FORCE_AWAKENS, EMPIRE_STRIKES_BACK, RETURN_OF_THE_JEDI]}, "
+                + "{id=1002, name=Han Solo, appearsIn=[A_NEW_HOPE, THE_FORCE_AWAKENS, EMPIRE_STRIKES_BACK, RETURN_OF_THE_JEDI]}, "
+                + "{id=1003, name=Leia Organa, appearsIn=[A_NEW_HOPE, THE_FORCE_AWAKENS, EMPIRE_STRIKES_BACK, RETURN_OF_THE_JEDI]}, "
+                + "{id=2000, name=C-3PO, appearsIn=[A_NEW_HOPE, THE_FORCE_AWAKENS, EMPIRE_STRIKES_BACK, RETURN_OF_THE_JEDI]}, "
+                + "{id=2001, name=R2-D2, appearsIn=[A_NEW_HOPE, THE_FORCE_AWAKENS, EMPIRE_STRIKES_BACK, RETURN_OF_THE_JEDI]}"
                 + "]}}";
 
         //when:
@@ -1198,7 +1209,7 @@ public class StarwarsQueryExecutorTests {
                 +   "name=Luke Skywalker, "
                 +   "homePlanet=Tatooine, "
                 +   "favoriteDroid={name=C-3PO}, "
-                +   "appearsIn=[A_NEW_HOPE, EMPIRE_STRIKES_BACK, RETURN_OF_THE_JEDI, THE_FORCE_AWAKENS]"
+                +   "appearsIn=[A_NEW_HOPE, THE_FORCE_AWAKENS, EMPIRE_STRIKES_BACK, RETURN_OF_THE_JEDI]"
                 + "}]}}";
 
         //when:


### PR DESCRIPTION
This PR builds a join fetch graph from query selection tree to avoid Hibernate error:  `query specified join fetching, but the owner of the fetched association was not present in the select list`

Given the following query:

```
{
  Humans(where: {
    friends: {
      name: {LIKE: "R2-D2"}
    }, 
    favoriteDroid: {
      primaryFunction: {
        function: {EQ: "Protocol"}
      }
    }
  }) {
    select {
      id
      name
      homePlanet
      favoriteDroid {
        name
        primaryFunction {
          function
        }
      }
      friends {
        name
        friends {
          name
        }
      }
    }
  }
}
```
The builder will traverse the selection graph to apply an explicit fetch join for each relation, after that it will reuse existing joins to apply where search criteria expressions. 

As a result the query will create a unique fetch join for each relation in the selection to fetch the related data and add where criteria restrictions to existing join to avoid filtering graph collections, i.e.

```
query {
  Authors(where: {
    books: {
      title: {LIKE: "War"}
    }
  }) {
    select {
      id
      name
      books {
        id
        title
        genre
      }
    }
  }
}
```
Will return result without filtering books collection containing book with title LIKE "War":

```
{
  "data": {
    "Authors": {
      "select": [
        {
          "id": 1,
          "name": "Leo Tolstoy",
          "books": [
            {
              "id": 2,
              "title": "War and Peace",
              "genre": "NOVEL"
            },
            {
              "id": 3,
              "title": "Anna Karenina",
              "genre": "NOVEL"
            }
          ]
        }
      ]
    }
  }
}
```
