### PR TITLE
feat: add NE predicate for custom attributes criteria  expressions

### DIFF
--- a/graphql-jpa-query-schema/src/main/java/com/introproventures/graphql/jpa/query/schema/impl/JpaPredicateBuilder.java
+++ b/graphql-jpa-query-schema/src/main/java/com/introproventures/graphql/jpa/query/schema/impl/JpaPredicateBuilder.java
@@ -452,8 +452,16 @@ class JpaPredicateBuilder {
                     object = getValue(object, type);
                 }
                     
-                if (filter.getCriterias().contains(PredicateFilter.Criteria.EQ)) {
-                    return cb.equal(from.get(filter.getField()), object);
+                if (filter.getCriterias().contains(PredicateFilter.Criteria.EQ)
+                        || filter.getCriterias().contains(PredicateFilter.Criteria.NE)) {
+                    
+                    Predicate equal = cb.equal(from.get(filter.getField()), object);
+                    
+                    if (filter.getCriterias().contains(PredicateFilter.Criteria.NE)) {
+                        return cb.not(equal);
+                    }
+                    
+                    return equal;
                 } 
                 else if (filter.getCriterias().contains(PredicateFilter.Criteria.IN) 
                         || filter.getCriterias().contains(PredicateFilter.Criteria.NIN)

--- a/graphql-jpa-query-schema/src/test/java/com/introproventures/graphql/jpa/query/converter/GraphQLJpaConverterTests.java
+++ b/graphql-jpa-query-schema/src/test/java/com/introproventures/graphql/jpa/query/converter/GraphQLJpaConverterTests.java
@@ -551,7 +551,36 @@ public class GraphQLJpaConverterTests {
 
         // then
         assertThat(result.toString()).isEqualTo(expected);
-    }          
+    }
+    
+    @Test
+    public void queryProcessVariablesWhereWithNEValueSearchCriteria() {
+        //given
+        String query = "query {" + 
+                " TaskVariables(where: {" 
+                +     "value: {NE: null}" 
+                + "}) {" + 
+                "    select {" + 
+                "      name" + 
+                "      value" + 
+                "    }" + 
+                "  }" + 
+                "}";
+        
+        String expected = "{TaskVariables={select=["
+                + "{name=variable1, value=data}, "
+                + "{name=variable2, value=true}, "
+                + "{name=variable4, value={key=data}}, "
+                + "{name=variable5, value=1.2345}, "
+                + "{name=variable6, value=12345}, "
+                + "{name=variable7, value=[1, 2, 3, 4, 5]}]}}";
+
+        //when
+        Object result = executor.execute(query).getData();
+
+        // then
+        assertThat(result.toString()).isEqualTo(expected);
+    }        
      
     @Test
     public void queryProcessVariablesWhereWithINListTypedValueSearchCriteria() {


### PR DESCRIPTION
This PR adds support for NE predicates on custom attributes criteria expressions, i.e.

```
query {
  TaskVariables(where: { 
    value: {NE: null} 
  }) {
    select {
      name
      value
    }
  }
}
```