### PR TITLE
fix: correct element collection fetch sort order

### DIFF
--- a/graphql-jpa-query-schema/src/main/java/com/introproventures/graphql/jpa/query/schema/impl/JpaPredicateBuilder.java
+++ b/graphql-jpa-query-schema/src/main/java/com/introproventures/graphql/jpa/query/schema/impl/JpaPredicateBuilder.java
@@ -28,8 +28,8 @@ import java.util.UUID;
 
 import javax.persistence.criteria.CriteriaBuilder;
 import javax.persistence.criteria.Expression;
-import javax.persistence.criteria.Fetch;
 import javax.persistence.criteria.From;
+import javax.persistence.criteria.Join;
 import javax.persistence.criteria.Path;
 import javax.persistence.criteria.Predicate;
 import javax.persistence.metamodel.EntityType;
@@ -420,14 +420,15 @@ class JpaPredicateBuilder {
                     || EntityType.class.isInstance(from.getModel())) {
                 From<?,?> join = null;
                 
-                for(Fetch<?,?> fetch: from.getFetches()) {
+                for(Join<?,?> fetch: from.getJoins()) {
                     if(fetch.getAttribute().getName().equals(filter.getField()))
                         join = (From<?,?>) fetch;
                 }
                 
                 if(join == null) {
-                    join = (From<?,?>) from.fetch(filter.getField());
+                    join = (From<?,?>) from.join(filter.getField());
                 }
+                
                 
                 Predicate in = join.in(value);
                 

--- a/graphql-jpa-query-schema/src/test/java/com/introproventures/graphql/jpa/query/schema/StarwarsQueryExecutorTests.java
+++ b/graphql-jpa-query-schema/src/test/java/com/introproventures/graphql/jpa/query/schema/StarwarsQueryExecutorTests.java
@@ -29,6 +29,7 @@ import javax.transaction.Transactional;
 
 import com.introproventures.graphql.jpa.query.schema.impl.GraphQLJpaExecutor;
 import com.introproventures.graphql.jpa.query.schema.impl.GraphQLJpaSchemaBuilder;
+import org.junit.Ignore;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -351,6 +352,7 @@ public class StarwarsQueryExecutorTests {
     }
 
     @Test
+    @Ignore
     public void queryOrderByFieldsNested() {
         //given:
         String query = "query { Humans(where: {id: {EQ: \"1000\"}}) { select {name(orderBy: DESC) homePlanet friends { name(orderBy:DESC) } } } }";
@@ -401,9 +403,9 @@ public class StarwarsQueryExecutorTests {
 
 
         String expected = "{Humans={select=["
-                + "{name=Luke Skywalker, appearsIn=[A_NEW_HOPE, THE_FORCE_AWAKENS, EMPIRE_STRIKES_BACK, RETURN_OF_THE_JEDI]}, "
-                + "{name=Han Solo, appearsIn=[A_NEW_HOPE, THE_FORCE_AWAKENS, EMPIRE_STRIKES_BACK, RETURN_OF_THE_JEDI]}, "
-                + "{name=Leia Organa, appearsIn=[A_NEW_HOPE, THE_FORCE_AWAKENS, EMPIRE_STRIKES_BACK, RETURN_OF_THE_JEDI]}"
+                + "{name=Luke Skywalker, appearsIn=[A_NEW_HOPE, EMPIRE_STRIKES_BACK, RETURN_OF_THE_JEDI, THE_FORCE_AWAKENS]}, "
+                + "{name=Han Solo, appearsIn=[A_NEW_HOPE, EMPIRE_STRIKES_BACK, RETURN_OF_THE_JEDI, THE_FORCE_AWAKENS]}, "
+                + "{name=Leia Organa, appearsIn=[A_NEW_HOPE, EMPIRE_STRIKES_BACK, RETURN_OF_THE_JEDI, THE_FORCE_AWAKENS]}"
                 + "]}}";
 
         //when:
@@ -684,6 +686,47 @@ public class StarwarsQueryExecutorTests {
     
     @Test
     public void queryWithWhereInsideCompositeRelationsAndCollectionFiltering() {
+        //given:
+        String query = "query {" + 
+                "  Characters(where: {\n" + 
+                "    friends: {appearsIn: {IN: A_NEW_HOPE}}\n" + 
+                "  }) {\n" + 
+                "    select {\n" + 
+                "      id\n" + 
+                "      name\n" + 
+                "      appearsIn\n" + 
+                "      friends(where: {name: {LIKE: \"Leia\"}}) {\n" + 
+                "        id\n" + 
+                "        name\n" + 
+                "      }\n" + 
+                "    }\n" + 
+                "  }\n" + 
+                "}";
+
+        String expected = "{Characters={select=["
+                + "{id=1000, name=Luke Skywalker, appearsIn=[A_NEW_HOPE, EMPIRE_STRIKES_BACK, RETURN_OF_THE_JEDI, THE_FORCE_AWAKENS], friends=["
+                +   "{id=1003, name=Leia Organa}"
+                + "]}, "
+                + "{id=1002, name=Han Solo, appearsIn=[A_NEW_HOPE, EMPIRE_STRIKES_BACK, RETURN_OF_THE_JEDI, THE_FORCE_AWAKENS], friends=["
+                +   "{id=1003, name=Leia Organa}"
+                + "]}, "
+                + "{id=2000, name=C-3PO, appearsIn=[A_NEW_HOPE, EMPIRE_STRIKES_BACK, RETURN_OF_THE_JEDI, THE_FORCE_AWAKENS], friends=["
+                +   "{id=1003, name=Leia Organa}"
+                + "]}, "
+                + "{id=2001, name=R2-D2, appearsIn=[A_NEW_HOPE, EMPIRE_STRIKES_BACK, RETURN_OF_THE_JEDI, THE_FORCE_AWAKENS], friends=["
+                +   "{id=1003, name=Leia Organa}"
+                + "]}"
+                + "]}}";
+
+        //when:
+        Object result = executor.execute(query).getData();
+
+        //then:
+        assertThat(result.toString()).isEqualTo(expected);
+    }       
+    
+    @Test
+    public void queryWithWhereInsideCompositeRelationsAndCollectionFiltering2() {
         //given:
         String query = "query {" + 
                 "  Humans(where: {" + 
@@ -1167,11 +1210,11 @@ public class StarwarsQueryExecutorTests {
                 "}";
 
         String expected = "{Characters={select=["
-                + "{id=1000, name=Luke Skywalker, appearsIn=[A_NEW_HOPE, THE_FORCE_AWAKENS, EMPIRE_STRIKES_BACK, RETURN_OF_THE_JEDI]}, "
-                + "{id=1002, name=Han Solo, appearsIn=[A_NEW_HOPE, THE_FORCE_AWAKENS, EMPIRE_STRIKES_BACK, RETURN_OF_THE_JEDI]}, "
-                + "{id=1003, name=Leia Organa, appearsIn=[A_NEW_HOPE, THE_FORCE_AWAKENS, EMPIRE_STRIKES_BACK, RETURN_OF_THE_JEDI]}, "
-                + "{id=2000, name=C-3PO, appearsIn=[A_NEW_HOPE, THE_FORCE_AWAKENS, EMPIRE_STRIKES_BACK, RETURN_OF_THE_JEDI]}, "
-                + "{id=2001, name=R2-D2, appearsIn=[A_NEW_HOPE, THE_FORCE_AWAKENS, EMPIRE_STRIKES_BACK, RETURN_OF_THE_JEDI]}"
+                + "{id=1000, name=Luke Skywalker, appearsIn=[A_NEW_HOPE, EMPIRE_STRIKES_BACK, RETURN_OF_THE_JEDI, THE_FORCE_AWAKENS]}, "
+                + "{id=1002, name=Han Solo, appearsIn=[A_NEW_HOPE, EMPIRE_STRIKES_BACK, RETURN_OF_THE_JEDI, THE_FORCE_AWAKENS]}, "
+                + "{id=1003, name=Leia Organa, appearsIn=[A_NEW_HOPE, EMPIRE_STRIKES_BACK, RETURN_OF_THE_JEDI, THE_FORCE_AWAKENS]}, "
+                + "{id=2000, name=C-3PO, appearsIn=[A_NEW_HOPE, EMPIRE_STRIKES_BACK, RETURN_OF_THE_JEDI, THE_FORCE_AWAKENS]}, "
+                + "{id=2001, name=R2-D2, appearsIn=[A_NEW_HOPE, EMPIRE_STRIKES_BACK, RETURN_OF_THE_JEDI, THE_FORCE_AWAKENS]}"
                 + "]}}";
 
         //when:
@@ -1207,7 +1250,7 @@ public class StarwarsQueryExecutorTests {
                 +   "name=Luke Skywalker, "
                 +   "homePlanet=Tatooine, "
                 +   "favoriteDroid={name=C-3PO}, "
-                +   "appearsIn=[A_NEW_HOPE, THE_FORCE_AWAKENS, EMPIRE_STRIKES_BACK, RETURN_OF_THE_JEDI]"
+                +   "appearsIn=[A_NEW_HOPE, EMPIRE_STRIKES_BACK, RETURN_OF_THE_JEDI, THE_FORCE_AWAKENS]"
                 + "}]}}";
 
         //when:

--- a/graphql-jpa-query-schema/src/test/java/com/introproventures/graphql/jpa/query/schema/StarwarsQueryExecutorTests.java
+++ b/graphql-jpa-query-schema/src/test/java/com/introproventures/graphql/jpa/query/schema/StarwarsQueryExecutorTests.java
@@ -29,7 +29,6 @@ import javax.transaction.Transactional;
 
 import com.introproventures.graphql.jpa.query.schema.impl.GraphQLJpaExecutor;
 import com.introproventures.graphql.jpa.query.schema.impl.GraphQLJpaSchemaBuilder;
-import org.junit.Ignore;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -352,7 +351,6 @@ public class StarwarsQueryExecutorTests {
     }
 
     @Test
-    @Ignore
     public void queryOrderByFieldsNested() {
         //given:
         String query = "query { Humans(where: {id: {EQ: \"1000\"}}) { select {name(orderBy: DESC) homePlanet friends { name(orderBy:DESC) } } } }";


### PR DESCRIPTION
This PR fixes element collections fetch  sort order, i.e. given

```
{
  Humans ( where: { 
    appearsIn: {IN: [THE_FORCE_AWAKENS]}
  }) { 
    select { 
      name 
      appearsIn 
    } 
  }
}
```

Will result:

```
{
  "data": {
    "Humans": {
      "select": [
        {
          "name": "Luke Skywalker",
          "appearsIn": [
            "A_NEW_HOPE",
            "EMPIRE_STRIKES_BACK",
            "RETURN_OF_THE_JEDI",
            "THE_FORCE_AWAKENS"
          ]
        },
        {
          "name": "Han Solo",
          "appearsIn": [
            "A_NEW_HOPE",
            "EMPIRE_STRIKES_BACK",
            "RETURN_OF_THE_JEDI",
            "THE_FORCE_AWAKENS"
          ]
        },
        {
          "name": "Leia Organa",
          "appearsIn": [
            "A_NEW_HOPE",
            "EMPIRE_STRIKES_BACK",
            "RETURN_OF_THE_JEDI",
            "THE_FORCE_AWAKENS"
          ]
        }
      ]
    }
  }
}
```