### PR TITLE
feat: add conditional property to disable GraphQLController

### DIFF
--- a/graphql-jpa-query-web/src/main/java/com/introproventures/graphql/jpa/query/web/autoconfigure/GraphQLControllerAutoConfiguration.java
+++ b/graphql-jpa-query-web/src/main/java/com/introproventures/graphql/jpa/query/web/autoconfigure/GraphQLControllerAutoConfiguration.java
@@ -12,7 +12,7 @@ import com.introproventures.graphql.jpa.query.web.GraphQLController;
 @Configuration
 @ConditionalOnWebApplication
 @ConditionalOnClass(GraphQLExecutor.class)
-@ConditionalOnProperty(name= "spring.graphql.jpa.query.web.enabled", havingValue="true", matchIfMissing=true)
+@ConditionalOnProperty(prefix = "spring.graphql.jpa.query", name = {"enabled", "web.enabled"}, havingValue="true", matchIfMissing=true)
 public class GraphQLControllerAutoConfiguration {
     
     @Import(GraphQLController.class)

--- a/graphql-jpa-query-web/src/main/java/com/introproventures/graphql/jpa/query/web/autoconfigure/GraphQLControllerAutoConfiguration.java
+++ b/graphql-jpa-query-web/src/main/java/com/introproventures/graphql/jpa/query/web/autoconfigure/GraphQLControllerAutoConfiguration.java
@@ -1,15 +1,18 @@
 package com.introproventures.graphql.jpa.query.web.autoconfigure;
 
-import com.introproventures.graphql.jpa.query.schema.GraphQLExecutor;
-import com.introproventures.graphql.jpa.query.web.GraphQLController;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnWebApplication;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Import;
 
+import com.introproventures.graphql.jpa.query.schema.GraphQLExecutor;
+import com.introproventures.graphql.jpa.query.web.GraphQLController;
+
 @Configuration
 @ConditionalOnWebApplication
 @ConditionalOnClass(GraphQLExecutor.class)
+@ConditionalOnProperty(name= "spring.graphql.jpa.query.web.enabled", havingValue="true", matchIfMissing=true)
 public class GraphQLControllerAutoConfiguration {
     
     @Import(GraphQLController.class)

--- a/graphql-jpa-query-web/src/test/java/com/introproventures/graphql/jpa/query/web/autoconfigure/GraphQLControllerAutoConfigurationPropertyDisabledTest.java
+++ b/graphql-jpa-query-web/src/test/java/com/introproventures/graphql/jpa/query/web/autoconfigure/GraphQLControllerAutoConfigurationPropertyDisabledTest.java
@@ -1,0 +1,38 @@
+package com.introproventures.graphql.jpa.query.web.autoconfigure;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.context.SpringBootTest.WebEnvironment;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.test.context.junit4.SpringRunner;
+
+import com.introproventures.graphql.jpa.query.schema.GraphQLExecutor;
+import com.introproventures.graphql.jpa.query.web.GraphQLController;
+
+@RunWith(SpringRunner.class)
+@SpringBootTest(webEnvironment=WebEnvironment.RANDOM_PORT,
+                properties = "spring.graphql.jpa.query.web.enabled=false")
+public class GraphQLControllerAutoConfigurationPropertyDisabledTest {
+    
+    @MockBean
+    private GraphQLExecutor graphQLExecutor;
+    
+    @Autowired(required=false)
+    private GraphQLController graphQLController;
+    
+    @SpringBootApplication
+    static class Application {
+        
+    }
+    
+    @Test
+    public void contextLoads() {
+        assertThat(graphQLController).isNull();
+    }
+
+}

--- a/graphql-jpa-query-web/src/test/java/com/introproventures/graphql/jpa/query/web/autoconfigure/GraphQLControllerAutoConfigurationWebPropertyDisabledTest.java
+++ b/graphql-jpa-query-web/src/test/java/com/introproventures/graphql/jpa/query/web/autoconfigure/GraphQLControllerAutoConfigurationWebPropertyDisabledTest.java
@@ -16,8 +16,9 @@ import com.introproventures.graphql.jpa.query.web.GraphQLController;
 
 @RunWith(SpringRunner.class)
 @SpringBootTest(webEnvironment=WebEnvironment.RANDOM_PORT,
-                properties = "spring.graphql.jpa.query.enabled=false")
-public class GraphQLControllerAutoConfigurationPropertyDisabledTest {
+                properties = {"spring.graphql.jpa.query.enabled=true",
+                              "spring.graphql.jpa.query.web.enabled=false"})
+public class GraphQLControllerAutoConfigurationWebPropertyDisabledTest {
     
     @MockBean
     private GraphQLExecutor graphQLExecutor;


### PR DESCRIPTION
This PR adds support to disable GraphQLController auto configuration using `spring.graphql.jpa.query.web.enabled` property. The auto configuration will also be disabled if `spring.graphql.jpa.query.enabled=false` 

Fixes https://github.com/introproventures/graphql-jpa-query/issues/144