### PR TITLE
feat: add support for variable where criteria expressions

### DIFF
--- a/graphql-jpa-query-schema/src/main/java/com/introproventures/graphql/jpa/query/schema/impl/QraphQLJpaBaseDataFetcher.java
+++ b/graphql-jpa-query-schema/src/main/java/com/introproventures/graphql/jpa/query/schema/impl/QraphQLJpaBaseDataFetcher.java
@@ -395,7 +395,7 @@ class QraphQLJpaBaseDataFetcher implements DataFetcher<Object> {
             
             GraphQLArgument graphQLArgument = environment.getExecutionStepInfo()
                                                 .getFieldDefinition()
-                                                .getArgument(variableName);
+                                                .getArgument(argument.getName());
             
             return (R) AstValueHelper.astFromValue(variableValue, graphQLArgument.getType());
         }
@@ -918,19 +918,19 @@ class QraphQLJpaBaseDataFetcher implements DataFetcher<Object> {
             }
         } else if (value instanceof ArrayValue) {
             Object convertedValue =  environment.getArgument(argument.getName());
-            
+
             if (convertedValue != null && getJavaType(environment, argument).isEnum()) {
-                
+
                 Function<Object, Value> f = (obj) -> Value.class.isInstance(obj)
-                                                        ? Value.class.cast(obj)  
+                                                        ? Value.class.cast(obj)
                                                         : new EnumValue(obj.toString());
-                
+
                 // unwrap [[EnumValue{name='value'}]]
                 if(convertedValue instanceof Collection
                     && ((Collection) convertedValue).stream().allMatch(it->it instanceof Collection)) {
                     convertedValue = ((Collection) convertedValue).iterator().next();
                 }
-                
+
                 if(convertedValue instanceof Collection) {
                     return ((Collection) convertedValue).stream()
                         .map((it) -> convertValue(environment, argument, f.apply(it)))
@@ -939,7 +939,7 @@ class QraphQLJpaBaseDataFetcher implements DataFetcher<Object> {
                     // Return real typed resolved array value
                 return convertValue(environment, argument, f.apply(convertedValue));
             }
-            else 
+            else
               if (convertedValue != null && !getJavaType(environment, argument).isEnum()) {
                 // unwrap [[EnumValue{name='value'}]]
                 if(convertedValue instanceof Collection

--- a/graphql-jpa-query-schema/src/test/java/com/introproventures/graphql/jpa/query/schema/GraphQLExecutorTests.java
+++ b/graphql-jpa-query-schema/src/test/java/com/introproventures/graphql/jpa/query/schema/GraphQLExecutorTests.java
@@ -18,15 +18,10 @@ package com.introproventures.graphql.jpa.query.schema;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-import java.util.AbstractMap;
 import java.util.Arrays;
-import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.Map.Entry;
-import java.util.stream.Collectors;
-import java.util.stream.Stream;
 
 import javax.persistence.EntityManager;
 
@@ -1421,110 +1416,6 @@ public class GraphQLExecutorTests {
 
         // then
         assertThat(result.toString()).isEqualTo(expected);
-    }
-    
-    @Test
-    public void queryBooksWithWhereVariableCriteriaExpression() {
-        //given
-        String query = "query($where: BooksCriteriaExpression) {" + 
-                "  Books (where: $where) {" + 
-                "    select {" + 
-                "      id" + 
-                "      title" + 
-                "      genre" + 
-                "    }" + 
-                "  }" + 
-                "}";
-        
-        Map<String, Object> variables = map(entry("where",
-                                                  map(entry("title",
-                                                            map(entry("LIKE",
-                                                                      "War"))))));
-        String expected = "{Books={select=["
-                + "{id=2, title=War and Peace, genre=NOVEL}"
-                + "]}}";
-
-        //when
-        Object result = executor.execute(query, variables).getData();
-
-        // then
-        assertThat(result.toString()).isEqualTo(expected);
-    }
-    
-    @Test
-    public void queryBooksWithWhereVariableCriteriaEnumListExpression() {
-        //given
-        String query = "query($where: BooksCriteriaExpression) {" + 
-                "  Books (where: $where) {" + 
-                "    select {" + 
-                "      id" + 
-                "      title" + 
-                "      genre" + 
-                "    }" + 
-                "  }" + 
-                "}";
-        
-        Map<String, Object> variables = map(entry("where",
-                                                  map(entry("genre",
-                                                            map(entry("IN",
-                                                                      Arrays.asList("NOVEL")))))));
-
-        String expected = "{Books={select=["
-                + "{id=2, title=War and Peace, genre=NOVEL}, "
-                + "{id=3, title=Anna Karenina, genre=NOVEL}"
-                + "]}}";
-
-        //when
-        Object result = executor.execute(query, variables).getData();
-
-        // then
-        assertThat(result.toString()).isEqualTo(expected);
-    }       
-    
-    @Test
-    public void queryBooksWithWhereVariableCriteriaEnumExpression() {
-        //given
-        String query = "query($where: BooksCriteriaExpression) {" + 
-                "  Books (where: $where) {" + 
-                "    select {" + 
-                "      id" + 
-                "      title" + 
-                "      genre" + 
-                "    }" + 
-                "  }" + 
-                "}";
-        
-        Map<String, Object> variables = map(entry("where",
-                                                  map(entry("genre",
-                                                            map(entry("IN",
-                                                                      "NOVEL"))))));
-        String expected = "{Books={select=["
-                + "{id=2, title=War and Peace, genre=NOVEL}, "
-                + "{id=3, title=Anna Karenina, genre=NOVEL}"
-                + "]}}";
-
-        //when
-        Object result = executor.execute(query, variables).getData();
-
-        // then
-        assertThat(result.toString()).isEqualTo(expected);
-    }
-    
-    
-    @SafeVarargs
-    static <K, V> Map<K, V> map(Entry<? extends K, ? extends V>... entries) {
-        if (entries.length == 0) { // implicit null check of entries array
-            return Collections.emptyMap();
-        } else if (entries.length == 1) {
-            return Collections.singletonMap(entries[0].getKey(), entries[0].getValue());
-        } else {
-            return Stream.of(entries)
-                         .collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue));
-        }
-    }
-    
-    static <K, V> Entry<K, V> entry(K k, V v) {
-        return new AbstractMap.SimpleImmutableEntry<>(k, v);
     }
     
 }

--- a/graphql-jpa-query-schema/src/test/java/com/introproventures/graphql/jpa/query/schema/GraphQLExecutorTests.java
+++ b/graphql-jpa-query-schema/src/test/java/com/introproventures/graphql/jpa/query/schema/GraphQLExecutorTests.java
@@ -18,19 +18,18 @@ package com.introproventures.graphql.jpa.query.schema;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+import java.util.AbstractMap;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Map.Entry;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 import javax.persistence.EntityManager;
 
-import com.introproventures.graphql.jpa.query.schema.impl.GraphQLJpaExecutor;
-import com.introproventures.graphql.jpa.query.schema.impl.GraphQLJpaSchemaBuilder;
-import graphql.ErrorType;
-import graphql.ExecutionResult;
-import graphql.GraphQLError;
-import graphql.validation.ValidationError;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -41,6 +40,14 @@ import org.springframework.context.annotation.Bean;
 import org.springframework.test.context.TestPropertySource;
 import org.springframework.test.context.junit4.SpringRunner;
 import org.springframework.util.Assert;
+
+import com.introproventures.graphql.jpa.query.schema.impl.GraphQLJpaExecutor;
+import com.introproventures.graphql.jpa.query.schema.impl.GraphQLJpaSchemaBuilder;
+
+import graphql.ErrorType;
+import graphql.ExecutionResult;
+import graphql.GraphQLError;
+import graphql.validation.ValidationError;
 
 
 @RunWith(SpringRunner.class)
@@ -1415,4 +1422,109 @@ public class GraphQLExecutorTests {
         // then
         assertThat(result.toString()).isEqualTo(expected);
     }
+    
+    @Test
+    public void queryBooksWithWhereVariableCriteriaExpression() {
+        //given
+        String query = "query($where: BooksCriteriaExpression) {" + 
+                "  Books (where: $where) {" + 
+                "    select {" + 
+                "      id" + 
+                "      title" + 
+                "      genre" + 
+                "    }" + 
+                "  }" + 
+                "}";
+        
+        Map<String, Object> variables = map(entry("where",
+                                                  map(entry("title",
+                                                            map(entry("LIKE",
+                                                                      "War"))))));
+        String expected = "{Books={select=["
+                + "{id=2, title=War and Peace, genre=NOVEL}"
+                + "]}}";
+
+        //when
+        Object result = executor.execute(query, variables).getData();
+
+        // then
+        assertThat(result.toString()).isEqualTo(expected);
+    }
+    
+    @Test
+    public void queryBooksWithWhereVariableCriteriaEnumListExpression() {
+        //given
+        String query = "query($where: BooksCriteriaExpression) {" + 
+                "  Books (where: $where) {" + 
+                "    select {" + 
+                "      id" + 
+                "      title" + 
+                "      genre" + 
+                "    }" + 
+                "  }" + 
+                "}";
+        
+        Map<String, Object> variables = map(entry("where",
+                                                  map(entry("genre",
+                                                            map(entry("IN",
+                                                                      Arrays.asList("NOVEL")))))));
+
+        String expected = "{Books={select=["
+                + "{id=2, title=War and Peace, genre=NOVEL}, "
+                + "{id=3, title=Anna Karenina, genre=NOVEL}"
+                + "]}}";
+
+        //when
+        Object result = executor.execute(query, variables).getData();
+
+        // then
+        assertThat(result.toString()).isEqualTo(expected);
+    }       
+    
+    @Test
+    public void queryBooksWithWhereVariableCriteriaEnumExpression() {
+        //given
+        String query = "query($where: BooksCriteriaExpression) {" + 
+                "  Books (where: $where) {" + 
+                "    select {" + 
+                "      id" + 
+                "      title" + 
+                "      genre" + 
+                "    }" + 
+                "  }" + 
+                "}";
+        
+        Map<String, Object> variables = map(entry("where",
+                                                  map(entry("genre",
+                                                            map(entry("IN",
+                                                                      "NOVEL"))))));
+        String expected = "{Books={select=["
+                + "{id=2, title=War and Peace, genre=NOVEL}, "
+                + "{id=3, title=Anna Karenina, genre=NOVEL}"
+                + "]}}";
+
+        //when
+        Object result = executor.execute(query, variables).getData();
+
+        // then
+        assertThat(result.toString()).isEqualTo(expected);
+    }
+    
+    
+    @SafeVarargs
+    static <K, V> Map<K, V> map(Entry<? extends K, ? extends V>... entries) {
+        if (entries.length == 0) { // implicit null check of entries array
+            return Collections.emptyMap();
+        } else if (entries.length == 1) {
+            return Collections.singletonMap(entries[0].getKey(), entries[0].getValue());
+        } else {
+            return Stream.of(entries)
+                         .collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue));
+        }
+    }
+    
+    static <K, V> Entry<K, V> entry(K k, V v) {
+        return new AbstractMap.SimpleImmutableEntry<>(k, v);
+    }
+    
 }

