### PR TITLE
Add METHOD to the @GraphQLIgnore annotation target

### DIFF
--- a/graphql-jpa-query-annotations/src/main/java/com/introproventures/graphql/jpa/query/annotation/GraphQLIgnore.java
+++ b/graphql-jpa-query-annotations/src/main/java/com/introproventures/graphql/jpa/query/annotation/GraphQLIgnore.java
@@ -16,6 +16,7 @@
 package com.introproventures.graphql.jpa.query.annotation;
 
 import static java.lang.annotation.ElementType.FIELD;
+import static java.lang.annotation.ElementType.METHOD;
 import static java.lang.annotation.ElementType.TYPE;
 import static java.lang.annotation.RetentionPolicy.RUNTIME;
 
@@ -28,7 +29,7 @@ import java.lang.annotation.Target;
  * @author Igor Dianov
  *
  */
-@Target( { TYPE, FIELD })
+@Target( { TYPE, FIELD, METHOD })
 @Retention(RUNTIME)
 public @interface GraphQLIgnore {
 }

--- a/graphql-jpa-query-example-model-books/src/main/java/com/introproventures/graphql/jpa/query/schema/model/book/Book.java
+++ b/graphql-jpa-query-example-model-books/src/main/java/com/introproventures/graphql/jpa/query/schema/model/book/Book.java
@@ -18,13 +18,9 @@ package com.introproventures.graphql.jpa.query.schema.model.book;
 
 import java.util.Date;
 
-import javax.persistence.Entity;
-import javax.persistence.EnumType;
-import javax.persistence.Enumerated;
-import javax.persistence.FetchType;
-import javax.persistence.Id;
-import javax.persistence.ManyToOne;
+import javax.persistence.*;
 
+import com.introproventures.graphql.jpa.query.annotation.GraphQLIgnore;
 import com.introproventures.graphql.jpa.query.annotation.GraphQLIgnoreFilter;
 import com.introproventures.graphql.jpa.query.annotation.GraphQLIgnoreOrder;
 import lombok.Data;
@@ -49,5 +45,11 @@ public class Book {
 	@Enumerated(EnumType.STRING)
 	Genre genre;
 	
-    Date publicationDate;	
+    Date publicationDate;
+
+    @Transient
+	@GraphQLIgnore
+    public String getAuthorName(){
+    	return author.getName();
+	}
 }

--- a/graphql-jpa-query-schema/src/main/java/com/introproventures/graphql/jpa/query/schema/impl/IntrospectionUtils.java
+++ b/graphql-jpa-query-schema/src/main/java/com/introproventures/graphql/jpa/query/schema/impl/IntrospectionUtils.java
@@ -76,21 +76,23 @@ public class IntrospectionUtils {
     		public String getName() {
     			return delegate.getName();
     		}
-    		
-    	    public boolean isAnnotationPresent(Class<? extends Annotation> annotation) {
-    	        boolean answer;
-    	        try {
-    	            answer = entity.getDeclaredField(delegate.getName())
-    	            					  .isAnnotationPresent(annotation);
 
-    	        } catch (NoSuchFieldException e) {
-    	        	if(delegate.getReadMethod() == null) return false;
-    				answer = delegate.getReadMethod()
-    								  .isAnnotationPresent(annotation);
-    	        }
-    	        return answer;
-    	    }
-    	
-    	}
+			public boolean isAnnotationPresent(Class<? extends Annotation> annotation) {
+				return isAnnotationPresentOnField(annotation) || isAnnotationPresentOnReadMethod(annotation);
+			}
+
+			private boolean isAnnotationPresentOnField(Class<? extends Annotation> annotation) {
+				try {
+					return entity.getDeclaredField(delegate.getName()).isAnnotationPresent(annotation);
+				} catch (NoSuchFieldException e) {
+					return false;
+				}
+			}
+
+			private boolean isAnnotationPresentOnReadMethod(Class<? extends Annotation> annotation) {
+				return delegate.getReadMethod() != null && delegate.getReadMethod().isAnnotationPresent(annotation);
+			}
+
+		}
     }
 }

