### PR TITLE
fix: add support for nested where criteria expressions

### DIFF
--- a/graphql-jpa-query-schema/src/main/java/com/introproventures/graphql/jpa/query/schema/impl/GraphQLJpaOneToManyDataFetcher.java
+++ b/graphql-jpa-query-schema/src/main/java/com/introproventures/graphql/jpa/query/schema/impl/GraphQLJpaOneToManyDataFetcher.java
@@ -46,7 +46,6 @@ import graphql.schema.DataFetchingEnvironment;
  */
 class GraphQLJpaOneToManyDataFetcher extends GraphQLJpaQueryDataFetcher {
     
-    protected static final String OPTIONAL = "optional";
     private final PluralAttribute<Object,Object,Object> attribute;
 
     public GraphQLJpaOneToManyDataFetcher(EntityManager entityManager, 
@@ -141,11 +140,8 @@ class GraphQLJpaOneToManyDataFetcher extends GraphQLJpaQueryDataFetcher {
         
         query.select(join.alias(attribute.getName()));
         
-        List<Predicate> predicates = getFieldArguments(field, query, cb, join, environment).stream()
-                                                                              .filter(it -> !OPTIONAL.equals(it.getName()))  
-                                                                              .map(it -> getPredicate(cb, from, join, environment, it))
-                                                                              .filter(it -> it != null)
-                                                                              .collect(Collectors.toList());
+        List<Predicate> predicates = getFieldPredicates(field, query, cb, from, join, environment);
+
         query.where(
             predicates.toArray(new Predicate[predicates.size()])
         );

--- a/graphql-jpa-query-schema/src/main/java/com/introproventures/graphql/jpa/query/schema/impl/GraphQLJpaSchemaBuilder.java
+++ b/graphql-jpa-query-schema/src/main/java/com/introproventures/graphql/jpa/query/schema/impl/GraphQLJpaSchemaBuilder.java
@@ -661,12 +661,14 @@ public class GraphQLJpaSchemaBuilder implements GraphQLSchemaBuilder {
             
             // make it configurable via builder api
             arguments.add(optionalArgument(toManyDefaultOptional));
-            
-            dataFetcher = new GraphQLJpaOneToManyDataFetcher(entityManager, 
-                                                             baseEntity,
-                                                             toManyDefaultOptional,
-                                                             isDefaultDistinct,
-                                                             (PluralAttribute) attribute);
+
+            if (attribute.getPersistentAttributeType() == Attribute.PersistentAttributeType.MANY_TO_MANY) {
+                dataFetcher = new GraphQLJpaOneToManyDataFetcher(entityManager,
+                                                                 baseEntity,
+                                                                 toManyDefaultOptional,
+                                                                 isDefaultDistinct,
+                                                                 (PluralAttribute) attribute);
+            }
         }
         
         return GraphQLFieldDefinition.newFieldDefinition()

--- a/graphql-jpa-query-schema/src/main/java/com/introproventures/graphql/jpa/query/schema/impl/QraphQLJpaBaseDataFetcher.java
+++ b/graphql-jpa-query-schema/src/main/java/com/introproventures/graphql/jpa/query/schema/impl/QraphQLJpaBaseDataFetcher.java
@@ -93,7 +93,11 @@ import graphql.util.TraverserContext;
  */
 class QraphQLJpaBaseDataFetcher implements DataFetcher<Object> {
 
-    private static final String OPTIONAL = "optional";
+    private static final String WHERE = "where";
+
+    protected static final String OPTIONAL = "optional";
+    
+    protected static final List<String> ARGUMENTS = Arrays.asList(OPTIONAL);
 
     // "__typename" is part of the graphql introspection spec and has to be ignored
     private static final String TYPENAME = "__typename";
@@ -130,11 +134,7 @@ class QraphQLJpaBaseDataFetcher implements DataFetcher<Object> {
         from.alias(from.getModel().getName());
 
         // Build predicates from query arguments
-        List<Predicate> predicates =  getFieldArguments(field, query, cb, from, environment)
-            .stream()
-            .map(it -> getPredicate(cb, from, from, environment, it))
-            .filter(it -> it != null)
-            .collect(Collectors.toList());
+        List<Predicate> predicates =  getFieldPredicates(field, query, cb,from, from, environment);
 
         // Use AND clause to filter results
         if(!predicates.isEmpty())
@@ -146,9 +146,10 @@ class QraphQLJpaBaseDataFetcher implements DataFetcher<Object> {
         return entityManager.createQuery(query.distinct(isDistinct));
     }
 
-    protected final List<Argument> getFieldArguments(Field field, CriteriaQuery<?> query, CriteriaBuilder cb, From<?,?> from, DataFetchingEnvironment environment) {
+    protected final List<Predicate> getFieldPredicates(Field field, CriteriaQuery<?> query, CriteriaBuilder cb, Root<?> root, From<?,?> from, DataFetchingEnvironment environment) {
 
         List<Argument> arguments = new ArrayList<>();
+        List<Predicate> predicates = new ArrayList<>();
 
         // Loop through all of the fields being requested
         field.getSelectionSet().getSelections().forEach(selection -> {
@@ -161,6 +162,8 @@ class QraphQLJpaBaseDataFetcher implements DataFetcher<Object> {
                     Path<?> fieldPath = from.get(selectedField.getName());
                     From<?,?> fetch = null;
                     Optional<Argument> optionalArgument = getArgument(selectedField, OPTIONAL);
+                    Optional<Argument> whereArgument = getArgument(selectedField, WHERE);
+                    Boolean isOptional = null;
 
                     // Build predicate arguments for singular attributes only
                     if(fieldPath.getModel() instanceof SingularAttribute) {
@@ -176,46 +179,50 @@ class QraphQLJpaBaseDataFetcher implements DataFetcher<Object> {
                                 query.orderBy(cb.asc(fieldPath));
                         }
 
-                        // Process where arguments clauses.
-                        arguments.addAll(selectedField.getArguments()
-                            .stream()
-                            .filter(it -> !isOrderByArgument(it) && !isOptionalArgument(it))
-                            .map(it -> new Argument(selectedField.getName() + "." + it.getName(), it.getValue()))
-                            .collect(Collectors.toList()));
-
                         // Check if it's an object and the foreign side is One.  Then we can eagerly join causing an inner join instead of 2 queries
-                        if (fieldPath.getModel() instanceof SingularAttribute) {
-                            SingularAttribute<?,?> attribute = (SingularAttribute<?,?>) fieldPath.getModel();
-                            if (attribute.getPersistentAttributeType() == Attribute.PersistentAttributeType.MANY_TO_ONE
-                                || attribute.getPersistentAttributeType() == Attribute.PersistentAttributeType.ONE_TO_ONE
-                            ) {
-                               // Let's do fugly conversion 
-                               Boolean isOptional = optionalArgument.map(it -> getArgumentValue(environment, it, Boolean.class))
-                                                                    .orElse(attribute.isOptional());
+                        SingularAttribute<?,?> attribute = (SingularAttribute<?,?>) fieldPath.getModel();
+                        if (attribute.getPersistentAttributeType() == Attribute.PersistentAttributeType.MANY_TO_ONE
+                            || attribute.getPersistentAttributeType() == Attribute.PersistentAttributeType.ONE_TO_ONE
+                        ) {
+                           // Let's do fugly conversion 
+                           isOptional = optionalArgument.map(it -> getArgumentValue(environment, it, Boolean.class))
+                                                                .orElse(attribute.isOptional());
 
-                               // Let's apply left outer join to retrieve optional associations
-                               fetch = reuseFetch(from, selectedField.getName(), isOptional);
-                            }
+                           // Let's apply left outer join to retrieve optional associations
+                           fetch = reuseFetch(from, selectedField.getName(), isOptional);
+                        } else if(attribute.getPersistentAttributeType() == PersistentAttributeType.EMBEDDED) {
+                            // Process where arguments clauses.
+                            arguments.addAll(selectedField.getArguments()
+                                                          .stream()
+                                                          .filter(it -> !isOrderByArgument(it) && !isOptionalArgument(it))
+                                                          .map(it -> new Argument(selectedField.getName() + "." + it.getName(),
+                                                                                  it.getValue()))
+                                                          .collect(Collectors.toList()));
+                                
                         }
                     } else {
-                        // We must add plural attributes with explicit join 
+                        // We must add plural attributes with explicit join fetch 
                         // Let's do fugly conversion 
                         // the many end is a collection, and it is always optional by default (empty collection)
-                        Boolean isOptional = optionalArgument.map(it -> getArgumentValue(environment, it, Boolean.class))
+                        isOptional = optionalArgument.map(it -> getArgumentValue(environment, it, Boolean.class))
                                                              .orElse(toManyDefaultOptional);
-                        
+
                         // Let's apply join to retrieve associated collection
                         fetch = reuseFetch(from, selectedField.getName(), isOptional);
 
-                        // TODO add fetch argument parameter
                         // Let's fetch element collections to avoid filtering their values used where search criteria
-                        from.fetch(selectedField.getName(), 
-                                   isOptional ? JoinType.LEFT : JoinType.INNER);
+                        GraphQLObjectType objectType = getObjectType(environment);
+                        EntityType<?> entityType = getEntityType(objectType);
+
+                        PluralAttribute<?, ?, ?> attribute = (PluralAttribute<?, ?, ?>) entityType.getAttribute(selectedField.getName());
+                        
+                        if(PersistentAttributeType.ELEMENT_COLLECTION == attribute.getPersistentAttributeType()) {
+                            from.fetch(selectedField.getName());
+                        }                    
                     }
-                    
                     // Let's build join fetch graph to avoid Hibernate error: 
                     // "query specified join fetching, but the owner of the fetched association was not present in the select list"
-                    if(fetch != null && selectedField.getSelectionSet() != null) {
+                    if(selectedField.getSelectionSet() != null && fetch != null) {
                         GraphQLFieldDefinition fieldDefinition = getFieldDef(environment.getGraphQLSchema(),
                                                                              this.getObjectType(environment),
                                                                              selectedField);  
@@ -224,16 +231,21 @@ class QraphQLJpaBaseDataFetcher implements DataFetcher<Object> {
                         DataFetchingEnvironment fieldEnvironment = wherePredicateEnvironment(environment, 
                                                                                              fieldDefinition, 
                                                                                              args);
-                        // TODO nested where criteria expressions
-                        getFieldArguments(selectedField, query, cb, fetch, fieldEnvironment);
+                        predicates.addAll(getFieldPredicates(selectedField, query, cb, root, fetch, fieldEnvironment));
                     }
                 }
             }
         });
-
+        
         arguments.addAll(field.getArguments());
 
-        return arguments;
+        arguments.stream()
+                 .filter(it -> !isOrderByArgument(it) && !isOptionalArgument(it))
+                 .map(it -> getPredicate(cb, root, from, environment, it))
+                 .filter(it -> it != null)
+                 .forEach(predicates::add);
+
+        return predicates;
     }
 
     /**
@@ -331,7 +343,7 @@ class QraphQLJpaBaseDataFetcher implements DataFetcher<Object> {
                 String fieldName = argument.getName().split("\\.")[0];
 
                 From<?,?> join = getCompoundJoin(path, argument.getName(), true);
-                Argument where = new Argument("where",  argument.getValue());
+                Argument where = new Argument(WHERE,  argument.getValue());
                 Map<String, Object> variables = environment.getExecutionContext().getVariables();
 
                 GraphQLFieldDefinition fieldDef = getFieldDef(
@@ -342,7 +354,7 @@ class QraphQLJpaBaseDataFetcher implements DataFetcher<Object> {
 
                 Map<String, Object> arguments = (Map<String, Object>) new ValuesResolver()
                     .getArgumentValues(fieldDef.getArguments(), Collections.singletonList(where), variables)
-                    .get("where");
+                    .get(WHERE);
 
                 return getWherePredicate(cb, from, join, wherePredicateEnvironment(environment, fieldDef, arguments), where);
             }
@@ -417,7 +429,7 @@ class QraphQLJpaBaseDataFetcher implements DataFetcher<Object> {
                                                                                    new Field(it.getName()));
                               boolean isOptional = false;
                               
-                              return getArgumentPredicate(cb, reuseFetch(from, it.getName(), isOptional),  
+                              return getArgumentPredicate(cb, reuseJoin(from, it.getName(), isOptional),  
                                                           wherePredicateEnvironment(environment, fieldDefinition, args),
                                                           arg);
                           }
@@ -502,7 +514,7 @@ class QraphQLJpaBaseDataFetcher implements DataFetcher<Object> {
                                                                                               new Field(it.getName()));
                                          boolean isOptional = false;
                                          
-                                         return getArgumentPredicate(cb, reuseFetch(path, it.getName(), isOptional),  
+                                         return getArgumentPredicate(cb, reuseJoin(path, it.getName(), isOptional),  
                                                                      wherePredicateEnvironment(environment, fieldDefinition, args),
                                                                      arg);
                                      }
@@ -631,7 +643,7 @@ class QraphQLJpaBaseDataFetcher implements DataFetcher<Object> {
                 isOptional = isOptionalAttribute(getAttribute(environment, argument));
             }
             
-            return getArgumentPredicate(cb, reuseFetch(path, fieldName, isOptional),  
+            return getArgumentPredicate(cb, reuseJoin(path, fieldName, isOptional),  
                                         wherePredicateEnvironment(environment, fieldDefinition, args),
                                         arg);
         }
@@ -714,7 +726,7 @@ class QraphQLJpaBaseDataFetcher implements DataFetcher<Object> {
     private From<?,?> getCompoundJoin(From<?,?> rootPath, String fieldName, boolean outer) {
         String[] compoundField = fieldName.split("\\.");
 
-        Join<?,?> join;
+        From<?,?> join;
 
         if (compoundField.length == 1) {
             return rootPath;
@@ -740,7 +752,7 @@ class QraphQLJpaBaseDataFetcher implements DataFetcher<Object> {
     private Path<?> getCompoundJoinedPath(From<?,?> rootPath, String fieldName, boolean outer) {
         String[] compoundField = fieldName.split("\\.");
 
-        Join<?,?> join;
+        From<?,?> join;
 
         if (compoundField.length == 1) {
             return rootPath.get(compoundField[0]);
@@ -760,7 +772,7 @@ class QraphQLJpaBaseDataFetcher implements DataFetcher<Object> {
     }
 
     // trying to find already existing joins to reuse
-    private Join<?,?> reuseJoin(From<?, ?> from, String fieldName, boolean outer) {
+    private From<?,?> reuseJoin(From<?, ?> from, String fieldName, boolean outer) {
 
         for (Join<?,?> join : from.getJoins()) {
             if (join.getAttribute().getName().equals(fieldName)) {

--- a/graphql-jpa-query-schema/src/test/java/com/introproventures/graphql/jpa/query/schema/GraphQLEnumVariableBindingsTests.java
+++ b/graphql-jpa-query-schema/src/test/java/com/introproventures/graphql/jpa/query/schema/GraphQLEnumVariableBindingsTests.java
@@ -195,9 +195,7 @@ public class GraphQLEnumVariableBindingsTests {
                 +   "{id=1, name=Leo Tolstoy, books=["
                 +       "{id=2, title=War and Peace, genre=NOVEL}, "
                 +       "{id=3, title=Anna Karenina, genre=NOVEL}"
-                +   "]}, "
-                +   "{id=4, name=Anton Chekhov, books=[]}, "
-                +   "{id=8, name=Igor Dianov, books=[]}"
+                +   "]}"
                 + "]}}";
 
         //when

--- a/graphql-jpa-query-schema/src/test/java/com/introproventures/graphql/jpa/query/schema/GraphQLExecutorTests.java
+++ b/graphql-jpa-query-schema/src/test/java/com/introproventures/graphql/jpa/query/schema/GraphQLExecutorTests.java
@@ -410,7 +410,7 @@ public class GraphQLExecutorTests {
                 "  }"
                 + "}";
         
-        String expected = "{Authors={select=[{id=8, name=Igor Dianov, books=[]}]}}";
+        String expected = "{Authors={select=[]}}";
 
         //when
         Object result = executor.execute(query).getData();
@@ -909,8 +909,8 @@ public class GraphQLExecutorTests {
                 +   "id=1, "
                 +   "name=Leo Tolstoy, "
                 +   "books=["
-                +       "{id=3, title=Anna Karenina, genre=NOVEL}, "
-                +       "{id=2, title=War and Peace, genre=NOVEL}"
+                +       "{id=2, title=War and Peace, genre=NOVEL}, "
+                +       "{id=3, title=Anna Karenina, genre=NOVEL}"
                 +   "]}"
                 + "}]}}";
 
@@ -921,9 +921,85 @@ public class GraphQLExecutorTests {
         assertThat(result.toString()).isEqualTo(expected);
     }    
     
+    @Test
+    public void queryWithOneToManyNestedRelationsWithManyToOneOptionalTrue() {
+        //given:
+        String query = "query { " +
+                "  Authors {" + 
+                "    select {" + 
+                "      id" + 
+                "      name" + 
+                "      books {" + 
+                "        id" + 
+                "        title" + 
+                "        genre" + 
+                "        author(optional: true) {" + 
+                "          id" + 
+                "        }" + 
+                "      }" + 
+                "    }" + 
+                "  }" +
+                "}";
+
+        String expected = "{Authors={select=["
+                + "{id=1, name=Leo Tolstoy, books=["
+                +   "{id=2, title=War and Peace, genre=NOVEL, author={id=1}}, "
+                +   "{id=3, title=Anna Karenina, genre=NOVEL, author={id=1}}"
+                + "]}, "
+                + "{id=4, name=Anton Chekhov, books=["
+                +   "{id=5, title=The Cherry Orchard, genre=PLAY, author={id=4}}, "
+                +   "{id=6, title=The Seagull, genre=PLAY, author={id=4}}, "
+                +   "{id=7, title=Three Sisters, genre=PLAY, author={id=4}}"
+                + "]}, "
+                + "{id=8, name=Igor Dianov, books=[]}"
+                + "]}}";
+
+        //when:
+        Object result = executor.execute(query).getData();
+
+        //then:
+        assertThat(result.toString()).isEqualTo(expected);
+    }    
+
+    @Test
+    public void queryWithOneToManyNestedRelationsWithManyToOneOptionalFalse() {
+        //given:
+        String query = "query { " +
+                "  Authors {" + 
+                "    select {" + 
+                "      id" + 
+                "      name" + 
+                "      books {" + 
+                "        id" + 
+                "        title" + 
+                "        genre" + 
+                "        author(optional: false) {" + 
+                "          id" + 
+                "        }" + 
+                "      }" + 
+                "    }" + 
+                "  }" +
+                "}";
+
+        String expected = "{Authors={select=["
+                + "{id=1, name=Leo Tolstoy, books=["
+                +   "{id=2, title=War and Peace, genre=NOVEL, author={id=1}}, "
+                +   "{id=3, title=Anna Karenina, genre=NOVEL, author={id=1}}"
+                + "]}, "
+                + "{id=4, name=Anton Chekhov, books=["
+                +   "{id=5, title=The Cherry Orchard, genre=PLAY, author={id=4}}, "
+                +   "{id=6, title=The Seagull, genre=PLAY, author={id=4}}, "
+                +   "{id=7, title=Three Sisters, genre=PLAY, author={id=4}}"
+                + "]}"
+                + "]}}";
+
+        //when:
+        Object result = executor.execute(query).getData();
+
+        //then:
+        assertThat(result.toString()).isEqualTo(expected);
+    }    
     
-
-
     @Test
     public void ignoreFilter() {
         //given

--- a/graphql-jpa-query-schema/src/test/java/com/introproventures/graphql/jpa/query/schema/StarwarsQueryExecutorTests.java
+++ b/graphql-jpa-query-schema/src/test/java/com/introproventures/graphql/jpa/query/schema/StarwarsQueryExecutorTests.java
@@ -29,7 +29,6 @@ import javax.transaction.Transactional;
 
 import com.introproventures.graphql.jpa.query.schema.impl.GraphQLJpaExecutor;
 import com.introproventures.graphql.jpa.query.schema.impl.GraphQLJpaSchemaBuilder;
-import org.junit.Ignore;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -919,7 +918,6 @@ public class StarwarsQueryExecutorTests {
     }
     
     @Test
-    @Ignore // TODO
     public void queryFilterNestedManyToOneToDo() {
         //given:
         String query = "query {" +
@@ -1039,9 +1037,9 @@ public class StarwarsQueryExecutorTests {
                 +   "}"
                 + "}, "
                 + "friends=["
-                +   "{name=Leia Organa}, "
                 +   "{name=C-3PO}, "
                 +   "{name=Han Solo}, "
+                +   "{name=Leia Organa}, "
                 +   "{name=R2-D2}"
                 + "]}"
                 + "]}}";


### PR DESCRIPTION
This PR adds support for nested where criteria expressions, i.e. given query

```
query { 
  Humans {        
    select {
      id
      name
      homePlanet
      favoriteDroid {
        name
        primaryFunction(where:{function:{EQ:"Astromech"}}) {
          function
        }
      }
    }
  }  
}
```

Will result in

```
{
  "data": {
    "Humans": {
      "select": [
        {
          "id": "1001",
          "name": "Darth Vader",
          "homePlanet": "Tatooine",
          "favoriteDroid": {
            "name": "R2-D2",
            "primaryFunction": {
              "function": "Astromech"
            }
          }
        }
      ]
    }
  }
}
```