--- a/graphql-jpa-query-schema/src/test/java/com/introproventures/graphql/jpa/query/schema/GraphQLWhereVariableBindingsTests.java
+++ b/graphql-jpa-query-schema/src/test/java/com/introproventures/graphql/jpa/query/schema/GraphQLWhereVariableBindingsTests.java
@@ -1,10 +1,10 @@
 package com.introproventures.graphql.jpa.query.schema;
 
-import static org.assertj.core.api.Assertions.tuple;
-import static org.assertj.core.api.BDDAssertions.then;
-
 import static com.introproventures.graphql.jpa.query.schema.model.book.Genre.NOVEL;
 import static com.introproventures.graphql.jpa.query.schema.model.book.Genre.PLAY;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.tuple;
+import static org.assertj.core.api.BDDAssertions.then;
 
 import java.io.IOException;
 import java.util.Map;
@@ -287,7 +287,106 @@ public class GraphQLWhereVariableBindingsTests {
 				.extracting("id", "title")
 				.containsOnly(tuple(5L, "The Cherry Orchard"));
 	}
+	
+    @Test
+    public void queryBooksWithWhereVariableCriteriaEnumListExpression() throws IOException {
+        //given
+        String query = "query($where: BooksCriteriaExpression) {" + 
+                "  Books (where: $where) {" + 
+                "    select {" + 
+                "      id" + 
+                "      title" + 
+                "      genre" + 
+                "    }" + 
+                "  }" + 
+                "}";
+        
+        String variables = "{"
+                + "  \"where\": {"
+                + "      \"genre\": {"
+                + "          \"IN\": [\"NOVEL\"]"
+                + "       }"
+                + "   } "
+                + "}";
+        
+        String expected = "{Books={select=["
+                + "{id=2, title=War and Peace, genre=NOVEL}, "
+                + "{id=3, title=Anna Karenina, genre=NOVEL}"
+                + "]}}";
 
+        //when
+        Object result = executor.execute(query, getVariablesMap(variables)).getData();
+
+        // then
+        assertThat(result.toString()).isEqualTo(expected);
+    }       
+    
+    @Test
+    public void queryBooksWithWhereVariableCriteriaEnumExpression() throws IOException {
+        //given
+        String query = "query($where: BooksCriteriaExpression) {" + 
+                "  Books (where: $where) {" + 
+                "    select {" + 
+                "      id" + 
+                "      title" + 
+                "      genre" + 
+                "    }" + 
+                "  }" + 
+                "}";
+
+        String variables = "{"
+                + "  \"where\": {"
+                + "      \"genre\": {"
+                + "          \"IN\": \"NOVEL\""
+                + "       }"
+                + "   } "
+                + "}";
+        
+        String expected = "{Books={select=["
+                + "{id=2, title=War and Peace, genre=NOVEL}, "
+                + "{id=3, title=Anna Karenina, genre=NOVEL}"
+                + "]}}";
+
+        //when
+        Object result = executor.execute(query, getVariablesMap(variables)).getData();
+
+        // then
+        assertThat(result.toString()).isEqualTo(expected);
+    }
+    
+    @Test
+    public void queryBooksWithWhereVariableCriteriaEQEnumExpression() throws IOException {
+        //given
+        String query = "query($where: BooksCriteriaExpression) {" + 
+                "  Books (where: $where) {" + 
+                "    select {" + 
+                "      id" + 
+                "      title" + 
+                "      genre" + 
+                "    }" + 
+                "  }" + 
+                "}";
+
+        String variables = "{"
+                + "  \"where\": {"
+                + "      \"genre\": {"
+                + "          \"EQ\": \"NOVEL\""
+                + "       }"
+                + "   } "
+                + "}";
+        
+        String expected = "{Books={select=["
+                + "{id=2, title=War and Peace, genre=NOVEL}, "
+                + "{id=3, title=Anna Karenina, genre=NOVEL}"
+                + "]}}";
+
+        //when
+        Object result = executor.execute(query, getVariablesMap(variables)).getData();
+
+        // then
+        assertThat(result.toString()).isEqualTo(expected);
+    }    
+    
 	@SuppressWarnings("unchecked")
 	private Map<String, Object> getVariablesMap(String variables) throws IOException {
 		ObjectMapper mapper = new ObjectMapper();

--- a/graphql-jpa-query-schema/src/test/java/com/introproventures/graphql/jpa/query/schema/GraphQLWhereVariableBindingsTests.java
+++ b/graphql-jpa-query-schema/src/test/java/com/introproventures/graphql/jpa/query/schema/GraphQLWhereVariableBindingsTests.java
@@ -1,0 +1,296 @@
+package com.introproventures.graphql.jpa.query.schema;
+
+import static org.assertj.core.api.Assertions.tuple;
+import static org.assertj.core.api.BDDAssertions.then;
+
+import static com.introproventures.graphql.jpa.query.schema.model.book.Genre.NOVEL;
+import static com.introproventures.graphql.jpa.query.schema.model.book.Genre.PLAY;
+
+import java.io.IOException;
+import java.util.Map;
+
+import javax.persistence.EntityManager;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.context.SpringBootTest.WebEnvironment;
+import org.springframework.context.annotation.Bean;
+import org.springframework.test.context.TestPropertySource;
+import org.springframework.test.context.junit4.SpringRunner;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.introproventures.graphql.jpa.query.schema.impl.GraphQLJpaExecutor;
+import com.introproventures.graphql.jpa.query.schema.impl.GraphQLJpaSchemaBuilder;
+
+import graphql.ExecutionResult;
+
+@RunWith(SpringRunner.class)
+@SpringBootTest(webEnvironment = WebEnvironment.NONE)
+@TestPropertySource({ "classpath:hibernate.properties" })
+public class GraphQLWhereVariableBindingsTests {
+
+	@SpringBootApplication
+	static class Application {
+
+		@Bean
+		public GraphQLExecutor graphQLExecutor(final GraphQLSchemaBuilder graphQLSchemaBuilder) {
+			return new GraphQLJpaExecutor(graphQLSchemaBuilder.build());
+		}
+
+		@Bean
+		public GraphQLSchemaBuilder graphQLSchemaBuilder(final EntityManager entityManager) {
+			return new GraphQLJpaSchemaBuilder(entityManager)
+					.name("GraphQLBooks")
+					.description("Books JPA test schema");
+		}
+
+	}
+
+	@Autowired
+	private GraphQLExecutor executor;
+
+	@Test
+	public void queryWithSimpleEqualsVariableBinding() throws IOException {
+		//given
+		String query = "" +
+				"query($where: BooksCriteriaExpression) {" +
+				"   Books(where: $where) {" +
+				"       select {" +
+				"           id" +
+				"           title" +
+				"           genre" +
+				"       }" +
+				"   }" +
+				"}";
+		String variables = "" +
+				"{" +
+				"   \"where\": {" +
+				"       \"title\": {" +
+				"           \"EQ\": \"War and Peace\"" +
+				"       }" +
+				"   }" +
+				"}";
+
+		//when
+		ExecutionResult executionResult = executor.execute(query, getVariablesMap(variables));
+
+		// then
+		then(executionResult.getErrors()).isEmpty();
+		Map<String, Object> result = executionResult.getData();
+		then(result)
+				.extracting("Books")
+				.flatExtracting("select")
+				.hasSize(1)
+				.extracting("id", "title", "genre")
+				.containsOnly(tuple(2L, "War and Peace", NOVEL));
+	}
+
+	@Test
+	public void queryWithNestedWhereClauseVariableBinding() throws IOException {
+		//given
+		String query = "" +
+				"query($where: BooksCriteriaExpression) {" +
+				"   Books(where: $where) {" +
+				"       select {" +
+				"           author {" +
+				"               id" +
+				"               name" +
+				"           }" +
+				"           title" +
+				"       }" +
+				"   }" +
+				"}";
+		String variables = "" +
+				"{" +
+				"   \"where\": {" +
+				"       \"author\": {" +
+				"           \"name\": {" +
+				"               \"EQ\": \"Leo Tolstoy\"" +
+				"           }" +
+				"       }" +
+				"   }" +
+				"}";
+
+		//when
+		ExecutionResult executionResult = executor.execute(query, getVariablesMap(variables));
+
+		// then
+		then(executionResult.getErrors()).isEmpty();
+		Map<String, Object> result = executionResult.getData();
+		then(result)
+				.extracting("Books")
+				.flatExtracting("select")
+				.hasSize(2)
+				.extracting("title")
+				.containsOnly("War and Peace", "Anna Karenina");
+		then(result)
+				.extracting("Books")
+				.flatExtracting("select")
+				.hasSize(2)
+				.extracting("author")
+				.extracting("id", "name")
+				.containsOnly(tuple(1L, "Leo Tolstoy"));
+	}
+
+	@Test
+	public void queryWithInVariableBinding() throws IOException {
+		//given
+		String query = "" +
+				"query($where: BooksCriteriaExpression) {" +
+				"   Books(where: $where) {" +
+				"       select {" +
+				"           id" +
+				"           title" +
+				"           genre" +
+				"       }" +
+				"   }" +
+				"}";
+		String variables = "" +
+				"{" +
+				"   \"where\": {" +
+				"       \"genre\": {" +
+				"           \"IN\": [\"PLAY\"]" +
+				"       }" +
+				"   }" +
+				"}";
+
+		//when
+		ExecutionResult executionResult = executor.execute(query, getVariablesMap(variables));
+
+		// then
+		then(executionResult.getErrors()).isEmpty();
+		Map<String, Object> result = executionResult.getData();
+		then(result)
+				.extracting("Books")
+				.flatExtracting("select")
+				.extracting("genre")
+				.containsOnly(PLAY);
+	}
+
+	@Test
+	public void queryWithMultipleRestrictionForOneProperty() throws IOException {
+		//given
+		String query = "" +
+				"query($where: BooksCriteriaExpression) {" +
+				"   Books(where: $where) {" +
+				"       select {" +
+				"           id" +
+				"           title" +
+				"       }" +
+				"   }" +
+				"}";
+		String variables = "" +
+				"{" +
+				"   \"where\": {" +
+				"       \"id\": {" +
+				"           \"GE\": 5," +
+				"           \"LE\": 7" +
+				"       }" +
+				"   }" +
+				"}";
+
+		//when
+		ExecutionResult executionResult = executor.execute(query, getVariablesMap(variables));
+
+		// then
+		then(executionResult.getErrors()).isEmpty();
+		Map<String, Object> result = executionResult.getData();
+		then(result)
+				.extracting("Books")
+				.flatExtracting("select")
+				.extracting("id", "title")
+				.containsOnly(
+						tuple(5L, "The Cherry Orchard"),
+						tuple(6L, "The Seagull"),
+						tuple(7L, "Three Sisters")
+				);
+	}
+
+	@Test
+	public void queryWithPropertyWhereVariableBinding() throws IOException {
+		//given
+		String query = "" +
+				"query($booksWhereClause: BooksCriteriaExpression) {" +
+				"   Authors {" +
+				"       select {" +
+				"           name" +
+				"           books(where: $booksWhereClause) {" +
+				"               genre" +
+				"           }" +
+				"       }" +
+				"   }" +
+				"}";
+		String variables = "" +
+				"{" +
+				"   \"booksWhereClause\": {" +
+				"       \"genre\": {" +
+				"           \"IN\": [\"NOVEL\"]" +
+				"       }" +
+				"   }" +
+				"}";
+
+		//when
+		ExecutionResult executionResult = executor.execute(query, getVariablesMap(variables));
+
+		// then
+		then(executionResult.getErrors()).isEmpty();
+		Map<String, Object> result = executionResult.getData();
+		then(result)
+				.extracting("Authors")
+				.flatExtracting("select")
+				.extracting("name")
+				.containsOnly("Leo Tolstoy");
+		then(result)
+				.extracting("Authors")
+				.flatExtracting("select")
+				.flatExtracting("books")
+				.extracting("genre")
+				.containsOnly(NOVEL);
+	}
+
+	@Test
+	public void queryWithRestrictionsForMultipleProperties() throws IOException {
+		//given
+		String query = "" +
+				"query($where: BooksCriteriaExpression) {" +
+				"   Books(where: $where) {" +
+				"       select {" +
+				"           id" +
+				"           title" +
+				"       }" +
+				"   }" +
+				"}";
+		String variables = "" +
+				"{" +
+				"   \"where\": {" +
+				"       \"title\": {" +
+				"           \"LIKE\": \"The\"" +
+				"       }," +
+				"		\"id\": {" +
+				"			\"LT\": 6" +
+				"		}" +
+				"   }" +
+				"}";
+
+		//when
+		ExecutionResult executionResult = executor.execute(query, getVariablesMap(variables));
+
+		// then
+		then(executionResult.getErrors()).isEmpty();
+		Map<String, Object> result = executionResult.getData();
+		then(result)
+				.extracting("Books")
+				.flatExtracting("select")
+				.extracting("id", "title")
+				.containsOnly(tuple(5L, "The Cherry Orchard"));
+	}
+
+	@SuppressWarnings("unchecked")
+	private Map<String, Object> getVariablesMap(String variables) throws IOException {
+		ObjectMapper mapper = new ObjectMapper();
+		return (Map<String, Object>) mapper.readValue(variables, Map.class);
+	}
+}


### PR DESCRIPTION
This PR adds support for variable where criteria expressions, i.e. given

```
query($where: BooksCriteriaExpression) {
  Books (where: $where) {
    select {
      id(orderBy: ASC)
      title
      genre
    }
  }
}
```
with variables payload:

```
{
  "where": { 
    "genre": {
      "IN": ["NOVEL"]
    }
  }
}
```
the expected result will be:

```
{
  "data": {
    "Books": {
      "select": [
        {
          "id": 2,
          "title": "War and Peace",
          "genre": "NOVEL"
        },
        {
          "id": 3,
          "title": "Anna Karenina",
          "genre": "NOVEL"
        }
      ]
    }
  }
}
```
Fixes https://github.com/introproventures/graphql-jpa-query/issues/126