### PR TITLE
feat: add optional argument for plural attributes 

### DIFF
--- a/graphql-jpa-query-autoconfigure/src/main/java/com/introproventures/graphql/jpa/query/autoconfigure/GraphQLJpaQueryProperties.java
+++ b/graphql-jpa-query-autoconfigure/src/main/java/com/introproventures/graphql/jpa/query/autoconfigure/GraphQLJpaQueryProperties.java
@@ -47,6 +47,11 @@ public class GraphQLJpaQueryProperties {
     private boolean isDefaultDistinct = true;
 
     /**
+     * Set default value for optional argument for join fetch collections.
+     */
+    private boolean toManyDefaultOptional = true;
+    
+    /**
      * Enable or disable QraphQL module services.
      */
     private boolean enabled;
@@ -142,6 +147,16 @@ public class GraphQLJpaQueryProperties {
      */
     public void setPath(String path) {
         this.path = path;
+    }
+
+    
+    public boolean isToManyDefaultOptional() {
+        return toManyDefaultOptional;
+    }
+
+    
+    public void setToManyDefaultOptional(boolean toManyDefaultOptional) {
+        this.toManyDefaultOptional = toManyDefaultOptional;
     }
     
 }

--- a/graphql-jpa-query-autoconfigure/src/test/java/com/introproventures/graphql/jpa/query/autoconfigure/GraphQLSchemaAutoConfigurationTest.java
+++ b/graphql-jpa-query-autoconfigure/src/test/java/com/introproventures/graphql/jpa/query/autoconfigure/GraphQLSchemaAutoConfigurationTest.java
@@ -99,10 +99,11 @@ public class GraphQLSchemaAutoConfigurationTest {
     
 
     @Test
-    public void configurationProperties() {
+    public void defaultConfigurationProperties() {
         // given
         assertThat(graphQLJpaQueryProperties.isDefaultDistinct()).isTrue();
         assertThat(graphQLJpaQueryProperties.isUseDistinctParameter()).isFalse();
+        assertThat(graphQLJpaQueryProperties.isToManyDefaultOptional()).isTrue();
     }
         
 

--- a/graphql-jpa-query-example-merge/src/main/resources/books.sql
+++ b/graphql-jpa-query-example-merge/src/main/resources/books.sql
@@ -6,3 +6,4 @@ insert into author (id, name) values (4, 'Anton Chekhov');
 insert into book (id, title, author_id, genre) values (5, 'The Cherry Orchard', 4, 'PLAY');
 insert into book (id, title, author_id, genre) values (6, 'The Seagull', 4, 'PLAY');
 insert into book (id, title, author_id, genre) values (7, 'Three Sisters', 4, 'PLAY');
+insert into author (id, name, genre) values (8, 'Igor Dianov', 'JAVA');

--- a/graphql-jpa-query-example-model-books/src/main/java/com/introproventures/graphql/jpa/query/schema/model/book/Genre.java
+++ b/graphql-jpa-query-example-model-books/src/main/java/com/introproventures/graphql/jpa/query/schema/model/book/Genre.java
@@ -17,5 +17,5 @@
 package com.introproventures.graphql.jpa.query.schema.model.book;
 
 public enum Genre {
-	NOVEL, PLAY
+	NOVEL, PLAY, JAVA
 }

--- a/graphql-jpa-query-schema/src/main/java/com/introproventures/graphql/jpa/query/schema/impl/GraphQLJpaOneToManyDataFetcher.java
+++ b/graphql-jpa-query-schema/src/main/java/com/introproventures/graphql/jpa/query/schema/impl/GraphQLJpaOneToManyDataFetcher.java
@@ -48,8 +48,12 @@ class GraphQLJpaOneToManyDataFetcher extends GraphQLJpaQueryDataFetcher {
     
     private final PluralAttribute<Object,Object,Object> attribute;
 
-    public GraphQLJpaOneToManyDataFetcher(EntityManager entityManager, EntityType<?> entityType, PluralAttribute<Object,Object,Object> attribute) {
-        super(entityManager, entityType);
+    public GraphQLJpaOneToManyDataFetcher(EntityManager entityManager, 
+                                          EntityType<?> entityType,
+                                          boolean toManyDefaultOptional,
+                                          boolean defaultDistinct,
+                                          PluralAttribute<Object,Object,Object> attribute) {
+        super(entityManager, entityType, defaultDistinct, toManyDefaultOptional);
         
         this.attribute = attribute;
     }
@@ -63,12 +67,23 @@ class GraphQLJpaOneToManyDataFetcher extends GraphQLJpaQueryDataFetcher {
         
         // Resolve collection query if where argument is present or any field in selection has orderBy argument
         if(whereArg.isPresent() || hasSelectionAnyOrderBy(field)) {
+            TypedQuery<?> query = getQuery(environment, field, isDefaultDistinct());
 
-            //EntityGraph<?> entityGraph = buildEntityGraph(new Field("select", new SelectionSet(Arrays.asList(field))));
+            // Let's not pass distinct if enabled to have better performance
+            if(isDefaultDistinct()) {
+                query.setHint(HIBERNATE_QUERY_PASS_DISTINCT_THROUGH, false);
+            }
             
-            return getQuery(environment, field, true)
-                //.setHint("javax.persistence.fetchgraph", entityGraph) // TODO: fix runtime exception
-                .getResultList();
+            List<?> resultList = query.getResultList();
+
+            // Let's remove any duplicate references for root entities 
+            if(isDefaultDistinct()) {
+                resultList = resultList.stream()
+                                       .distinct()
+                                       .collect(Collectors.toList());
+            }
+            
+            return resultList;
         }
 
         // Let hibernate resolve collection query

--- a/graphql-jpa-query-schema/src/main/java/com/introproventures/graphql/jpa/query/schema/impl/GraphQLJpaOneToManyDataFetcher.java
+++ b/graphql-jpa-query-schema/src/main/java/com/introproventures/graphql/jpa/query/schema/impl/GraphQLJpaOneToManyDataFetcher.java
@@ -46,6 +46,7 @@ import graphql.schema.DataFetchingEnvironment;
  */
 class GraphQLJpaOneToManyDataFetcher extends GraphQLJpaQueryDataFetcher {
     
+    protected static final String OPTIONAL = "optional";
     private final PluralAttribute<Object,Object,Object> attribute;
 
     public GraphQLJpaOneToManyDataFetcher(EntityManager entityManager, 
@@ -141,6 +142,7 @@ class GraphQLJpaOneToManyDataFetcher extends GraphQLJpaQueryDataFetcher {
         query.select(join.alias(attribute.getName()));
         
         List<Predicate> predicates = getFieldArguments(field, query, cb, join, environment).stream()
+                                                                              .filter(it -> !OPTIONAL.equals(it.getName()))  
                                                                               .map(it -> getPredicate(cb, from, join, environment, it))
                                                                               .filter(it -> it != null)
                                                                               .collect(Collectors.toList());

--- a/graphql-jpa-query-schema/src/main/java/com/introproventures/graphql/jpa/query/schema/impl/GraphQLJpaQueryDataFetcher.java
+++ b/graphql-jpa-query-schema/src/main/java/com/introproventures/graphql/jpa/query/schema/impl/GraphQLJpaQueryDataFetcher.java
@@ -49,18 +49,21 @@ class GraphQLJpaQueryDataFetcher extends QraphQLJpaBaseDataFetcher {
 
     private boolean defaultDistinct = true;
 	
-    private static final String HIBERNATE_QUERY_PASS_DISTINCT_THROUGH = "hibernate.query.passDistinctThrough";
-    private static final String ORG_HIBERNATE_CACHEABLE = "org.hibernate.cacheable";
-    private static final String ORG_HIBERNATE_FETCH_SIZE = "org.hibernate.fetchSize";
-    private static final String ORG_HIBERNATE_READ_ONLY = "org.hibernate.readOnly";
-    private static final String JAVAX_PERSISTENCE_FETCHGRAPH = "javax.persistence.fetchgraph";
+    protected static final String HIBERNATE_QUERY_PASS_DISTINCT_THROUGH = "hibernate.query.passDistinctThrough";
+    protected static final String ORG_HIBERNATE_CACHEABLE = "org.hibernate.cacheable";
+    protected static final String ORG_HIBERNATE_FETCH_SIZE = "org.hibernate.fetchSize";
+    protected static final String ORG_HIBERNATE_READ_ONLY = "org.hibernate.readOnly";
+    protected static final String JAVAX_PERSISTENCE_FETCHGRAPH = "javax.persistence.fetchgraph";
 
-    public GraphQLJpaQueryDataFetcher(EntityManager entityManager, EntityType<?> entityType) {
-        super(entityManager, entityType);
+    private GraphQLJpaQueryDataFetcher(EntityManager entityManager, EntityType<?> entityType, boolean toManyDefaultOptional) {
+        super(entityManager, entityType, toManyDefaultOptional);
     }
 
-    public GraphQLJpaQueryDataFetcher(EntityManager entityManager, EntityType<?> entityType, boolean defaultDistinct) {
-        super(entityManager, entityType);
+    public GraphQLJpaQueryDataFetcher(EntityManager entityManager, 
+                                      EntityType<?> entityType, 
+                                      boolean defaultDistinct,
+                                      boolean toManyDefaultOptional) {
+        super(entityManager, entityType, toManyDefaultOptional);
         this.defaultDistinct = defaultDistinct;
     }
 

--- a/graphql-jpa-query-schema/src/main/java/com/introproventures/graphql/jpa/query/schema/impl/GraphQLJpaSchemaBuilder.java
+++ b/graphql-jpa-query-schema/src/main/java/com/introproventures/graphql/jpa/query/schema/impl/GraphQLJpaSchemaBuilder.java
@@ -641,7 +641,7 @@ public class GraphQLJpaSchemaBuilder implements GraphQLSchemaBuilder {
             // TODO fix page count query
             arguments.add(getWhereArgument(foreignType));
             
-            arguments.add(optionalArgument(SingularAttribute.class.cast(attribute)));
+            arguments.add(optionalArgument(SingularAttribute.class.cast(attribute).isOptional()));
 
         } //  Get Sub-Objects fields queries via DataFetcher
         else if (attribute instanceof PluralAttribute
@@ -652,7 +652,8 @@ public class GraphQLJpaSchemaBuilder implements GraphQLSchemaBuilder {
 
             arguments.add(getWhereArgument(elementType));
             
-            arguments.add(optionalArgument(PluralAttribute.class.cast(attribute)));
+            // TODO make it configurable via builder api
+            arguments.add(optionalArgument(false));
             
             dataFetcher = new GraphQLJpaOneToManyDataFetcher(entityManager, baseEntity, (PluralAttribute) attribute);
         }
@@ -666,25 +667,15 @@ public class GraphQLJpaSchemaBuilder implements GraphQLSchemaBuilder {
                 .build();
     }
     
-    private GraphQLArgument optionalArgument(SingularAttribute<?,?> attribute) {
+    private GraphQLArgument optionalArgument(Boolean defaultValue) {
         return GraphQLArgument.newArgument()
                 .name("optional")
                 .description("Optional association specification")
                 .type(Scalars.GraphQLBoolean)
-                .defaultValue(attribute.isOptional())
+                .defaultValue(defaultValue)
                 .build();
     }
     
-    private GraphQLArgument optionalArgument(PluralAttribute<?,?,?> attribute) {
-        return GraphQLArgument.newArgument()
-                .name("optional")
-                .description("Optional association specification")
-                .type(Scalars.GraphQLBoolean)
-                .defaultValue(false)
-                .build();
-    }    
-    
-
     protected ManagedType<?> getForeignType(Attribute<?,?> attribute) {
         if(SingularAttribute.class.isInstance(attribute))
             return (ManagedType<?>) ((SingularAttribute<?,?>) attribute).getType();

--- a/graphql-jpa-query-schema/src/main/java/com/introproventures/graphql/jpa/query/schema/impl/GraphQLJpaSchemaBuilder.java
+++ b/graphql-jpa-query-schema/src/main/java/com/introproventures/graphql/jpa/query/schema/impl/GraphQLJpaSchemaBuilder.java
@@ -651,6 +651,9 @@ public class GraphQLJpaSchemaBuilder implements GraphQLSchemaBuilder {
             EntityType elementType =  (EntityType) ((PluralAttribute) attribute).getElementType();
 
             arguments.add(getWhereArgument(elementType));
+            
+            arguments.add(optionalArgument(PluralAttribute.class.cast(attribute)));
+            
             dataFetcher = new GraphQLJpaOneToManyDataFetcher(entityManager, baseEntity, (PluralAttribute) attribute);
         }
         
@@ -670,7 +673,17 @@ public class GraphQLJpaSchemaBuilder implements GraphQLSchemaBuilder {
                 .type(Scalars.GraphQLBoolean)
                 .defaultValue(attribute.isOptional())
                 .build();
+    }
+    
+    private GraphQLArgument optionalArgument(PluralAttribute<?,?,?> attribute) {
+        return GraphQLArgument.newArgument()
+                .name("optional")
+                .description("Optional association specification")
+                .type(Scalars.GraphQLBoolean)
+                .defaultValue(false)
+                .build();
     }    
+    
 
     protected ManagedType<?> getForeignType(Attribute<?,?> attribute) {
         if(SingularAttribute.class.isInstance(attribute))

--- a/graphql-jpa-query-schema/src/main/java/com/introproventures/graphql/jpa/query/schema/impl/GraphQLJpaSimpleDataFetcher.java
+++ b/graphql-jpa-query-schema/src/main/java/com/introproventures/graphql/jpa/query/schema/impl/GraphQLJpaSimpleDataFetcher.java
@@ -16,6 +16,10 @@
 
 package com.introproventures.graphql.jpa.query.schema.impl;
 
+import java.util.List;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
 import javax.persistence.EntityGraph;
 import javax.persistence.EntityManager;
 import javax.persistence.NoResultException;
@@ -26,14 +30,12 @@ import graphql.language.Field;
 import graphql.language.ObjectValue;
 import graphql.schema.DataFetchingEnvironment;
 
-import java.util.List;
-import java.util.stream.Collectors;
-import java.util.stream.Stream;
-
 class GraphQLJpaSimpleDataFetcher extends QraphQLJpaBaseDataFetcher {
 
-    public GraphQLJpaSimpleDataFetcher(EntityManager entityManager, EntityType<?> entityType) {
-        super(entityManager, entityType);
+    public GraphQLJpaSimpleDataFetcher(EntityManager entityManager, 
+                                       EntityType<?> entityType,
+                                       boolean toManyDefaultOptional) {
+        super(entityManager, entityType, toManyDefaultOptional);
     }
     
     @Override

--- a/graphql-jpa-query-schema/src/main/java/com/introproventures/graphql/jpa/query/schema/impl/QraphQLJpaBaseDataFetcher.java
+++ b/graphql-jpa-query-schema/src/main/java/com/introproventures/graphql/jpa/query/schema/impl/QraphQLJpaBaseDataFetcher.java
@@ -209,7 +209,7 @@ class QraphQLJpaBaseDataFetcher implements DataFetcher<Object> {
 
                         // TODO add fetch argument parameter
                         // Let's fetch element collections to avoid filtering their values used where search criteria
-                        /*join = (Join<?,?>)*/ from.fetch(selectedField.getName(), 
+                        from.fetch(selectedField.getName(), 
                                    isOptional ? JoinType.LEFT : JoinType.INNER);
                     }
                     

--- a/graphql-jpa-query-schema/src/test/java/com/introproventures/graphql/jpa/query/schema/BooksSchemaBuildTest.java
+++ b/graphql-jpa-query-schema/src/test/java/com/introproventures/graphql/jpa/query/schema/BooksSchemaBuildTest.java
@@ -1,0 +1,150 @@
+/*
+ * Copyright 2017 IntroPro Ventures Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.introproventures.graphql.jpa.query.schema;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.stream.Collectors;
+
+import javax.persistence.EntityManager;
+
+import com.introproventures.graphql.jpa.query.schema.impl.GraphQLJpaSchemaBuilder;
+import graphql.schema.GraphQLFieldDefinition;
+import graphql.schema.GraphQLSchema;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.context.SpringBootTest.WebEnvironment;
+import org.springframework.context.annotation.Bean;
+import org.springframework.test.context.junit4.SpringRunner;
+
+@RunWith(SpringRunner.class)
+@SpringBootTest(
+    webEnvironment=WebEnvironment.NONE
+)
+public class BooksSchemaBuildTest {
+
+    @SpringBootApplication
+    static class TestConfiguration {
+        @Bean
+        public GraphQLJpaSchemaBuilder graphQLSchemaBuilder(EntityManager entityManager) {
+            return new GraphQLJpaSchemaBuilder(entityManager)
+                .name("BooksExampleSchema")
+                .description("Books Example Schema");
+        }
+    }
+    
+    @Autowired
+    private GraphQLJpaSchemaBuilder builder;
+
+    @Before
+    public void setup() {
+    }
+
+    @Test
+    public void correctlyDerivesSchemaFromGivenEntities() {
+        //when
+        GraphQLSchema schema = builder.build();
+
+        // then
+        assertThat(schema)
+            .describedAs("Ensure the result is returned")
+            .isNotNull();
+
+        //then
+        assertThat(schema.getQueryType().getFieldDefinition("Book").getArgument("id"))
+            .describedAs( "Ensure that identity can be queried on")
+            .isNotNull();
+        
+        //then
+        assertThat(schema.getQueryType().getFieldDefinition("Books").getArgument("where"))
+            .describedAs( "Ensure that collections can be queried on")
+            .isNotNull();
+
+        //then
+        assertThat(schema.getQueryType().getFieldDefinition("Author").getArgument("id"))
+            .describedAs( "Ensure that collections can be queried on")
+            .isNotNull();
+
+        assertThat(schema.getQueryType().getFieldDefinition("Authors").getArgument("where"))
+            .describedAs( "Ensure that collections can be queried on")
+            .isNotNull();
+    }
+
+    @Test
+    public void correctlyDerivesToManyOptionalFromGivenEntities() {
+        //when
+        GraphQLSchema schema = builder.build();
+
+        // then
+        assertThat(schema)
+            .describedAs("Ensure the schema is generated")
+            .isNotNull();
+
+        //then
+        assertThat(schema.getQueryType()
+                         .getFieldDefinition("Book")
+                         .getType()
+                         .getChildren()
+                         .stream()
+                         .map(GraphQLFieldDefinition.class::cast)
+                         .collect(Collectors.toList())
+                  )
+                  .filteredOn("name", "author")
+                  .extracting(it -> it.getArgument("optional"))
+                  .extractingResultOf("getDefaultValue", Object.class)
+                  .containsExactly(new Boolean(false));
+    }
+
+    @Test
+    public void correctlyDerivesToOneOptionalFromGivenEntities() {
+        //when
+        GraphQLSchema schema = builder.build();
+
+        // then
+        assertThat(schema)
+            .describedAs("Ensure the schema is generated")
+            .isNotNull();
+
+        //then
+        assertThat(schema.getQueryType()
+                         .getFieldDefinition("Author")
+                         .getType()
+                         .getChildren()
+                         .stream()
+                         .map(GraphQLFieldDefinition.class::cast)
+                         .collect(Collectors.toList())
+                  )
+                  .filteredOn("name", "books")
+                  .extracting(it -> it.getArgument("optional"))
+                  .extractingResultOf("getDefaultValue", Object.class)
+                  .containsExactly(new Boolean(true));
+    }
+    
+    @Test
+    public void testBuildSchema(){
+        //given
+        GraphQLSchema schema = builder.build();
+
+        //then
+        assertThat(schema).isNotNull();
+    }
+    
+}

--- a/graphql-jpa-query-schema/src/test/java/com/introproventures/graphql/jpa/query/schema/GraphQLEnumVariableBindingsTests.java
+++ b/graphql-jpa-query-schema/src/test/java/com/introproventures/graphql/jpa/query/schema/GraphQLEnumVariableBindingsTests.java
@@ -196,7 +196,8 @@ public class GraphQLEnumVariableBindingsTests {
                 +       "{id=2, title=War and Peace, genre=NOVEL}, "
                 +       "{id=3, title=Anna Karenina, genre=NOVEL}"
                 +   "]}, "
-                +   "{id=4, name=Anton Chekhov, books=[]}"
+                +   "{id=4, name=Anton Chekhov, books=[]}, "
+                +   "{id=8, name=Igor Dianov, books=[]}"
                 + "]}}";
 
         //when

--- a/graphql-jpa-query-schema/src/test/java/com/introproventures/graphql/jpa/query/schema/GraphQLExecutorSuperClassTests.java
+++ b/graphql-jpa-query-schema/src/test/java/com/introproventures/graphql/jpa/query/schema/GraphQLExecutorSuperClassTests.java
@@ -1,6 +1,10 @@
 package com.introproventures.graphql.jpa.query.schema;
 
 
+import static org.assertj.core.api.Assertions.assertThat;
+
+import javax.persistence.EntityManager;
+
 import com.introproventures.graphql.jpa.query.schema.impl.GraphQLJpaExecutor;
 import com.introproventures.graphql.jpa.query.schema.impl.GraphQLJpaSchemaBuilder;
 import org.junit.Test;
@@ -12,10 +16,6 @@ import org.springframework.context.annotation.Bean;
 import org.springframework.test.context.TestPropertySource;
 import org.springframework.test.context.junit4.SpringRunner;
 import org.springframework.util.Assert;
-
-import javax.persistence.EntityManager;
-
-import static org.assertj.core.api.Assertions.assertThat;
 
 @RunWith(SpringRunner.class)
 @SpringBootTest(webEnvironment= SpringBootTest.WebEnvironment.NONE)
@@ -54,7 +54,8 @@ public class GraphQLExecutorSuperClassTests {
 
         String expected = "{SuperAuthors={select=[" +
                 "{id=1, name=Leo Tolstoy, genre=NOVEL}, " +
-                "{id=4, name=Anton Chekhov, genre=PLAY}" +
+                "{id=4, name=Anton Chekhov, genre=PLAY}, " +
+                "{id=8, name=Igor Dianov, genre=JAVA}" +
                 "]}}";
 
         //when

--- a/graphql-jpa-query-schema/src/test/java/com/introproventures/graphql/jpa/query/schema/GraphQLExecutorTests.java
+++ b/graphql-jpa-query-schema/src/test/java/com/introproventures/graphql/jpa/query/schema/GraphQLExecutorTests.java
@@ -946,7 +946,7 @@ public class GraphQLExecutorTests {
     }
     
     @Test
-    public void queryForAuthorsWithDefaultOptionalBooksFalse() {
+    public void queryForAuthorsWithDefaultOptionalBooks() {
         //given
         String query = "query { "
                 + "Authors {" + 
@@ -971,7 +971,8 @@ public class GraphQLExecutorTests {
                 +   "{id=5, title=The Cherry Orchard, genre=PLAY}, "
                 +   "{id=6, title=The Seagull, genre=PLAY}, "
                 +   "{id=7, title=Three Sisters, genre=PLAY}"
-                + "]}"
+                + "]}, "
+                + "{id=8, name=Igor Dianov, books=[]}"
                 + "]}}";
 
         //when

--- a/graphql-jpa-query-schema/src/test/java/com/introproventures/graphql/jpa/query/schema/GraphQLExecutorTests.java
+++ b/graphql-jpa-query-schema/src/test/java/com/introproventures/graphql/jpa/query/schema/GraphQLExecutorTests.java
@@ -356,22 +356,22 @@ public class GraphQLExecutorTests {
     public void queryAuthorBooksWithExplictOptional() {
         //given
         String query = "query { "
-                + "Authors(\n" + 
-                "    where: {\n" + 
-                "      books: {\n" + 
-                "        title: {LIKE: \"War\"}\n" + 
-                "      }\n" + 
-                "    }\n" + 
-                "  ) {\n" + 
-                "    select {\n" + 
-                "      id\n" + 
-                "      name\n" + 
-                "      books(optional: true) {\n" + 
-                "        id\n" + 
-                "        title(orderBy: ASC)\n" + 
-                "        genre\n" + 
-                "      }\n" + 
-                "    }\n" + 
+                + "Authors(" + 
+                "    where: {" + 
+                "      books: {" + 
+                "        title: {LIKE: \"War\"}" + 
+                "      }" + 
+                "    }" + 
+                "  ) {" + 
+                "    select {" + 
+                "      id" + 
+                "      name" + 
+                "      books(optional: true) {" + 
+                "        id" + 
+                "        title(orderBy: ASC)" + 
+                "        genre" + 
+                "      }" + 
+                "    }" + 
                 "  }"
                 + "}";
         
@@ -387,6 +387,37 @@ public class GraphQLExecutorTests {
         assertThat(result.toString()).isEqualTo(expected);
     }
         
+    @Test
+    public void queryAuthorBooksWithIsNullId() {
+        //given
+        String query = "query { "
+                + "Authors(" + 
+                "    where: {" + 
+                "      books: {" + 
+                "        id: {IS_NULL: true}" + 
+                "      }" + 
+                "    }" + 
+                "  ) {" + 
+                "    select {" + 
+                "      id" + 
+                "      name" + 
+                "      books {" + 
+                "        id" + 
+                "        title" + 
+                "        genre" + 
+                "      }" + 
+                "    }" + 
+                "  }"
+                + "}";
+        
+        String expected = "{Authors={select=[{id=8, name=Igor Dianov, books=[]}]}}";
+
+        //when
+        Object result = executor.execute(query).getData();
+
+        // then
+        assertThat(result.toString()).isEqualTo(expected);
+    }
     
     
     // https://github.com/introproventures/graphql-jpa-query/issues/30

--- a/graphql-jpa-query-schema/src/test/java/com/introproventures/graphql/jpa/query/schema/GraphQLExecutorTests.java
+++ b/graphql-jpa-query-schema/src/test/java/com/introproventures/graphql/jpa/query/schema/GraphQLExecutorTests.java
@@ -949,16 +949,16 @@ public class GraphQLExecutorTests {
     public void queryForAuthorsWithDefaultOptionalBooksFalse() {
         //given
         String query = "query { "
-                + "Authors {\n" + 
-                "    select {\n" + 
-                "      id\n" + 
-                "      name\n" + 
-                "      books {\n" + 
-                "        id\n" + 
-                "        title\n" + 
-                "        genre\n" + 
-                "      }\n" + 
-                "    }\n" + 
+                + "Authors {" + 
+                "    select {" + 
+                "      id" + 
+                "      name" + 
+                "      books {" + 
+                "        id" + 
+                "        title" + 
+                "        genre" + 
+                "      }" + 
+                "    }" + 
                 "  }"+
                 "}";
 
@@ -985,16 +985,16 @@ public class GraphQLExecutorTests {
     public void queryForAuthorsWithExlicitOptionalBooksFalse() {
         //given
         String query = "query { "
-                + "Authors {\n" + 
-                "    select {\n" + 
-                "      id\n" + 
-                "      name\n" + 
-                "      books(optional: false) {\n" + 
-                "        id\n" + 
-                "        title\n" + 
-                "        genre\n" + 
-                "      }\n" + 
-                "    }\n" + 
+                + "Authors {" + 
+                "    select {" + 
+                "      id" + 
+                "      name" + 
+                "      books(optional: false) {" + 
+                "        id" + 
+                "        title" + 
+                "        genre" + 
+                "      }" + 
+                "    }" + 
                 "  }"+
                 "}";
 
@@ -1021,16 +1021,16 @@ public class GraphQLExecutorTests {
     public void queryForAuthorsWithExlicitOptionalBooksTrue() {
         //given
         String query = "query { "
-                + "Authors {\n" + 
-                "    select {\n" + 
-                "      id\n" + 
-                "      name\n" + 
-                "      books(optional: true) {\n" + 
-                "        id\n" + 
-                "        title\n" + 
-                "        genre\n" + 
-                "      }\n" + 
-                "    }\n" + 
+                + "Authors {" + 
+                "    select {" + 
+                "      id" + 
+                "      name" + 
+                "      books(optional: true) {" + 
+                "        id" + 
+                "        title" + 
+                "        genre" + 
+                "      }" + 
+                "    }" + 
                 "  }"+
                 "}";
 

--- a/graphql-jpa-query-schema/src/test/java/com/introproventures/graphql/jpa/query/schema/GraphQLExecutorTests.java
+++ b/graphql-jpa-query-schema/src/test/java/com/introproventures/graphql/jpa/query/schema/GraphQLExecutorTests.java
@@ -352,6 +352,42 @@ public class GraphQLExecutorTests {
         assertThat(result.toString()).isEqualTo(expected);
     }
     
+    @Test
+    public void queryAuthorBooksWithExplictOptional() {
+        //given
+        String query = "query { "
+                + "Authors(\n" + 
+                "    where: {\n" + 
+                "      books: {\n" + 
+                "        title: {LIKE: \"War\"}\n" + 
+                "      }\n" + 
+                "    }\n" + 
+                "  ) {\n" + 
+                "    select {\n" + 
+                "      id\n" + 
+                "      name\n" + 
+                "      books(optional: true) {\n" + 
+                "        id\n" + 
+                "        title(orderBy: ASC)\n" + 
+                "        genre\n" + 
+                "      }\n" + 
+                "    }\n" + 
+                "  }"
+                + "}";
+        
+        String expected = "{Authors={select=["
+                + "{id=1, name=Leo Tolstoy, books=[{id=3, title=Anna Karenina, genre=NOVEL}, "
+                + "{id=2, title=War and Peace, genre=NOVEL}]}"
+                + "]}}";
+
+        //when
+        Object result = executor.execute(query).getData();
+
+        // then
+        assertThat(result.toString()).isEqualTo(expected);
+    }
+        
+    
     
     // https://github.com/introproventures/graphql-jpa-query/issues/30
     @Test

--- a/graphql-jpa-query-schema/src/test/java/com/introproventures/graphql/jpa/query/schema/GraphQLExecutorTests.java
+++ b/graphql-jpa-query-schema/src/test/java/com/introproventures/graphql/jpa/query/schema/GraphQLExecutorTests.java
@@ -944,4 +944,113 @@ public class GraphQLExecutorTests {
         //then:
         assertThat(result.toString()).isEqualTo(expected);
     }
+    
+    @Test
+    public void queryForAuthorsWithDefaultOptionalBooksFalse() {
+        //given
+        String query = "query { "
+                + "Authors {\n" + 
+                "    select {\n" + 
+                "      id\n" + 
+                "      name\n" + 
+                "      books {\n" + 
+                "        id\n" + 
+                "        title\n" + 
+                "        genre\n" + 
+                "      }\n" + 
+                "    }\n" + 
+                "  }"+
+                "}";
+
+        String expected = "{Authors={select=["
+                + "{id=1, name=Leo Tolstoy, books=["
+                +   "{id=2, title=War and Peace, genre=NOVEL}, "
+                +   "{id=3, title=Anna Karenina, genre=NOVEL}"
+                + "]}, "
+                + "{id=4, name=Anton Chekhov, books=["
+                +   "{id=5, title=The Cherry Orchard, genre=PLAY}, "
+                +   "{id=6, title=The Seagull, genre=PLAY}, "
+                +   "{id=7, title=Three Sisters, genre=PLAY}"
+                + "]}"
+                + "]}}";
+
+        //when
+        Object result = executor.execute(query).getData();
+
+        // then
+        assertThat(result.toString()).isEqualTo(expected);
+    }
+    
+    @Test
+    public void queryForAuthorsWithExlicitOptionalBooksFalse() {
+        //given
+        String query = "query { "
+                + "Authors {\n" + 
+                "    select {\n" + 
+                "      id\n" + 
+                "      name\n" + 
+                "      books(optional: false) {\n" + 
+                "        id\n" + 
+                "        title\n" + 
+                "        genre\n" + 
+                "      }\n" + 
+                "    }\n" + 
+                "  }"+
+                "}";
+
+        String expected = "{Authors={select=["
+                + "{id=1, name=Leo Tolstoy, books=["
+                +   "{id=2, title=War and Peace, genre=NOVEL}, "
+                +   "{id=3, title=Anna Karenina, genre=NOVEL}"
+                + "]}, "
+                + "{id=4, name=Anton Chekhov, books=["
+                +   "{id=5, title=The Cherry Orchard, genre=PLAY}, "
+                +   "{id=6, title=The Seagull, genre=PLAY}, "
+                +   "{id=7, title=Three Sisters, genre=PLAY}"
+                + "]}"
+                + "]}}";
+
+        //when
+        Object result = executor.execute(query).getData();
+
+        // then
+        assertThat(result.toString()).isEqualTo(expected);
+    }
+ 
+    @Test
+    public void queryForAuthorsWithExlicitOptionalBooksTrue() {
+        //given
+        String query = "query { "
+                + "Authors {\n" + 
+                "    select {\n" + 
+                "      id\n" + 
+                "      name\n" + 
+                "      books(optional: true) {\n" + 
+                "        id\n" + 
+                "        title\n" + 
+                "        genre\n" + 
+                "      }\n" + 
+                "    }\n" + 
+                "  }"+
+                "}";
+
+        String expected = "{Authors={select=["
+                + "{id=1, name=Leo Tolstoy, books=["
+                +   "{id=2, title=War and Peace, genre=NOVEL}, "
+                +   "{id=3, title=Anna Karenina, genre=NOVEL}"
+                + "]}, "
+                + "{id=4, name=Anton Chekhov, books=["
+                +   "{id=5, title=The Cherry Orchard, genre=PLAY}, "
+                +   "{id=6, title=The Seagull, genre=PLAY}, "
+                +   "{id=7, title=Three Sisters, genre=PLAY}"
+                + "]}, "
+                + "{id=8, name=Igor Dianov, books=[]}"
+                + "]}}";
+
+        //when
+        Object result = executor.execute(query).getData();
+
+        // then
+        assertThat(result.toString()).isEqualTo(expected);
+    }    
 }

--- a/graphql-jpa-query-schema/src/test/java/com/introproventures/graphql/jpa/query/schema/model/book_superclass/SuperGenre.java
+++ b/graphql-jpa-query-schema/src/test/java/com/introproventures/graphql/jpa/query/schema/model/book_superclass/SuperGenre.java
@@ -17,5 +17,5 @@
 package com.introproventures.graphql.jpa.query.schema.model.book_superclass;
 
 public enum SuperGenre {
-	NOVEL, PLAY
+	NOVEL, PLAY, JAVA
 }

--- a/graphql-jpa-query-schema/src/test/resources/data.sql
+++ b/graphql-jpa-query-schema/src/test/resources/data.sql
@@ -124,6 +124,7 @@ insert into book (id, title, author_id, genre, publication_date, description)
 values (6, 'The Seagull', 4, 'PLAY', '1896-10-17', 'It dramatises the romantic and artistic conflicts between four characters');
 insert into book (id, title, author_id, genre, publication_date, description)
 values (7, 'Three Sisters', 4, 'PLAY', '1900-01-01', 'The play is sometimes included on the short list of Chekhov''s outstanding plays, along with The Cherry Orchard, The Seagull and Uncle Vanya.[1]');
+insert into author (id, name, genre) values (8, 'Igor Dianov', 'JAVA');
 
 insert into author_phone_numbers(phone_number, author_id) values
 	('1-123-1234', 1),


### PR DESCRIPTION
This PR adds support for default `optional: true` argument for collections in the query selection graph, i.e.

```
query {
  Authors {
    select {
      id
      name
      books(optional: true) {
        id
        title
        genre
      }
    }
  }
}
```
With `optional: true`, the data fetcher will apply LEFT OUTER JOIN on books and return empty books collections:

```
{
  "data": {
    "Authors": {
      "select": [
        {
          "id": 1,
          "name": "Leo Tolstoy",
          "books": [
            {
              "id": 2,
              "title": "War and Peace",
              "genre": "NOVEL"
            },
            {
              "id": 3,
              "title": "Anna Karenina",
              "genre": "NOVEL"
            }
          ]
        },
        {
          "id": 4,
          "name": "Anton Chekhov",
          "books": [
            {
              "id": 5,
              "title": "The Cherry Orchard",
              "genre": "PLAY"
            },
            {
              "id": 6,
              "title": "The Seagull",
              "genre": "PLAY"
            },
            {
              "id": 7,
              "title": "Three Sisters",
              "genre": "PLAY"
            }
          ]
        },
        {
          "id": 8,
          "name": "Igor Dianov",
          "books": []
        }
      ]
    }
  }
}
```

Use `optional: false` to enforce INNER JOIN, so that

```
query {
  Authors {
    select {
      id
      name
      books(optional: false) {
        id
        title
        genre
      }
    }
}
```
Will return entity graph with only existing associations:

```
{
  "data": {
    "Authors": {
      "select": [
        {
          "id": 1,
          "name": "Leo Tolstoy",
          "books": [
            {
              "id": 2,
              "title": "War and Peace",
              "genre": "NOVEL"
            },
            {
              "id": 3,
              "title": "Anna Karenina",
              "genre": "NOVEL"
            }
          ]
        },
        {
          "id": 4,
          "name": "Anton Chekhov",
          "books": [
            {
              "id": 5,
              "title": "The Cherry Orchard",
              "genre": "PLAY"
            },
            {
              "id": 6,
              "title": "The Seagull",
              "genre": "PLAY"
            },
            {
              "id": 7,
              "title": "Three Sisters",
              "genre": "PLAY"
            }
          ]
        }
      ]
    }
  }
}
```

You can also configure default join fetch optional argument value via Api.