--- a/graphql-jpa-query-schema/src/main/java/com/introproventures/graphql/jpa/query/schema/impl/IntrospectionUtils.java
+++ b/graphql-jpa-query-schema/src/main/java/com/introproventures/graphql/jpa/query/schema/impl/IntrospectionUtils.java
@@ -15,84 +15,84 @@ import java.util.stream.Stream;
 import javax.persistence.Transient;
 
 public class IntrospectionUtils {
-	private static final Map<Class<?>, CachedIntrospectionResult> map = new LinkedHashMap<>();
-	
-	public static CachedIntrospectionResult introspect(Class<?> entity) {
-    	return map.computeIfAbsent(entity, CachedIntrospectionResult::new);
-	}
-	
-    public static boolean isTransient(Class<?> entity, String propertyName) {
-    	return introspect(entity).getPropertyDescriptor(propertyName)
-    						     .map(it -> it.isAnnotationPresent(Transient.class))
-    						     .orElseThrow(() -> new RuntimeException(new NoSuchFieldException(propertyName)));
+    private static final Map<Class<?>, CachedIntrospectionResult> map = new LinkedHashMap<>();
+
+    public static CachedIntrospectionResult introspect(Class<?> entity) {
+        return map.computeIfAbsent(entity, CachedIntrospectionResult::new);
     }
-    
+
+    public static boolean isTransient(Class<?> entity, String propertyName) {
+        return introspect(entity).getPropertyDescriptor(propertyName)
+                .map(it -> it.isAnnotationPresent(Transient.class))
+                .orElseThrow(() -> new RuntimeException(new NoSuchFieldException(propertyName)));
+    }
+
     public static class CachedIntrospectionResult {
 
-    	private final Map<String, CachedPropertyDescriptor> map;
-    	private final Class<?> entity;
-    	private final BeanInfo beanInfo;
-    	
-    	public CachedIntrospectionResult(Class<?> entity) {
-    		try {
-    			this.beanInfo = Introspector.getBeanInfo(entity);
-    		} catch (IntrospectionException cause) {
-    			throw new RuntimeException(cause);
-    		}
+        private final Map<String, CachedPropertyDescriptor> map;
+        private final Class<?> entity;
+        private final BeanInfo beanInfo;
 
-    		this.entity = entity;
-    		this.map = Stream.of(beanInfo.getPropertyDescriptors())
-    						 .map(CachedPropertyDescriptor::new)
-    			             .collect(Collectors.toMap(CachedPropertyDescriptor::getName, it -> it));
-    	}
-    	
-    	public Collection<CachedPropertyDescriptor> getPropertyDescriptors() {
-    		return map.values();
-    	}
-    	
-    	public Optional<CachedPropertyDescriptor> getPropertyDescriptor(String fieldName) {
-    		return Optional.ofNullable(map.getOrDefault(fieldName, null));
-    	}
+        public CachedIntrospectionResult(Class<?> entity) {
+            try {
+                this.beanInfo = Introspector.getBeanInfo(entity);
+            } catch (IntrospectionException cause) {
+                throw new RuntimeException(cause);
+            }
 
-    	public Class<?> getEntity() {
-    		return entity;
-    	}
+            this.entity = entity;
+            this.map = Stream.of(beanInfo.getPropertyDescriptors())
+                    .map(CachedPropertyDescriptor::new)
+                    .collect(Collectors.toMap(CachedPropertyDescriptor::getName, it -> it));
+        }
 
-    	public BeanInfo getBeanInfo() {
-    		return beanInfo;
-    	}
-    	
-    	public class CachedPropertyDescriptor {
-    		private final PropertyDescriptor delegate;
-    		
-    		public CachedPropertyDescriptor(PropertyDescriptor delegate) {
-    			this.delegate = delegate;
-    		}
-    		
-    		public PropertyDescriptor getDelegate() {
-    			return delegate;
-    		}
-    		
-    		public String getName() {
-    			return delegate.getName();
-    		}
+        public Collection<CachedPropertyDescriptor> getPropertyDescriptors() {
+            return map.values();
+        }
 
-			public boolean isAnnotationPresent(Class<? extends Annotation> annotation) {
-				return isAnnotationPresentOnField(annotation) || isAnnotationPresentOnReadMethod(annotation);
-			}
+        public Optional<CachedPropertyDescriptor> getPropertyDescriptor(String fieldName) {
+            return Optional.ofNullable(map.getOrDefault(fieldName, null));
+        }
 
-			private boolean isAnnotationPresentOnField(Class<? extends Annotation> annotation) {
-				try {
-					return entity.getDeclaredField(delegate.getName()).isAnnotationPresent(annotation);
-				} catch (NoSuchFieldException e) {
-					return false;
-				}
-			}
+        public Class<?> getEntity() {
+            return entity;
+        }
 
-			private boolean isAnnotationPresentOnReadMethod(Class<? extends Annotation> annotation) {
-				return delegate.getReadMethod() != null && delegate.getReadMethod().isAnnotationPresent(annotation);
-			}
+        public BeanInfo getBeanInfo() {
+            return beanInfo;
+        }
 
-		}
+        public class CachedPropertyDescriptor {
+            private final PropertyDescriptor delegate;
+
+            public CachedPropertyDescriptor(PropertyDescriptor delegate) {
+                this.delegate = delegate;
+            }
+
+            public PropertyDescriptor getDelegate() {
+                return delegate;
+            }
+
+            public String getName() {
+                return delegate.getName();
+            }
+
+            public boolean isAnnotationPresent(Class<? extends Annotation> annotation) {
+                return isAnnotationPresentOnField(annotation) || isAnnotationPresentOnReadMethod(annotation);
+            }
+
+            private boolean isAnnotationPresentOnField(Class<? extends Annotation> annotation) {
+                try {
+                    return entity.getDeclaredField(delegate.getName()).isAnnotationPresent(annotation);
+                } catch (NoSuchFieldException e) {
+                    return false;
+                }
+            }
+
+            private boolean isAnnotationPresentOnReadMethod(Class<? extends Annotation> annotation) {
+                return delegate.getReadMethod() != null && delegate.getReadMethod().isAnnotationPresent(annotation);
+            }
+
+        }
     }
 }

--- a/graphql-jpa-query-schema/src/main/java/com/introproventures/graphql/jpa/query/schema/impl/IntrospectionUtils.java
+++ b/graphql-jpa-query-schema/src/main/java/com/introproventures/graphql/jpa/query/schema/impl/IntrospectionUtils.java
@@ -1,5 +1,7 @@
 package com.introproventures.graphql.jpa.query.schema.impl;
 
+import com.introproventures.graphql.jpa.query.annotation.GraphQLIgnore;
+
 import java.beans.BeanInfo;
 import java.beans.IntrospectionException;
 import java.beans.Introspector;
@@ -22,8 +24,16 @@ public class IntrospectionUtils {
     }
 
     public static boolean isTransient(Class<?> entity, String propertyName) {
+        return isAnnotationPresent(entity, propertyName, Transient.class);
+    }
+
+    public static boolean isIgnored(Class<?> entity, String propertyName) {
+        return isAnnotationPresent(entity, propertyName, GraphQLIgnore.class);
+    }
+
+    private static boolean isAnnotationPresent(Class<?> entity, String propertyName, Class<? extends Annotation> annotation){
         return introspect(entity).getPropertyDescriptor(propertyName)
-                .map(it -> it.isAnnotationPresent(Transient.class))
+                .map(it -> it.isAnnotationPresent(annotation))
                 .orElseThrow(() -> new RuntimeException(new NoSuchFieldException(propertyName)));
     }
 

--- a/graphql-jpa-query-schema/src/main/java/com/introproventures/graphql/jpa/query/schema/impl/IntrospectionUtils.java
+++ b/graphql-jpa-query-schema/src/main/java/com/introproventures/graphql/jpa/query/schema/impl/IntrospectionUtils.java
@@ -34,7 +34,7 @@ public class IntrospectionUtils {
     private static boolean isAnnotationPresent(Class<?> entity, String propertyName, Class<? extends Annotation> annotation){
         return introspect(entity).getPropertyDescriptor(propertyName)
                 .map(it -> it.isAnnotationPresent(annotation))
-                .orElseThrow(() -> new RuntimeException(new NoSuchFieldException(propertyName)));
+                .orElse(false);
     }
 
     public static class CachedIntrospectionResult {

--- a/graphql-jpa-query-schema/src/test/java/com/introproventures/graphql/jpa/query/schema/GraphQLExecutorTests.java
+++ b/graphql-jpa-query-schema/src/test/java/com/introproventures/graphql/jpa/query/schema/GraphQLExecutorTests.java
@@ -17,6 +17,8 @@
 package com.introproventures.graphql.jpa.query.schema;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.tuple;
+import static org.assertj.core.util.Lists.list;
 
 import java.util.Arrays;
 import java.util.HashMap;
@@ -31,6 +33,7 @@ import graphql.ErrorType;
 import graphql.ExecutionResult;
 import graphql.GraphQLError;
 import graphql.validation.ValidationError;
+import graphql.validation.ValidationErrorType;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -1414,5 +1417,27 @@ public class GraphQLExecutorTests {
 
         // then
         assertThat(result.toString()).isEqualTo(expected);
+    }
+
+    @Test
+    public void queryForTransientMethodAnnotatedWithGraphQLIgnoreShouldFail() {
+        //given
+        String query = ""
+                + "query { "
+                + "    Books {"
+                + "        select {"
+                + "            authorName"
+                + "        }"
+                + "    }"
+                + "}";
+
+        //when
+        ExecutionResult result = executor.execute(query);
+
+        // then
+        assertThat(result.getErrors())
+                .isNotEmpty()
+                .extracting("validationErrorType", "queryPath")
+                .containsOnly(tuple(ValidationErrorType.FieldUndefined, list("Books", "select", "authorName")));
     }
 }

--- a/graphql-jpa-query-schema/src/test/java/com/introproventures/graphql/jpa/query/schema/impl/IntrospectionUtilsTest.java
+++ b/graphql-jpa-query-schema/src/test/java/com/introproventures/graphql/jpa/query/schema/impl/IntrospectionUtilsTest.java
@@ -4,14 +4,14 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 import org.junit.Test;
 
+import com.introproventures.graphql.jpa.query.annotation.GraphQLIgnore;
 import com.introproventures.graphql.jpa.query.schema.model.calculated.CalculatedEntity;
 
 public class IntrospectionUtilsTest {
 
 	// given
-    Class<CalculatedEntity> entity = CalculatedEntity.class;
+    private final Class<CalculatedEntity> entity = CalculatedEntity.class;
 
-    
     @Test(expected=RuntimeException.class)
     public void testIsTransientNonExisting() throws Exception {
         // then
@@ -42,10 +42,7 @@ public class IntrospectionUtilsTest {
 
     @Test
     public void testNotTransientFields() throws Exception {
-    	// given
-        Class<CalculatedEntity> entity = CalculatedEntity.class;
-        
-        // then
+    	// then
         assertThat(IntrospectionUtils.isTransient(entity, "id")).isFalse();
         assertThat(IntrospectionUtils.isTransient(entity, "info")).isFalse();
         assertThat(IntrospectionUtils.isTransient(entity, "title")).isFalse();
@@ -53,10 +50,25 @@ public class IntrospectionUtilsTest {
 
     @Test
     public void testByPassSetMethod() throws Exception {
-        // given
-        Class<CalculatedEntity> entity = CalculatedEntity.class;
-
         // then
         assertThat(IntrospectionUtils.isTransient(entity,"something")).isFalse();
     }
+
+	@Test
+	public void shouldIgnoreMethodsThatAreAnnotatedWithGraphQLIgnore() {
+		//when
+		boolean propertyIgnoredOnGetter = isIgnored("propertyIgnoredOnGetter");
+		boolean ignoredTransientValue = isIgnored("ignoredTransientValue");
+
+		//then
+		assertThat(propertyIgnoredOnGetter).isTrue();
+		assertThat(ignoredTransientValue).isTrue();
+	}
+
+	private boolean isIgnored(String property) {
+		return IntrospectionUtils.introspect(entity)
+				.getPropertyDescriptor(property)
+				.map(cachedPropertyDescriptor -> cachedPropertyDescriptor.isAnnotationPresent(GraphQLIgnore.class))
+				.orElse(false);
+	}
 }

--- a/graphql-jpa-query-schema/src/test/java/com/introproventures/graphql/jpa/query/schema/impl/IntrospectionUtilsTest.java
+++ b/graphql-jpa-query-schema/src/test/java/com/introproventures/graphql/jpa/query/schema/impl/IntrospectionUtilsTest.java
@@ -12,7 +12,7 @@ public class IntrospectionUtilsTest {
 	// given
     private final Class<CalculatedEntity> entity = CalculatedEntity.class;
 
-    @Test(expected=RuntimeException.class)
+    @Test
     public void testIsTransientNonExisting() throws Exception {
         // then
         assertThat(IntrospectionUtils.isTransient(entity, "notFound")).isFalse();

--- a/graphql-jpa-query-schema/src/test/java/com/introproventures/graphql/jpa/query/schema/impl/IntrospectionUtilsTest.java
+++ b/graphql-jpa-query-schema/src/test/java/com/introproventures/graphql/jpa/query/schema/impl/IntrospectionUtilsTest.java
@@ -54,21 +54,14 @@ public class IntrospectionUtilsTest {
         assertThat(IntrospectionUtils.isTransient(entity,"something")).isFalse();
     }
 
-	@Test
-	public void shouldIgnoreMethodsThatAreAnnotatedWithGraphQLIgnore() {
-		//when
-		boolean propertyIgnoredOnGetter = isIgnored("propertyIgnoredOnGetter");
-		boolean ignoredTransientValue = isIgnored("ignoredTransientValue");
+    @Test
+    public void shouldIgnoreMethodsThatAreAnnotatedWithGraphQLIgnore() {
+        //when
+        boolean propertyIgnoredOnGetter = IntrospectionUtils.isIgnored(entity, "propertyIgnoredOnGetter");
+        boolean ignoredTransientValue = IntrospectionUtils.isIgnored(entity, "ignoredTransientValue");
 
-		//then
-		assertThat(propertyIgnoredOnGetter).isTrue();
-		assertThat(ignoredTransientValue).isTrue();
-	}
-
-	private boolean isIgnored(String property) {
-		return IntrospectionUtils.introspect(entity)
-				.getPropertyDescriptor(property)
-				.map(cachedPropertyDescriptor -> cachedPropertyDescriptor.isAnnotationPresent(GraphQLIgnore.class))
-				.orElse(false);
-	}
+        //then
+        assertThat(propertyIgnoredOnGetter).isTrue();
+        assertThat(ignoredTransientValue).isTrue();
+    }
 }

--- a/graphql-jpa-query-schema/src/test/java/com/introproventures/graphql/jpa/query/schema/model/calculated/CalculatedEntity.java
+++ b/graphql-jpa-query-schema/src/test/java/com/introproventures/graphql/jpa/query/schema/model/calculated/CalculatedEntity.java
@@ -30,6 +30,7 @@ public class CalculatedEntity {
     @GraphQLIgnore
     String hideField = "hideField";
 
+    String propertyIgnoredOnGetter;
    
     @Transient
     @GraphQLDescription("i desc function")
@@ -47,4 +48,15 @@ public class CalculatedEntity {
     }
 
     public void setSomething(int a){}
+
+    @GraphQLIgnore
+    public String getPropertyIgnoredOnGetter() {
+        return propertyIgnoredOnGetter;
+    }
+
+    @Transient
+    @GraphQLIgnore
+    public String getIgnoredTransientValue(){
+        return "IgnoredTransientValue";
+    }
 }


### PR DESCRIPTION
Fixes #153 by adding METHOD to annotation target, so given `@GraphQLIgnore` annotation

```java
@Target( { TYPE, FIELD, METHOD })
@Retention(RUNTIME)
public @interface GraphQLIgnore {
}
```

can be applied on getter methods in entity class to exclude these properties from schema mapping, i.e.:

```java
@Data
@Entity
@EqualsAndHashCode(exclude="author")
public class Book {
    @Id
    Long id;

    String title;

    @ManyToOne(fetch=FetchType.LAZY, optional = false)
    Author author;

    @Transient
    @GraphQLIgnore
    public String getAuthorName(){
    	return author.getName();
    }
}
```


