### PR TITLE
fix: NoSuchFieldException - add support for mapping transient fields with entity class hierarchy introspection

### DIFF
--- a/graphql-jpa-query-schema/src/main/java/com/introproventures/graphql/jpa/query/schema/impl/IntrospectionUtils.java
+++ b/graphql-jpa-query-schema/src/main/java/com/introproventures/graphql/jpa/query/schema/impl/IntrospectionUtils.java
@@ -44,7 +44,7 @@ public class IntrospectionUtils {
     
     public static boolean isIgnored(Class<?> entity, String propertyName) {
         return isAnnotationPresent(entity, propertyName, GraphQLIgnore.class)
-                 .orElseThrow(() -> new RuntimeException(new NoSuchFieldException(propertyName)));
+                 .orElse(false);
     }
 
     private static Optional<Boolean> isAnnotationPresent(Class<?> entity, String propertyName, Class<? extends Annotation> annotation){

--- a/graphql-jpa-query-schema/src/main/java/com/introproventures/graphql/jpa/query/schema/impl/IntrospectionUtils.java
+++ b/graphql-jpa-query-schema/src/main/java/com/introproventures/graphql/jpa/query/schema/impl/IntrospectionUtils.java
@@ -44,7 +44,7 @@ public class IntrospectionUtils {
     
     public static boolean isIgnored(Class<?> entity, String propertyName) {
         return isAnnotationPresent(entity, propertyName, GraphQLIgnore.class)
-                 .orElse(false);
+                .orElseThrow(() -> new RuntimeException(new NoSuchFieldException(propertyName)));
     }
 
     private static Optional<Boolean> isAnnotationPresent(Class<?> entity, String propertyName, Class<? extends Annotation> annotation){

--- a/graphql-jpa-query-schema/src/main/java/com/introproventures/graphql/jpa/query/schema/impl/IntrospectionUtils.java
+++ b/graphql-jpa-query-schema/src/main/java/com/introproventures/graphql/jpa/query/schema/impl/IntrospectionUtils.java
@@ -36,15 +36,15 @@ public class IntrospectionUtils {
         if(!introspect(entity).hasPropertyDescriptor(propertyName)) {
             throw new RuntimeException(new NoSuchFieldException(propertyName));
         }
-        
+
         return Stream.of(isAnnotationPresent(entity, propertyName, Transient.class),
                          isModifierPresent(entity, propertyName, Modifier::isTransient))
                      .anyMatch(it -> it.isPresent() && it.get() == true);
     }
-    
+
     public static boolean isIgnored(Class<?> entity, String propertyName) {
         return isAnnotationPresent(entity, propertyName, GraphQLIgnore.class)
-                .orElseThrow(() -> new RuntimeException(new NoSuchFieldException(propertyName)));
+                .orElse(false);
     }
 
     private static Optional<Boolean> isAnnotationPresent(Class<?> entity, String propertyName, Class<? extends Annotation> annotation){
@@ -56,14 +56,14 @@ public class IntrospectionUtils {
         return introspect(entity).getField(propertyName)
                                  .map(it -> function.apply(it.getModifiers()));
     }
-    
+
     public static class CachedIntrospectionResult {
 
         private final Map<String, CachedPropertyDescriptor> map;
         private final Class<?> entity;
         private final BeanInfo beanInfo;
         private final Map<String, Field> fields;
-        
+
         @SuppressWarnings("rawtypes")
         public CachedIntrospectionResult(Class<?> entity) {
             try {
@@ -76,7 +76,7 @@ public class IntrospectionUtils {
             this.map = Stream.of(beanInfo.getPropertyDescriptors())
                     .map(CachedPropertyDescriptor::new)
                     .collect(Collectors.toMap(CachedPropertyDescriptor::getName, it -> it));
-            
+
             this.fields = iterate((Class) entity, k -> Optional.ofNullable(k.getSuperclass()))
                     .flatMap(k -> Arrays.stream(k.getDeclaredFields()))
                     .filter(f -> map.containsKey(f.getName()))
@@ -94,7 +94,7 @@ public class IntrospectionUtils {
         public boolean hasPropertyDescriptor(String fieldName) {
             return map.containsKey(fieldName);
         }
-        
+
         public Optional<Field> getField(String fieldName) {
             return Optional.ofNullable(fields.get(fieldName));
         }
@@ -121,7 +121,7 @@ public class IntrospectionUtils {
             public Class<?> getPropertyType() {
                 return delegate.getPropertyType();
             }
-            
+
             public String getName() {
                 return delegate.getName();
             }
@@ -142,12 +142,12 @@ public class IntrospectionUtils {
 
         }
     }
-    
+
     /**
-     * The following method is borrowed from Streams.iterate, 
-     * however Streams.iterate is designed to create infinite streams. 
-     * 
-     * This version has been modified to end when Optional.empty() 
+     * The following method is borrowed from Streams.iterate,
+     * however Streams.iterate is designed to create infinite streams.
+     *
+     * This version has been modified to end when Optional.empty()
      * is returned from the fetchNextFunction.
      */
     protected static <T> Stream<T> iterate( T seed, Function<T, Optional<T>> fetchNextFunction ) {
@@ -175,5 +175,5 @@ public class IntrospectionUtils {
             Spliterators.spliteratorUnknownSize( iterator, Spliterator.ORDERED | Spliterator.IMMUTABLE),
             false
         );
-    }        
+    }
 }


### PR DESCRIPTION
There is an error what throwing `NoSuchFieldException` when declare `private` access modifier on `getter method`.

**Error**
``` json
 WARN o.s.b.w.s.c.AnnotationConfigServletWebServerApplicationContext Exception encountered during context initialization - cancelling refresh attempt: org.springframework.beans.factory.UnsatisfiedDependencyException: Error creating bean with name 'customGraphqlExecutor' defined in file [E:\core\core\build\classes\java\main\com\mbanq\graphql\CustomGraphqlExecutor.class]: Unsatisfied dependency expressed through constructor parameter 0; nested exception is org.springframework.beans.factory.BeanCreationException: Error creating bean with name 'graphQLSchemaFactoryBean' defined in class path resource [com/introproventures/graphql/jpa/query/autoconfigure/GraphQLSchemaAutoConfiguration.class]: Bean instantiation via factory method failed; nested exception is org.springframework.beans.BeanInstantiationException: Failed to instantiate [com.introproventures.graphql.jpa.query.autoconfigure.GraphQLSchemaFactoryBean]: Factory method 'graphQLSchemaFactoryBean' threw exception; nested exception is java.lang.RuntimeException: java.lang.NoSuchFieldException: age
 INFO o.s.o.j.LocalContainerEntityManagerFactoryBean Closing JPA EntityManagerFactory for persistence unit 'jpa-pu' 
Aug 29, 2019 10:44:41 AM org.apache.catalina.core.StandardService stopInternal
INFO: Stopping service [Tomcat]
```
**Example of Code**

```
public class Student{

    @Temporal(TemporalType.DATE)
    @Column(name = "DOB")
    private Date DateOfBirth;

    @Column(name ="age")
     private Integer age;

     private Integer getAge(){
           return Period.between(LocalDate.now(), dob).getYears();
     }
}
```