### PR TITLE
fix: add query support for entities with `@EmbeddedId` attribute

### DIFF
--- a/graphql-jpa-query-schema/src/main/java/com/introproventures/graphql/jpa/query/schema/impl/JpaPredicateBuilder.java
+++ b/graphql-jpa-query-schema/src/main/java/com/introproventures/graphql/jpa/query/schema/impl/JpaPredicateBuilder.java
@@ -19,7 +19,12 @@ package com.introproventures.graphql.jpa.query.schema.impl;
 import java.lang.reflect.Constructor;
 import java.math.BigDecimal;
 import java.math.BigInteger;
-import java.time.*;
+import java.time.Instant;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.LocalTime;
+import java.time.OffsetDateTime;
+import java.time.ZonedDateTime;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Date;
@@ -37,6 +42,7 @@ import javax.persistence.metamodel.EntityType;
 import javax.persistence.metamodel.PluralAttribute;
 
 import com.introproventures.graphql.jpa.query.schema.impl.PredicateFilter.Criteria;
+
 import graphql.language.NullValue;
 
 /**
@@ -783,8 +789,7 @@ class JpaPredicateBuilder {
                 Object arg = NullValue.class.isInstance(object) ? null : object;
                 return constructor.newInstance(arg);
             }
-        } catch (Exception e) {
-            e.printStackTrace();
+        } catch (Exception ignored) {
         }
         
         return object;

--- a/graphql-jpa-query-schema/src/test/java/com/introproventures/graphql/jpa/query/embeddedid/EntityWithEmbeddedIdTest.java
+++ b/graphql-jpa-query-schema/src/test/java/com/introproventures/graphql/jpa/query/embeddedid/EntityWithEmbeddedIdTest.java
@@ -1,0 +1,138 @@
+package com.introproventures.graphql.jpa.query.embeddedid;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import javax.persistence.EntityManager;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.context.annotation.Bean;
+import org.springframework.test.context.TestPropertySource;
+import org.springframework.test.context.junit4.SpringRunner;
+
+import com.introproventures.graphql.jpa.query.schema.GraphQLExecutor;
+import com.introproventures.graphql.jpa.query.schema.GraphQLSchemaBuilder;
+import com.introproventures.graphql.jpa.query.schema.impl.GraphQLJpaExecutor;
+import com.introproventures.graphql.jpa.query.schema.impl.GraphQLJpaSchemaBuilder;
+
+@RunWith(SpringRunner.class)
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.NONE,
+        properties = "spring.datasource.data=EntityWithEmbeddedIdTest.sql")
+@TestPropertySource({"classpath:hibernate.properties"})
+public class EntityWithEmbeddedIdTest {
+
+    @SpringBootApplication
+    static class Application {
+        @Bean
+        public GraphQLExecutor graphQLExecutor(final GraphQLSchemaBuilder graphQLSchemaBuilder) {
+            return new GraphQLJpaExecutor(graphQLSchemaBuilder.build());
+        }
+
+        @Bean
+        public GraphQLSchemaBuilder graphQLSchemaBuilder(final EntityManager entityManager) {
+            return new GraphQLJpaSchemaBuilder(entityManager)
+                    .name("EntityWithEmbeddedIdTest");
+        }
+    }
+
+    @Autowired
+    private GraphQLExecutor executor;
+
+    @Test
+    public void queryBookWithEmbeddedId() {
+        //given
+        String query = "query {" +
+                "  Book(" +
+                "    bookId: {"
+                + "    title: \"War and Piece\"" +
+                "      language: \"Russian\"" +
+                "    }" +
+                "  )" +
+                "  {" +
+                "    bookId {" +
+                "      title" +
+                "      language" +
+                "    }" +
+                "    description" +
+                "  }" +
+                "}";
+
+        String expected = "{Book={bookId={title=War and Piece, language=Russian}, description=War and Piece Novel}}";
+
+        //when
+        Object result = executor.execute(query).getData();
+
+        // then
+        assertThat(result.toString()).isEqualTo(expected);
+    }
+
+    @Test
+    public void queryBooksWithyWithEmbeddedId() {
+        //given
+        String query = "query {" +
+                "  Books {" +
+                "    total" +
+                "    pages" +
+                "    select {" +
+                "      bookId {" +
+                "        title" +
+                "        language" +
+                "      }" +
+                "      description" +
+                "    }" +
+                "  }" +
+                "}";
+
+        String expected = "{Books={total=2, pages=1, select=["
+                + "{bookId={title=Witch Of Water, language=English}, description=Witch Of Water Fantasy}, "
+                + "{bookId={title=War and Piece, language=Russian}, description=War and Piece Novel}"
+                + "]}}";
+
+        //when
+        Object result = executor.execute(query).getData();
+
+        // then
+        assertThat(result.toString()).isEqualTo(expected);
+    }
+    
+    @Test
+    public void queryBooksWithyWithEmbeddedIdWhereCriteriaExpression() {
+        //given
+        String query = "query {" +
+                "  Books( " +
+                "    where: {" +
+                "      bookId: {" +
+                "        EQ: {" +
+                "          title: \"War and Piece\"" +
+                "          language: \"Russian\"" +
+                "        }" +
+                "      }" +
+                "    }" +
+                "  ){" +
+                "    total" +
+                "    pages" +
+                "    select {" +
+                "      bookId {" +
+                "        title" +
+                "        language" +
+                "      }" +
+                "      description" +
+                "    }" +
+                "  }" +
+                "}";
+        
+        String expected = "{Books={total=1, pages=1, select=["
+                + "{bookId={title=War and Piece, language=Russian}, description=War and Piece Novel}"
+                + "]}}";
+
+        //when
+        Object result = executor.execute(query).getData();
+
+        // then
+        assertThat(result.toString()).isEqualTo(expected);
+    }
+
+}

--- a/graphql-jpa-query-schema/src/test/java/com/introproventures/graphql/jpa/query/embeddedid/model/Book.java
+++ b/graphql-jpa-query-schema/src/test/java/com/introproventures/graphql/jpa/query/embeddedid/model/Book.java
@@ -1,0 +1,17 @@
+package com.introproventures.graphql.jpa.query.embeddedid.model;
+
+
+import javax.persistence.EmbeddedId;
+import javax.persistence.Entity;
+
+import lombok.Data;
+
+@Data
+@Entity
+public class Book {
+
+    @EmbeddedId
+    private BookId bookId;
+
+    private String description;
+}

--- a/graphql-jpa-query-schema/src/test/java/com/introproventures/graphql/jpa/query/embeddedid/model/BookId.java
+++ b/graphql-jpa-query-schema/src/test/java/com/introproventures/graphql/jpa/query/embeddedid/model/BookId.java
@@ -1,0 +1,17 @@
+package com.introproventures.graphql.jpa.query.embeddedid.model;
+
+
+import java.io.Serializable;
+
+import javax.persistence.Embeddable;
+
+import lombok.Data;
+
+@Data
+@Embeddable
+public class BookId implements Serializable {
+    private static final long serialVersionUID = 1L;
+    
+    private String title;
+    private String language;
+}

--- a/graphql-jpa-query-schema/src/test/resources/EntityWithEmbeddedIdTest.sql
+++ b/graphql-jpa-query-schema/src/test/resources/EntityWithEmbeddedIdTest.sql
@@ -1,0 +1,3 @@
+insert into Book(title, language, description) values
+('War and Piece', 'Russian', 'War and Piece Novel'),
+('Witch Of Water', 'English', 'Witch Of Water Fantasy');


### PR DESCRIPTION
This PR adds query support for entitites with `@EmbeddedId` attributes, i.e. given:

```java
@Data
@Entity
public class Book {

    @EmbeddedId
    private BookId bookId;

    private String description;
} 
```

with embedded id attribute

```java
@Data
@Embeddable
public class BookId implements Serializable {
    private static final long serialVersionUID = 1L;

    private String title;
    private String language;
} 
```

then, use query with embedded id:

```
query {
  Books( 
    where: {
      bookId: {
        EQ: {
          title:  "War and Piece"
          language:  "Russian"
        }
      }
    }
  ){
    total
    pages
    select {
      bookId {
        title
        language
      }
      description
    }
  }
}

```

