### PR TITLE
fix(versions): upgrade spring-boot-dependencies to 2.1.11.RELEASE

### DIFF
--- a/graphql-jpa-query-build/pom.xml
+++ b/graphql-jpa-query-build/pom.xml
@@ -15,7 +15,7 @@
             <dependency>
                 <groupId>org.springframework.boot</groupId>
                 <artifactId>spring-boot-dependencies</artifactId>
-                <version>2.1.8.RELEASE</version>
+                <version>2.1.9.RELEASE</version>
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>

--- a/graphql-jpa-query-build/pom.xml
+++ b/graphql-jpa-query-build/pom.xml
@@ -15,7 +15,7 @@
             <dependency>
                 <groupId>org.springframework.boot</groupId>
                 <artifactId>spring-boot-dependencies</artifactId>
-                <version>2.1.7.RELEASE</version>
+                <version>2.1.8.RELEASE</version>
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>

--- a/graphql-jpa-query-build/pom.xml
+++ b/graphql-jpa-query-build/pom.xml
@@ -15,7 +15,7 @@
             <dependency>
                 <groupId>org.springframework.boot</groupId>
                 <artifactId>spring-boot-dependencies</artifactId>
-                <version>2.1.9.RELEASE</version>
+                <version>2.1.11.RELEASE</version>
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>

--- a/graphql-jpa-query-schema/src/test/java/com/introproventures/graphql/jpa/query/AbstractSpringBootTestSupport.java
+++ b/graphql-jpa-query-schema/src/test/java/com/introproventures/graphql/jpa/query/AbstractSpringBootTestSupport.java
@@ -1,0 +1,14 @@
+package com.introproventures.graphql.jpa.query;
+
+import org.junit.runner.RunWith;
+import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
+import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase.Replace;
+import org.springframework.test.context.TestPropertySource;
+import org.springframework.test.context.junit4.SpringRunner;
+
+@RunWith(SpringRunner.class)
+@TestPropertySource({"classpath:hibernate.properties"})
+@AutoConfigureTestDatabase(replace = Replace.ANY)
+public abstract class AbstractSpringBootTestSupport {
+
+}

--- a/graphql-jpa-query-schema/src/test/java/com/introproventures/graphql/jpa/query/converter/GraphQLJpaConverterTests.java
+++ b/graphql-jpa-query-schema/src/test/java/com/introproventures/graphql/jpa/query/converter/GraphQLJpaConverterTests.java
@@ -36,6 +36,8 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
+import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase.Replace;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.context.SpringBootTest.WebEnvironment;
 import org.springframework.context.annotation.Bean;
@@ -60,6 +62,7 @@ import com.introproventures.graphql.jpa.query.schema.impl.GraphQLJpaSchemaBuilde
                 properties = "spring.datasource.data=GraphQLJpaConverterTests.sql")
 @TestPropertySource({"classpath:hibernate.properties"})
 @DirtiesContext
+@AutoConfigureTestDatabase(replace = Replace.ANY)
 public class GraphQLJpaConverterTests {
     
     @SpringBootApplication

--- a/graphql-jpa-query-schema/src/test/java/com/introproventures/graphql/jpa/query/converter/GraphQLJpaConverterTests.java
+++ b/graphql-jpa-query-schema/src/test/java/com/introproventures/graphql/jpa/query/converter/GraphQLJpaConverterTests.java
@@ -32,6 +32,17 @@ import javax.persistence.criteria.Root;
 import javax.persistence.criteria.Subquery;
 import javax.transaction.Transactional;
 
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.context.SpringBootTest.WebEnvironment;
+import org.springframework.context.annotation.Bean;
+import org.springframework.test.annotation.DirtiesContext;
+import org.springframework.test.context.TestPropertySource;
+import org.springframework.test.context.junit4.SpringRunner;
+
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.introproventures.graphql.jpa.query.converter.model.JsonEntity;
@@ -42,21 +53,13 @@ import com.introproventures.graphql.jpa.query.schema.GraphQLExecutor;
 import com.introproventures.graphql.jpa.query.schema.GraphQLSchemaBuilder;
 import com.introproventures.graphql.jpa.query.schema.impl.GraphQLJpaExecutor;
 import com.introproventures.graphql.jpa.query.schema.impl.GraphQLJpaSchemaBuilder;
-import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.autoconfigure.SpringBootApplication;
-import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.boot.test.context.SpringBootTest.WebEnvironment;
-import org.springframework.context.annotation.Bean;
-import org.springframework.test.context.TestPropertySource;
-import org.springframework.test.context.junit4.SpringRunner;
 
 
 @RunWith(SpringRunner.class)
 @SpringBootTest(webEnvironment=WebEnvironment.NONE, 
                 properties = "spring.datasource.data=GraphQLJpaConverterTests.sql")
 @TestPropertySource({"classpath:hibernate.properties"})
+@DirtiesContext
 public class GraphQLJpaConverterTests {
     
     @SpringBootApplication

--- a/graphql-jpa-query-schema/src/test/java/com/introproventures/graphql/jpa/query/converter/GraphQLJpaConverterTests.java
+++ b/graphql-jpa-query-schema/src/test/java/com/introproventures/graphql/jpa/query/converter/GraphQLJpaConverterTests.java
@@ -33,20 +33,14 @@ import javax.persistence.criteria.Subquery;
 import javax.transaction.Transactional;
 
 import org.junit.Test;
-import org.junit.runner.RunWith;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
-import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
-import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase.Replace;
 import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.boot.test.context.SpringBootTest.WebEnvironment;
 import org.springframework.context.annotation.Bean;
-import org.springframework.test.annotation.DirtiesContext;
-import org.springframework.test.context.TestPropertySource;
-import org.springframework.test.context.junit4.SpringRunner;
 
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.introproventures.graphql.jpa.query.AbstractSpringBootTestSupport;
 import com.introproventures.graphql.jpa.query.converter.model.JsonEntity;
 import com.introproventures.graphql.jpa.query.converter.model.TaskEntity;
 import com.introproventures.graphql.jpa.query.converter.model.TaskVariableEntity;
@@ -57,13 +51,8 @@ import com.introproventures.graphql.jpa.query.schema.impl.GraphQLJpaExecutor;
 import com.introproventures.graphql.jpa.query.schema.impl.GraphQLJpaSchemaBuilder;
 
 
-@RunWith(SpringRunner.class)
-@SpringBootTest(webEnvironment=WebEnvironment.NONE, 
-                properties = "spring.datasource.data=GraphQLJpaConverterTests.sql")
-@TestPropertySource({"classpath:hibernate.properties"})
-@DirtiesContext
-@AutoConfigureTestDatabase(replace = Replace.ANY)
-public class GraphQLJpaConverterTests {
+@SpringBootTest(properties = "spring.datasource.data=GraphQLJpaConverterTests.sql")
+public class GraphQLJpaConverterTests extends AbstractSpringBootTestSupport {
     
     @SpringBootApplication
     static class Application {

--- a/graphql-jpa-query-schema/src/test/java/com/introproventures/graphql/jpa/query/embeddedid/EntityWithEmbeddedIdTest.java
+++ b/graphql-jpa-query-schema/src/test/java/com/introproventures/graphql/jpa/query/embeddedid/EntityWithEmbeddedIdTest.java
@@ -8,6 +8,8 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
+import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase.Replace;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.context.annotation.Bean;
 import org.springframework.test.annotation.DirtiesContext;
@@ -24,6 +26,7 @@ import com.introproventures.graphql.jpa.query.schema.impl.GraphQLJpaSchemaBuilde
         properties = "spring.datasource.data=EntityWithEmbeddedIdTest.sql")
 @TestPropertySource({"classpath:hibernate.properties"})
 @DirtiesContext
+@AutoConfigureTestDatabase(replace = Replace.ANY)
 public class EntityWithEmbeddedIdTest {
 
     @SpringBootApplication

--- a/graphql-jpa-query-schema/src/test/java/com/introproventures/graphql/jpa/query/embeddedid/EntityWithEmbeddedIdTest.java
+++ b/graphql-jpa-query-schema/src/test/java/com/introproventures/graphql/jpa/query/embeddedid/EntityWithEmbeddedIdTest.java
@@ -10,6 +10,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.context.annotation.Bean;
+import org.springframework.test.annotation.DirtiesContext;
 import org.springframework.test.context.TestPropertySource;
 import org.springframework.test.context.junit4.SpringRunner;
 
@@ -22,6 +23,7 @@ import com.introproventures.graphql.jpa.query.schema.impl.GraphQLJpaSchemaBuilde
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.NONE,
         properties = "spring.datasource.data=EntityWithEmbeddedIdTest.sql")
 @TestPropertySource({"classpath:hibernate.properties"})
+@DirtiesContext
 public class EntityWithEmbeddedIdTest {
 
     @SpringBootApplication

--- a/graphql-jpa-query-schema/src/test/java/com/introproventures/graphql/jpa/query/embeddedid/EntityWithEmbeddedIdTest.java
+++ b/graphql-jpa-query-schema/src/test/java/com/introproventures/graphql/jpa/query/embeddedid/EntityWithEmbeddedIdTest.java
@@ -5,29 +5,19 @@ import static org.assertj.core.api.Assertions.assertThat;
 import javax.persistence.EntityManager;
 
 import org.junit.Test;
-import org.junit.runner.RunWith;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
-import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
-import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase.Replace;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.context.annotation.Bean;
-import org.springframework.test.annotation.DirtiesContext;
-import org.springframework.test.context.TestPropertySource;
-import org.springframework.test.context.junit4.SpringRunner;
 
+import com.introproventures.graphql.jpa.query.AbstractSpringBootTestSupport;
 import com.introproventures.graphql.jpa.query.schema.GraphQLExecutor;
 import com.introproventures.graphql.jpa.query.schema.GraphQLSchemaBuilder;
 import com.introproventures.graphql.jpa.query.schema.impl.GraphQLJpaExecutor;
 import com.introproventures.graphql.jpa.query.schema.impl.GraphQLJpaSchemaBuilder;
 
-@RunWith(SpringRunner.class)
-@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.NONE,
-        properties = "spring.datasource.data=EntityWithEmbeddedIdTest.sql")
-@TestPropertySource({"classpath:hibernate.properties"})
-@DirtiesContext
-@AutoConfigureTestDatabase(replace = Replace.ANY)
-public class EntityWithEmbeddedIdTest {
+@SpringBootTest(properties = "spring.datasource.data=EntityWithEmbeddedIdTest.sql")
+public class EntityWithEmbeddedIdTest  extends AbstractSpringBootTestSupport {
 
     @SpringBootApplication
     static class Application {

--- a/graphql-jpa-query-schema/src/test/java/com/introproventures/graphql/jpa/query/idclass/EntityWithIdClassTest.java
+++ b/graphql-jpa-query-schema/src/test/java/com/introproventures/graphql/jpa/query/idclass/EntityWithIdClassTest.java
@@ -5,29 +5,19 @@ import static org.assertj.core.api.Assertions.assertThat;
 import javax.persistence.EntityManager;
 
 import org.junit.Test;
-import org.junit.runner.RunWith;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
-import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
-import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase.Replace;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.context.annotation.Bean;
-import org.springframework.test.annotation.DirtiesContext;
-import org.springframework.test.context.TestPropertySource;
-import org.springframework.test.context.junit4.SpringRunner;
 
+import com.introproventures.graphql.jpa.query.AbstractSpringBootTestSupport;
 import com.introproventures.graphql.jpa.query.schema.GraphQLExecutor;
 import com.introproventures.graphql.jpa.query.schema.GraphQLSchemaBuilder;
 import com.introproventures.graphql.jpa.query.schema.impl.GraphQLJpaExecutor;
 import com.introproventures.graphql.jpa.query.schema.impl.GraphQLJpaSchemaBuilder;
 
-@RunWith(SpringRunner.class)
-@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.NONE,
-        properties = "spring.datasource.data=EntityWithIdClassTest.sql")
-@TestPropertySource({"classpath:hibernate.properties"})
-@DirtiesContext
-@AutoConfigureTestDatabase(replace = Replace.ANY)
-public class EntityWithIdClassTest {
+@SpringBootTest(properties = "spring.datasource.data=EntityWithIdClassTest.sql")
+public class EntityWithIdClassTest extends AbstractSpringBootTestSupport {
 
     @SpringBootApplication
     static class Application {

--- a/graphql-jpa-query-schema/src/test/java/com/introproventures/graphql/jpa/query/idclass/EntityWithIdClassTest.java
+++ b/graphql-jpa-query-schema/src/test/java/com/introproventures/graphql/jpa/query/idclass/EntityWithIdClassTest.java
@@ -8,6 +8,8 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
+import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase.Replace;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.context.annotation.Bean;
 import org.springframework.test.annotation.DirtiesContext;
@@ -24,6 +26,7 @@ import com.introproventures.graphql.jpa.query.schema.impl.GraphQLJpaSchemaBuilde
         properties = "spring.datasource.data=EntityWithIdClassTest.sql")
 @TestPropertySource({"classpath:hibernate.properties"})
 @DirtiesContext
+@AutoConfigureTestDatabase(replace = Replace.ANY)
 public class EntityWithIdClassTest {
 
     @SpringBootApplication

--- a/graphql-jpa-query-schema/src/test/java/com/introproventures/graphql/jpa/query/idclass/EntityWithIdClassTest.java
+++ b/graphql-jpa-query-schema/src/test/java/com/introproventures/graphql/jpa/query/idclass/EntityWithIdClassTest.java
@@ -10,6 +10,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.context.annotation.Bean;
+import org.springframework.test.annotation.DirtiesContext;
 import org.springframework.test.context.TestPropertySource;
 import org.springframework.test.context.junit4.SpringRunner;
 
@@ -22,6 +23,7 @@ import com.introproventures.graphql.jpa.query.schema.impl.GraphQLJpaSchemaBuilde
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.NONE,
         properties = "spring.datasource.data=EntityWithIdClassTest.sql")
 @TestPropertySource({"classpath:hibernate.properties"})
+@DirtiesContext
 public class EntityWithIdClassTest {
 
     @SpringBootApplication

--- a/graphql-jpa-query-schema/src/test/java/com/introproventures/graphql/jpa/query/localdatetime/GraphQLLocalDateTimeTest.java
+++ b/graphql-jpa-query-schema/src/test/java/com/introproventures/graphql/jpa/query/localdatetime/GraphQLLocalDateTimeTest.java
@@ -2,12 +2,17 @@ package com.introproventures.graphql.jpa.query.localdatetime;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+import java.util.TimeZone;
+
 import javax.persistence.EntityManager;
 
+import org.junit.BeforeClass;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
+import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase.Replace;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.context.annotation.Bean;
 import org.springframework.test.annotation.DirtiesContext;
@@ -24,6 +29,7 @@ import com.introproventures.graphql.jpa.query.schema.impl.GraphQLJpaSchemaBuilde
         properties = "spring.datasource.data=LocalDatetTmeData.sql")
 @TestPropertySource({"classpath:hibernate.properties"})
 @DirtiesContext
+@AutoConfigureTestDatabase(replace = Replace.ANY)
 public class GraphQLLocalDateTimeTest {
 
     @SpringBootApplication
@@ -47,6 +53,11 @@ public class GraphQLLocalDateTimeTest {
     @Autowired
     private EntityManager entityManager;
 
+    @BeforeClass
+    public static void init() {
+        TimeZone.setDefault(TimeZone.getTimeZone("UTC"));
+    }
+    
     @Test
     public void queryLocalDateWithEqualTest() {
         //given

--- a/graphql-jpa-query-schema/src/test/java/com/introproventures/graphql/jpa/query/localdatetime/GraphQLLocalDateTimeTest.java
+++ b/graphql-jpa-query-schema/src/test/java/com/introproventures/graphql/jpa/query/localdatetime/GraphQLLocalDateTimeTest.java
@@ -2,35 +2,23 @@ package com.introproventures.graphql.jpa.query.localdatetime;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-import java.util.TimeZone;
-
 import javax.persistence.EntityManager;
 
 import org.junit.BeforeClass;
 import org.junit.Test;
-import org.junit.runner.RunWith;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
-import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
-import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase.Replace;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.context.annotation.Bean;
-import org.springframework.test.annotation.DirtiesContext;
-import org.springframework.test.context.TestPropertySource;
-import org.springframework.test.context.junit4.SpringRunner;
 
+import com.introproventures.graphql.jpa.query.AbstractSpringBootTestSupport;
 import com.introproventures.graphql.jpa.query.schema.GraphQLExecutor;
 import com.introproventures.graphql.jpa.query.schema.GraphQLSchemaBuilder;
 import com.introproventures.graphql.jpa.query.schema.impl.GraphQLJpaExecutor;
 import com.introproventures.graphql.jpa.query.schema.impl.GraphQLJpaSchemaBuilder;
 
-@RunWith(SpringRunner.class)
-@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.NONE,
-        properties = "spring.datasource.data=LocalDatetTmeData.sql")
-@TestPropertySource({"classpath:hibernate.properties"})
-@DirtiesContext
-@AutoConfigureTestDatabase(replace = Replace.ANY)
-public class GraphQLLocalDateTimeTest {
+@SpringBootTest(properties = "spring.datasource.data=LocalDatetTmeData.sql")
+public class GraphQLLocalDateTimeTest extends AbstractSpringBootTestSupport {
 
     @SpringBootApplication
     static class Application {
@@ -55,7 +43,7 @@ public class GraphQLLocalDateTimeTest {
 
     @BeforeClass
     public static void init() {
-        TimeZone.setDefault(TimeZone.getTimeZone("UTC"));
+        //TimeZone.setDefault(TimeZone.getTimeZone("UTC"));
     }
     
     @Test

--- a/graphql-jpa-query-schema/src/test/java/com/introproventures/graphql/jpa/query/localdatetime/GraphQLLocalDateTimeTest.java
+++ b/graphql-jpa-query-schema/src/test/java/com/introproventures/graphql/jpa/query/localdatetime/GraphQLLocalDateTimeTest.java
@@ -1,26 +1,29 @@
 package com.introproventures.graphql.jpa.query.localdatetime;
 
-import com.introproventures.graphql.jpa.query.schema.GraphQLExecutor;
-import com.introproventures.graphql.jpa.query.schema.GraphQLSchemaBuilder;
-import com.introproventures.graphql.jpa.query.schema.impl.GraphQLJpaExecutor;
-import com.introproventures.graphql.jpa.query.schema.impl.GraphQLJpaSchemaBuilder;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import javax.persistence.EntityManager;
+
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.context.annotation.Bean;
+import org.springframework.test.annotation.DirtiesContext;
 import org.springframework.test.context.TestPropertySource;
 import org.springframework.test.context.junit4.SpringRunner;
 
-import javax.persistence.EntityManager;
-
-import static org.assertj.core.api.Assertions.assertThat;
+import com.introproventures.graphql.jpa.query.schema.GraphQLExecutor;
+import com.introproventures.graphql.jpa.query.schema.GraphQLSchemaBuilder;
+import com.introproventures.graphql.jpa.query.schema.impl.GraphQLJpaExecutor;
+import com.introproventures.graphql.jpa.query.schema.impl.GraphQLJpaSchemaBuilder;
 
 @RunWith(SpringRunner.class)
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.NONE,
         properties = "spring.datasource.data=LocalDatetTmeData.sql")
 @TestPropertySource({"classpath:hibernate.properties"})
+@DirtiesContext
 public class GraphQLLocalDateTimeTest {
 
     @SpringBootApplication

--- a/graphql-jpa-query-schema/src/test/java/com/introproventures/graphql/jpa/query/schema/BooksSchemaBuildTest.java
+++ b/graphql-jpa-query-schema/src/test/java/com/introproventures/graphql/jpa/query/schema/BooksSchemaBuildTest.java
@@ -26,30 +26,20 @@ import javax.persistence.EntityManager;
 
 import org.junit.Before;
 import org.junit.Test;
-import org.junit.runner.RunWith;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
-import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
-import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase.Replace;
 import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.boot.test.context.SpringBootTest.WebEnvironment;
 import org.springframework.context.annotation.Bean;
-import org.springframework.test.annotation.DirtiesContext;
-import org.springframework.test.context.junit4.SpringRunner;
 
+import com.introproventures.graphql.jpa.query.AbstractSpringBootTestSupport;
 import com.introproventures.graphql.jpa.query.schema.impl.GraphQLJpaSchemaBuilder;
 
 import graphql.schema.GraphQLFieldDefinition;
 import graphql.schema.GraphQLList;
 import graphql.schema.GraphQLSchema;
 
-@RunWith(SpringRunner.class)
-@SpringBootTest(
-    webEnvironment=WebEnvironment.NONE
-)
-@DirtiesContext
-@AutoConfigureTestDatabase(replace = Replace.ANY)
-public class BooksSchemaBuildTest {
+@SpringBootTest
+public class BooksSchemaBuildTest extends AbstractSpringBootTestSupport {
 
     @SpringBootApplication
     static class TestConfiguration {

--- a/graphql-jpa-query-schema/src/test/java/com/introproventures/graphql/jpa/query/schema/BooksSchemaBuildTest.java
+++ b/graphql-jpa-query-schema/src/test/java/com/introproventures/graphql/jpa/query/schema/BooksSchemaBuildTest.java
@@ -29,6 +29,8 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
+import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase.Replace;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.context.SpringBootTest.WebEnvironment;
 import org.springframework.context.annotation.Bean;
@@ -46,6 +48,7 @@ import graphql.schema.GraphQLSchema;
     webEnvironment=WebEnvironment.NONE
 )
 @DirtiesContext
+@AutoConfigureTestDatabase(replace = Replace.ANY)
 public class BooksSchemaBuildTest {
 
     @SpringBootApplication

--- a/graphql-jpa-query-schema/src/test/java/com/introproventures/graphql/jpa/query/schema/BooksSchemaBuildTest.java
+++ b/graphql-jpa-query-schema/src/test/java/com/introproventures/graphql/jpa/query/schema/BooksSchemaBuildTest.java
@@ -24,10 +24,6 @@ import java.util.Optional;
 
 import javax.persistence.EntityManager;
 
-import com.introproventures.graphql.jpa.query.schema.impl.GraphQLJpaSchemaBuilder;
-import graphql.schema.GraphQLFieldDefinition;
-import graphql.schema.GraphQLList;
-import graphql.schema.GraphQLSchema;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -36,12 +32,20 @@ import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.context.SpringBootTest.WebEnvironment;
 import org.springframework.context.annotation.Bean;
+import org.springframework.test.annotation.DirtiesContext;
 import org.springframework.test.context.junit4.SpringRunner;
+
+import com.introproventures.graphql.jpa.query.schema.impl.GraphQLJpaSchemaBuilder;
+
+import graphql.schema.GraphQLFieldDefinition;
+import graphql.schema.GraphQLList;
+import graphql.schema.GraphQLSchema;
 
 @RunWith(SpringRunner.class)
 @SpringBootTest(
     webEnvironment=WebEnvironment.NONE
 )
+@DirtiesContext
 public class BooksSchemaBuildTest {
 
     @SpringBootApplication

--- a/graphql-jpa-query-schema/src/test/java/com/introproventures/graphql/jpa/query/schema/CalculatedEntityTests.java
+++ b/graphql-jpa-query-schema/src/test/java/com/introproventures/graphql/jpa/query/schema/CalculatedEntityTests.java
@@ -15,6 +15,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.context.annotation.Bean;
+import org.springframework.test.annotation.DirtiesContext;
 import org.springframework.test.context.TestPropertySource;
 import org.springframework.test.context.junit4.SpringRunner;
 import org.springframework.util.Assert;
@@ -30,6 +31,7 @@ import graphql.validation.ValidationErrorType;
 @RunWith(SpringRunner.class)
 @SpringBootTest(webEnvironment= SpringBootTest.WebEnvironment.NONE)
 @TestPropertySource({"classpath:hibernate.properties"})
+@DirtiesContext
 public class CalculatedEntityTests {
     @SpringBootApplication
     static class Application {

--- a/graphql-jpa-query-schema/src/test/java/com/introproventures/graphql/jpa/query/schema/CalculatedEntityTests.java
+++ b/graphql-jpa-query-schema/src/test/java/com/introproventures/graphql/jpa/query/schema/CalculatedEntityTests.java
@@ -10,18 +10,13 @@ import java.util.Optional;
 import javax.persistence.EntityManager;
 
 import org.junit.Test;
-import org.junit.runner.RunWith;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
-import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
-import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase.Replace;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.context.annotation.Bean;
-import org.springframework.test.annotation.DirtiesContext;
-import org.springframework.test.context.TestPropertySource;
-import org.springframework.test.context.junit4.SpringRunner;
 import org.springframework.util.Assert;
 
+import com.introproventures.graphql.jpa.query.AbstractSpringBootTestSupport;
 import com.introproventures.graphql.jpa.query.schema.impl.GraphQLJpaExecutor;
 import com.introproventures.graphql.jpa.query.schema.impl.GraphQLJpaSchemaBuilder;
 
@@ -30,12 +25,8 @@ import graphql.schema.GraphQLFieldDefinition;
 import graphql.schema.GraphQLSchema;
 import graphql.validation.ValidationErrorType;
 
-@RunWith(SpringRunner.class)
-@SpringBootTest(webEnvironment= SpringBootTest.WebEnvironment.NONE)
-@TestPropertySource({"classpath:hibernate.properties"})
-@DirtiesContext
-@AutoConfigureTestDatabase(replace = Replace.ANY)
-public class CalculatedEntityTests {
+@SpringBootTest
+public class CalculatedEntityTests extends AbstractSpringBootTestSupport {
     @SpringBootApplication
     static class Application {
         @Bean

--- a/graphql-jpa-query-schema/src/test/java/com/introproventures/graphql/jpa/query/schema/CalculatedEntityTests.java
+++ b/graphql-jpa-query-schema/src/test/java/com/introproventures/graphql/jpa/query/schema/CalculatedEntityTests.java
@@ -13,6 +13,8 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
+import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase.Replace;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.context.annotation.Bean;
 import org.springframework.test.annotation.DirtiesContext;
@@ -32,6 +34,7 @@ import graphql.validation.ValidationErrorType;
 @SpringBootTest(webEnvironment= SpringBootTest.WebEnvironment.NONE)
 @TestPropertySource({"classpath:hibernate.properties"})
 @DirtiesContext
+@AutoConfigureTestDatabase(replace = Replace.ANY)
 public class CalculatedEntityTests {
     @SpringBootApplication
     static class Application {

--- a/graphql-jpa-query-schema/src/test/java/com/introproventures/graphql/jpa/query/schema/EntityIntrospectorTest.java
+++ b/graphql-jpa-query-schema/src/test/java/com/introproventures/graphql/jpa/query/schema/EntityIntrospectorTest.java
@@ -19,6 +19,7 @@ import org.mockito.Mockito;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.annotation.DirtiesContext;
 import org.springframework.test.context.TestPropertySource;
 import org.springframework.test.context.junit4.SpringRunner;
 
@@ -32,6 +33,7 @@ import com.introproventures.graphql.jpa.query.schema.model.metamodel.ClassWithCu
 @RunWith(SpringRunner.class)
 @SpringBootTest(webEnvironment= SpringBootTest.WebEnvironment.NONE)
 @TestPropertySource({"classpath:hibernate.properties"})
+@DirtiesContext
 public class EntityIntrospectorTest {
 
     @SpringBootApplication

--- a/graphql-jpa-query-schema/src/test/java/com/introproventures/graphql/jpa/query/schema/EntityIntrospectorTest.java
+++ b/graphql-jpa-query-schema/src/test/java/com/introproventures/graphql/jpa/query/schema/EntityIntrospectorTest.java
@@ -14,17 +14,12 @@ import javax.persistence.metamodel.ManagedType;
 
 import org.junit.Before;
 import org.junit.Test;
-import org.junit.runner.RunWith;
 import org.mockito.Mockito;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
-import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
-import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase.Replace;
 import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.test.annotation.DirtiesContext;
-import org.springframework.test.context.TestPropertySource;
-import org.springframework.test.context.junit4.SpringRunner;
 
+import com.introproventures.graphql.jpa.query.AbstractSpringBootTestSupport;
 import com.introproventures.graphql.jpa.query.schema.impl.EntityIntrospector;
 import com.introproventures.graphql.jpa.query.schema.impl.EntityIntrospector.EntityIntrospectionResult;
 import com.introproventures.graphql.jpa.query.schema.impl.EntityIntrospector.EntityIntrospectionResult.AttributePropertyDescriptor;
@@ -32,12 +27,8 @@ import com.introproventures.graphql.jpa.query.schema.model.calculated.Calculated
 import com.introproventures.graphql.jpa.query.schema.model.calculated.ParentCalculatedEntity;
 import com.introproventures.graphql.jpa.query.schema.model.metamodel.ClassWithCustomMetamodel;
 
-@RunWith(SpringRunner.class)
-@SpringBootTest(webEnvironment= SpringBootTest.WebEnvironment.NONE)
-@TestPropertySource({"classpath:hibernate.properties"})
-@DirtiesContext
-@AutoConfigureTestDatabase(replace = Replace.ANY)
-public class EntityIntrospectorTest {
+@SpringBootTest
+public class EntityIntrospectorTest extends AbstractSpringBootTestSupport {
 
     @SpringBootApplication
     static class Application {

--- a/graphql-jpa-query-schema/src/test/java/com/introproventures/graphql/jpa/query/schema/EntityIntrospectorTest.java
+++ b/graphql-jpa-query-schema/src/test/java/com/introproventures/graphql/jpa/query/schema/EntityIntrospectorTest.java
@@ -18,6 +18,8 @@ import org.junit.runner.RunWith;
 import org.mockito.Mockito;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
+import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase.Replace;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.test.annotation.DirtiesContext;
 import org.springframework.test.context.TestPropertySource;
@@ -34,6 +36,7 @@ import com.introproventures.graphql.jpa.query.schema.model.metamodel.ClassWithCu
 @SpringBootTest(webEnvironment= SpringBootTest.WebEnvironment.NONE)
 @TestPropertySource({"classpath:hibernate.properties"})
 @DirtiesContext
+@AutoConfigureTestDatabase(replace = Replace.ANY)
 public class EntityIntrospectorTest {
 
     @SpringBootApplication

--- a/graphql-jpa-query-schema/src/test/java/com/introproventures/graphql/jpa/query/schema/GraphQLEnumVariableBindingsTests.java
+++ b/graphql-jpa-query-schema/src/test/java/com/introproventures/graphql/jpa/query/schema/GraphQLEnumVariableBindingsTests.java
@@ -24,8 +24,6 @@ import java.util.Map;
 
 import javax.persistence.EntityManager;
 
-import com.introproventures.graphql.jpa.query.schema.impl.GraphQLJpaExecutor;
-import com.introproventures.graphql.jpa.query.schema.impl.GraphQLJpaSchemaBuilder;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -33,13 +31,18 @@ import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.context.SpringBootTest.WebEnvironment;
 import org.springframework.context.annotation.Bean;
+import org.springframework.test.annotation.DirtiesContext;
 import org.springframework.test.context.TestPropertySource;
 import org.springframework.test.context.junit4.SpringRunner;
+
+import com.introproventures.graphql.jpa.query.schema.impl.GraphQLJpaExecutor;
+import com.introproventures.graphql.jpa.query.schema.impl.GraphQLJpaSchemaBuilder;
 
 
 @RunWith(SpringRunner.class)
 @SpringBootTest(webEnvironment=WebEnvironment.NONE)
 @TestPropertySource({"classpath:hibernate.properties"})
+@DirtiesContext
 public class GraphQLEnumVariableBindingsTests {
     
     @SpringBootApplication

--- a/graphql-jpa-query-schema/src/test/java/com/introproventures/graphql/jpa/query/schema/GraphQLEnumVariableBindingsTests.java
+++ b/graphql-jpa-query-schema/src/test/java/com/introproventures/graphql/jpa/query/schema/GraphQLEnumVariableBindingsTests.java
@@ -28,6 +28,8 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
+import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase.Replace;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.context.SpringBootTest.WebEnvironment;
 import org.springframework.context.annotation.Bean;
@@ -43,6 +45,7 @@ import com.introproventures.graphql.jpa.query.schema.impl.GraphQLJpaSchemaBuilde
 @SpringBootTest(webEnvironment=WebEnvironment.NONE)
 @TestPropertySource({"classpath:hibernate.properties"})
 @DirtiesContext
+@AutoConfigureTestDatabase(replace = Replace.ANY)
 public class GraphQLEnumVariableBindingsTests {
     
     @SpringBootApplication

--- a/graphql-jpa-query-schema/src/test/java/com/introproventures/graphql/jpa/query/schema/GraphQLEnumVariableBindingsTests.java
+++ b/graphql-jpa-query-schema/src/test/java/com/introproventures/graphql/jpa/query/schema/GraphQLEnumVariableBindingsTests.java
@@ -25,28 +25,18 @@ import java.util.Map;
 import javax.persistence.EntityManager;
 
 import org.junit.Test;
-import org.junit.runner.RunWith;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
-import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
-import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase.Replace;
 import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.boot.test.context.SpringBootTest.WebEnvironment;
 import org.springframework.context.annotation.Bean;
-import org.springframework.test.annotation.DirtiesContext;
-import org.springframework.test.context.TestPropertySource;
-import org.springframework.test.context.junit4.SpringRunner;
 
+import com.introproventures.graphql.jpa.query.AbstractSpringBootTestSupport;
 import com.introproventures.graphql.jpa.query.schema.impl.GraphQLJpaExecutor;
 import com.introproventures.graphql.jpa.query.schema.impl.GraphQLJpaSchemaBuilder;
 
 
-@RunWith(SpringRunner.class)
-@SpringBootTest(webEnvironment=WebEnvironment.NONE)
-@TestPropertySource({"classpath:hibernate.properties"})
-@DirtiesContext
-@AutoConfigureTestDatabase(replace = Replace.ANY)
-public class GraphQLEnumVariableBindingsTests {
+@SpringBootTest
+public class GraphQLEnumVariableBindingsTests extends AbstractSpringBootTestSupport {
     
     @SpringBootApplication
     static class Application {

--- a/graphql-jpa-query-schema/src/test/java/com/introproventures/graphql/jpa/query/schema/GraphQLExecutorListCriteriaTests.java
+++ b/graphql-jpa-query-schema/src/test/java/com/introproventures/graphql/jpa/query/schema/GraphQLExecutorListCriteriaTests.java
@@ -24,6 +24,8 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
+import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase.Replace;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.context.SpringBootTest.WebEnvironment;
 import org.springframework.context.annotation.Bean;
@@ -40,6 +42,7 @@ import com.introproventures.graphql.jpa.query.schema.impl.GraphQLJpaSchemaBuilde
 @SpringBootTest(webEnvironment=WebEnvironment.NONE)
 @TestPropertySource({"classpath:hibernate.properties"})
 @DirtiesContext
+@AutoConfigureTestDatabase(replace = Replace.ANY)
 public class GraphQLExecutorListCriteriaTests {
     
     @SpringBootApplication

--- a/graphql-jpa-query-schema/src/test/java/com/introproventures/graphql/jpa/query/schema/GraphQLExecutorListCriteriaTests.java
+++ b/graphql-jpa-query-schema/src/test/java/com/introproventures/graphql/jpa/query/schema/GraphQLExecutorListCriteriaTests.java
@@ -27,6 +27,7 @@ import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.context.SpringBootTest.WebEnvironment;
 import org.springframework.context.annotation.Bean;
+import org.springframework.test.annotation.DirtiesContext;
 import org.springframework.test.context.TestPropertySource;
 import org.springframework.test.context.junit4.SpringRunner;
 import org.springframework.util.Assert;
@@ -38,6 +39,7 @@ import com.introproventures.graphql.jpa.query.schema.impl.GraphQLJpaSchemaBuilde
 @RunWith(SpringRunner.class)
 @SpringBootTest(webEnvironment=WebEnvironment.NONE)
 @TestPropertySource({"classpath:hibernate.properties"})
+@DirtiesContext
 public class GraphQLExecutorListCriteriaTests {
     
     @SpringBootApplication

--- a/graphql-jpa-query-schema/src/test/java/com/introproventures/graphql/jpa/query/schema/GraphQLExecutorListCriteriaTests.java
+++ b/graphql-jpa-query-schema/src/test/java/com/introproventures/graphql/jpa/query/schema/GraphQLExecutorListCriteriaTests.java
@@ -21,29 +21,19 @@ import static org.assertj.core.api.Assertions.assertThat;
 import javax.persistence.EntityManager;
 
 import org.junit.Test;
-import org.junit.runner.RunWith;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
-import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
-import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase.Replace;
 import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.boot.test.context.SpringBootTest.WebEnvironment;
 import org.springframework.context.annotation.Bean;
-import org.springframework.test.annotation.DirtiesContext;
-import org.springframework.test.context.TestPropertySource;
-import org.springframework.test.context.junit4.SpringRunner;
 import org.springframework.util.Assert;
 
+import com.introproventures.graphql.jpa.query.AbstractSpringBootTestSupport;
 import com.introproventures.graphql.jpa.query.schema.impl.GraphQLJpaExecutor;
 import com.introproventures.graphql.jpa.query.schema.impl.GraphQLJpaSchemaBuilder;
 
 
-@RunWith(SpringRunner.class)
-@SpringBootTest(webEnvironment=WebEnvironment.NONE)
-@TestPropertySource({"classpath:hibernate.properties"})
-@DirtiesContext
-@AutoConfigureTestDatabase(replace = Replace.ANY)
-public class GraphQLExecutorListCriteriaTests {
+@SpringBootTest
+public class GraphQLExecutorListCriteriaTests extends AbstractSpringBootTestSupport {
     
     @SpringBootApplication
     static class Application {

--- a/graphql-jpa-query-schema/src/test/java/com/introproventures/graphql/jpa/query/schema/GraphQLExecutorSuperClassTests.java
+++ b/graphql-jpa-query-schema/src/test/java/com/introproventures/graphql/jpa/query/schema/GraphQLExecutorSuperClassTests.java
@@ -9,6 +9,8 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
+import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase.Replace;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.context.annotation.Bean;
 import org.springframework.test.annotation.DirtiesContext;
@@ -23,6 +25,7 @@ import com.introproventures.graphql.jpa.query.schema.impl.GraphQLJpaSchemaBuilde
 @SpringBootTest(webEnvironment= SpringBootTest.WebEnvironment.NONE)
 @TestPropertySource({"classpath:hibernate.properties"})
 @DirtiesContext
+@AutoConfigureTestDatabase(replace = Replace.ANY)
 public class GraphQLExecutorSuperClassTests {
 
     @SpringBootApplication

--- a/graphql-jpa-query-schema/src/test/java/com/introproventures/graphql/jpa/query/schema/GraphQLExecutorSuperClassTests.java
+++ b/graphql-jpa-query-schema/src/test/java/com/introproventures/graphql/jpa/query/schema/GraphQLExecutorSuperClassTests.java
@@ -5,21 +5,24 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 import javax.persistence.EntityManager;
 
-import com.introproventures.graphql.jpa.query.schema.impl.GraphQLJpaExecutor;
-import com.introproventures.graphql.jpa.query.schema.impl.GraphQLJpaSchemaBuilder;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.context.annotation.Bean;
+import org.springframework.test.annotation.DirtiesContext;
 import org.springframework.test.context.TestPropertySource;
 import org.springframework.test.context.junit4.SpringRunner;
 import org.springframework.util.Assert;
 
+import com.introproventures.graphql.jpa.query.schema.impl.GraphQLJpaExecutor;
+import com.introproventures.graphql.jpa.query.schema.impl.GraphQLJpaSchemaBuilder;
+
 @RunWith(SpringRunner.class)
 @SpringBootTest(webEnvironment= SpringBootTest.WebEnvironment.NONE)
 @TestPropertySource({"classpath:hibernate.properties"})
+@DirtiesContext
 public class GraphQLExecutorSuperClassTests {
 
     @SpringBootApplication

--- a/graphql-jpa-query-schema/src/test/java/com/introproventures/graphql/jpa/query/schema/GraphQLExecutorSuperClassTests.java
+++ b/graphql-jpa-query-schema/src/test/java/com/introproventures/graphql/jpa/query/schema/GraphQLExecutorSuperClassTests.java
@@ -6,27 +6,18 @@ import static org.assertj.core.api.Assertions.assertThat;
 import javax.persistence.EntityManager;
 
 import org.junit.Test;
-import org.junit.runner.RunWith;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
-import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
-import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase.Replace;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.context.annotation.Bean;
-import org.springframework.test.annotation.DirtiesContext;
-import org.springframework.test.context.TestPropertySource;
-import org.springframework.test.context.junit4.SpringRunner;
 import org.springframework.util.Assert;
 
+import com.introproventures.graphql.jpa.query.AbstractSpringBootTestSupport;
 import com.introproventures.graphql.jpa.query.schema.impl.GraphQLJpaExecutor;
 import com.introproventures.graphql.jpa.query.schema.impl.GraphQLJpaSchemaBuilder;
 
-@RunWith(SpringRunner.class)
-@SpringBootTest(webEnvironment= SpringBootTest.WebEnvironment.NONE)
-@TestPropertySource({"classpath:hibernate.properties"})
-@DirtiesContext
-@AutoConfigureTestDatabase(replace = Replace.ANY)
-public class GraphQLExecutorSuperClassTests {
+@SpringBootTest
+public class GraphQLExecutorSuperClassTests extends AbstractSpringBootTestSupport {
 
     @SpringBootApplication
     static class Application {

--- a/graphql-jpa-query-schema/src/test/java/com/introproventures/graphql/jpa/query/schema/GraphQLExecutorTests.java
+++ b/graphql-jpa-query-schema/src/test/java/com/introproventures/graphql/jpa/query/schema/GraphQLExecutorTests.java
@@ -37,6 +37,7 @@ import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.context.SpringBootTest.WebEnvironment;
 import org.springframework.context.annotation.Bean;
+import org.springframework.test.annotation.DirtiesContext;
 import org.springframework.test.context.TestPropertySource;
 import org.springframework.test.context.junit4.SpringRunner;
 import org.springframework.util.Assert;
@@ -54,6 +55,7 @@ import graphql.validation.ValidationErrorType;
 @RunWith(SpringRunner.class)
 @SpringBootTest(webEnvironment=WebEnvironment.NONE)
 @TestPropertySource({"classpath:hibernate.properties"})
+@DirtiesContext
 public class GraphQLExecutorTests {
     
     @SpringBootApplication

--- a/graphql-jpa-query-schema/src/test/java/com/introproventures/graphql/jpa/query/schema/GraphQLExecutorTests.java
+++ b/graphql-jpa-query-schema/src/test/java/com/introproventures/graphql/jpa/query/schema/GraphQLExecutorTests.java
@@ -36,6 +36,8 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
+import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase.Replace;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.context.SpringBootTest.WebEnvironment;
 import org.springframework.context.annotation.Bean;
@@ -58,6 +60,7 @@ import graphql.validation.ValidationErrorType;
 @SpringBootTest(webEnvironment=WebEnvironment.NONE)
 @TestPropertySource({"classpath:hibernate.properties"})
 @DirtiesContext
+@AutoConfigureTestDatabase(replace = Replace.ANY)
 public class GraphQLExecutorTests {
     
     @SpringBootApplication

--- a/graphql-jpa-query-schema/src/test/java/com/introproventures/graphql/jpa/query/schema/GraphQLExecutorTests.java
+++ b/graphql-jpa-query-schema/src/test/java/com/introproventures/graphql/jpa/query/schema/GraphQLExecutorTests.java
@@ -26,10 +26,12 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.TimeZone;
 
 import javax.persistence.EntityManager;
 
 import org.assertj.core.util.Maps;
+import org.junit.BeforeClass;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -77,6 +79,11 @@ public class GraphQLExecutorTests {
     
     @Autowired
     private GraphQLExecutor executor;
+
+    @BeforeClass
+    public static void init() {
+        TimeZone.setDefault(TimeZone.getTimeZone("UTC"));
+    }
     
     @Test
     public void contextLoads() {

--- a/graphql-jpa-query-schema/src/test/java/com/introproventures/graphql/jpa/query/schema/GraphQLExecutorTests.java
+++ b/graphql-jpa-query-schema/src/test/java/com/introproventures/graphql/jpa/query/schema/GraphQLExecutorTests.java
@@ -33,19 +33,13 @@ import javax.persistence.EntityManager;
 import org.assertj.core.util.Maps;
 import org.junit.BeforeClass;
 import org.junit.Test;
-import org.junit.runner.RunWith;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
-import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
-import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase.Replace;
 import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.boot.test.context.SpringBootTest.WebEnvironment;
 import org.springframework.context.annotation.Bean;
-import org.springframework.test.annotation.DirtiesContext;
-import org.springframework.test.context.TestPropertySource;
-import org.springframework.test.context.junit4.SpringRunner;
 import org.springframework.util.Assert;
 
+import com.introproventures.graphql.jpa.query.AbstractSpringBootTestSupport;
 import com.introproventures.graphql.jpa.query.schema.impl.GraphQLJpaExecutor;
 import com.introproventures.graphql.jpa.query.schema.impl.GraphQLJpaSchemaBuilder;
 
@@ -56,12 +50,8 @@ import graphql.validation.ValidationError;
 import graphql.validation.ValidationErrorType;
 
 
-@RunWith(SpringRunner.class)
-@SpringBootTest(webEnvironment=WebEnvironment.NONE)
-@TestPropertySource({"classpath:hibernate.properties"})
-@DirtiesContext
-@AutoConfigureTestDatabase(replace = Replace.ANY)
-public class GraphQLExecutorTests {
+@SpringBootTest
+public class GraphQLExecutorTests extends AbstractSpringBootTestSupport {
     
     @SpringBootApplication
     static class Application {

--- a/graphql-jpa-query-schema/src/test/java/com/introproventures/graphql/jpa/query/schema/GraphQLWhereVariableBindingsTests.java
+++ b/graphql-jpa-query-schema/src/test/java/com/introproventures/graphql/jpa/query/schema/GraphQLWhereVariableBindingsTests.java
@@ -15,6 +15,8 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
+import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase.Replace;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.context.SpringBootTest.WebEnvironment;
 import org.springframework.context.annotation.Bean;
@@ -32,6 +34,7 @@ import graphql.ExecutionResult;
 @SpringBootTest(webEnvironment = WebEnvironment.NONE)
 @TestPropertySource({ "classpath:hibernate.properties" })
 @DirtiesContext
+@AutoConfigureTestDatabase(replace = Replace.ANY)
 public class GraphQLWhereVariableBindingsTests {
 
 	@SpringBootApplication

--- a/graphql-jpa-query-schema/src/test/java/com/introproventures/graphql/jpa/query/schema/GraphQLWhereVariableBindingsTests.java
+++ b/graphql-jpa-query-schema/src/test/java/com/introproventures/graphql/jpa/query/schema/GraphQLWhereVariableBindingsTests.java
@@ -12,30 +12,20 @@ import java.util.Map;
 import javax.persistence.EntityManager;
 
 import org.junit.Test;
-import org.junit.runner.RunWith;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
-import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
-import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase.Replace;
 import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.boot.test.context.SpringBootTest.WebEnvironment;
 import org.springframework.context.annotation.Bean;
-import org.springframework.test.annotation.DirtiesContext;
-import org.springframework.test.context.TestPropertySource;
-import org.springframework.test.context.junit4.SpringRunner;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.introproventures.graphql.jpa.query.AbstractSpringBootTestSupport;
 import com.introproventures.graphql.jpa.query.schema.impl.GraphQLJpaExecutor;
 import com.introproventures.graphql.jpa.query.schema.impl.GraphQLJpaSchemaBuilder;
 
 import graphql.ExecutionResult;
 
-@RunWith(SpringRunner.class)
-@SpringBootTest(webEnvironment = WebEnvironment.NONE)
-@TestPropertySource({ "classpath:hibernate.properties" })
-@DirtiesContext
-@AutoConfigureTestDatabase(replace = Replace.ANY)
-public class GraphQLWhereVariableBindingsTests {
+@SpringBootTest
+public class GraphQLWhereVariableBindingsTests extends AbstractSpringBootTestSupport {
 
 	@SpringBootApplication
 	static class Application {

--- a/graphql-jpa-query-schema/src/test/java/com/introproventures/graphql/jpa/query/schema/GraphQLWhereVariableBindingsTests.java
+++ b/graphql-jpa-query-schema/src/test/java/com/introproventures/graphql/jpa/query/schema/GraphQLWhereVariableBindingsTests.java
@@ -18,6 +18,7 @@ import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.context.SpringBootTest.WebEnvironment;
 import org.springframework.context.annotation.Bean;
+import org.springframework.test.annotation.DirtiesContext;
 import org.springframework.test.context.TestPropertySource;
 import org.springframework.test.context.junit4.SpringRunner;
 
@@ -30,6 +31,7 @@ import graphql.ExecutionResult;
 @RunWith(SpringRunner.class)
 @SpringBootTest(webEnvironment = WebEnvironment.NONE)
 @TestPropertySource({ "classpath:hibernate.properties" })
+@DirtiesContext
 public class GraphQLWhereVariableBindingsTests {
 
 	@SpringBootApplication

--- a/graphql-jpa-query-schema/src/test/java/com/introproventures/graphql/jpa/query/schema/StarwarsQueryExecutorTests.java
+++ b/graphql-jpa-query-schema/src/test/java/com/introproventures/graphql/jpa/query/schema/StarwarsQueryExecutorTests.java
@@ -33,6 +33,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.context.annotation.Bean;
+import org.springframework.test.annotation.DirtiesContext;
 import org.springframework.test.context.TestPropertySource;
 import org.springframework.test.context.junit4.SpringRunner;
 
@@ -44,6 +45,7 @@ import com.introproventures.graphql.jpa.query.schema.model.starwars.Droid;
 @RunWith(SpringRunner.class)
 @SpringBootTest
 @TestPropertySource({"classpath:hibernate.properties"})
+@DirtiesContext
 public class StarwarsQueryExecutorTests {
 
     @SpringBootApplication

--- a/graphql-jpa-query-schema/src/test/java/com/introproventures/graphql/jpa/query/schema/StarwarsQueryExecutorTests.java
+++ b/graphql-jpa-query-schema/src/test/java/com/introproventures/graphql/jpa/query/schema/StarwarsQueryExecutorTests.java
@@ -31,6 +31,8 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
+import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase.Replace;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.context.annotation.Bean;
 import org.springframework.test.annotation.DirtiesContext;
@@ -46,6 +48,7 @@ import com.introproventures.graphql.jpa.query.schema.model.starwars.Droid;
 @SpringBootTest
 @TestPropertySource({"classpath:hibernate.properties"})
 @DirtiesContext
+@AutoConfigureTestDatabase(replace = Replace.ANY)
 public class StarwarsQueryExecutorTests {
 
     @SpringBootApplication

--- a/graphql-jpa-query-schema/src/test/java/com/introproventures/graphql/jpa/query/schema/StarwarsQueryExecutorTests.java
+++ b/graphql-jpa-query-schema/src/test/java/com/introproventures/graphql/jpa/query/schema/StarwarsQueryExecutorTests.java
@@ -28,28 +28,19 @@ import javax.persistence.Query;
 import javax.transaction.Transactional;
 
 import org.junit.Test;
-import org.junit.runner.RunWith;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
-import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
-import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase.Replace;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.context.annotation.Bean;
-import org.springframework.test.annotation.DirtiesContext;
-import org.springframework.test.context.TestPropertySource;
-import org.springframework.test.context.junit4.SpringRunner;
 
+import com.introproventures.graphql.jpa.query.AbstractSpringBootTestSupport;
 import com.introproventures.graphql.jpa.query.schema.impl.GraphQLJpaExecutor;
 import com.introproventures.graphql.jpa.query.schema.impl.GraphQLJpaSchemaBuilder;
 import com.introproventures.graphql.jpa.query.schema.model.starwars.Character;
 import com.introproventures.graphql.jpa.query.schema.model.starwars.Droid;
 
-@RunWith(SpringRunner.class)
 @SpringBootTest
-@TestPropertySource({"classpath:hibernate.properties"})
-@DirtiesContext
-@AutoConfigureTestDatabase(replace = Replace.ANY)
-public class StarwarsQueryExecutorTests {
+public class StarwarsQueryExecutorTests extends AbstractSpringBootTestSupport {
 
     @SpringBootApplication
     static class Application {

--- a/graphql-jpa-query-schema/src/test/java/com/introproventures/graphql/jpa/query/schema/StarwarsSchemaBuildTest.java
+++ b/graphql-jpa-query-schema/src/test/java/com/introproventures/graphql/jpa/query/schema/StarwarsSchemaBuildTest.java
@@ -22,17 +22,12 @@ import javax.persistence.EntityManager;
 
 import org.junit.Before;
 import org.junit.Test;
-import org.junit.runner.RunWith;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
-import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
-import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase.Replace;
 import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.boot.test.context.SpringBootTest.WebEnvironment;
 import org.springframework.context.annotation.Bean;
-import org.springframework.test.annotation.DirtiesContext;
-import org.springframework.test.context.junit4.SpringRunner;
 
+import com.introproventures.graphql.jpa.query.AbstractSpringBootTestSupport;
 import com.introproventures.graphql.jpa.query.schema.impl.GraphQLJpaSchemaBuilder;
 
 import graphql.Scalars;
@@ -40,13 +35,8 @@ import graphql.schema.GraphQLInputObjectType;
 import graphql.schema.GraphQLObjectType;
 import graphql.schema.GraphQLSchema;
 
-@RunWith(SpringRunner.class)
-@SpringBootTest(
-    webEnvironment=WebEnvironment.NONE
-)
-@DirtiesContext
-@AutoConfigureTestDatabase(replace = Replace.ANY)
-public class StarwarsSchemaBuildTest {
+@SpringBootTest
+public class StarwarsSchemaBuildTest extends AbstractSpringBootTestSupport {
 
     @SpringBootApplication
     static class TestConfiguration {

--- a/graphql-jpa-query-schema/src/test/java/com/introproventures/graphql/jpa/query/schema/StarwarsSchemaBuildTest.java
+++ b/graphql-jpa-query-schema/src/test/java/com/introproventures/graphql/jpa/query/schema/StarwarsSchemaBuildTest.java
@@ -28,19 +28,21 @@ import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.context.SpringBootTest.WebEnvironment;
 import org.springframework.context.annotation.Bean;
+import org.springframework.test.annotation.DirtiesContext;
 import org.springframework.test.context.junit4.SpringRunner;
 
 import com.introproventures.graphql.jpa.query.schema.impl.GraphQLJpaSchemaBuilder;
 
 import graphql.Scalars;
 import graphql.schema.GraphQLInputObjectType;
-import graphql.schema.GraphQLSchema;
 import graphql.schema.GraphQLObjectType;
+import graphql.schema.GraphQLSchema;
 
 @RunWith(SpringRunner.class)
 @SpringBootTest(
     webEnvironment=WebEnvironment.NONE
 )
+@DirtiesContext
 public class StarwarsSchemaBuildTest {
 
     @SpringBootApplication

--- a/graphql-jpa-query-schema/src/test/java/com/introproventures/graphql/jpa/query/schema/StarwarsSchemaBuildTest.java
+++ b/graphql-jpa-query-schema/src/test/java/com/introproventures/graphql/jpa/query/schema/StarwarsSchemaBuildTest.java
@@ -25,6 +25,8 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
+import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase.Replace;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.context.SpringBootTest.WebEnvironment;
 import org.springframework.context.annotation.Bean;
@@ -43,6 +45,7 @@ import graphql.schema.GraphQLSchema;
     webEnvironment=WebEnvironment.NONE
 )
 @DirtiesContext
+@AutoConfigureTestDatabase(replace = Replace.ANY)
 public class StarwarsSchemaBuildTest {
 
     @SpringBootApplication

--- a/graphql-jpa-query-schema/src/test/java/com/introproventures/graphql/jpa/query/schema/StarwarsSchemaBuildWithDistinctTest.java
+++ b/graphql-jpa-query-schema/src/test/java/com/introproventures/graphql/jpa/query/schema/StarwarsSchemaBuildWithDistinctTest.java
@@ -1,8 +1,12 @@
 package com.introproventures.graphql.jpa.query.schema;
 
-import com.introproventures.graphql.jpa.query.schema.impl.GraphQLJpaExecutor;
-import com.introproventures.graphql.jpa.query.schema.impl.GraphQLJpaSchemaBuilder;
-import graphql.schema.GraphQLSchema;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.LinkedHashMap;
+import java.util.List;
+
+import javax.persistence.EntityManager;
+
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -10,19 +14,19 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.context.annotation.Bean;
+import org.springframework.test.annotation.DirtiesContext;
 import org.springframework.test.context.junit4.SpringRunner;
 
-import javax.persistence.EntityManager;
+import com.introproventures.graphql.jpa.query.schema.impl.GraphQLJpaExecutor;
+import com.introproventures.graphql.jpa.query.schema.impl.GraphQLJpaSchemaBuilder;
 
-import java.util.LinkedHashMap;
-import java.util.List;
-
-import static org.assertj.core.api.Assertions.assertThat;
+import graphql.schema.GraphQLSchema;
 
 @RunWith(SpringRunner.class)
 @SpringBootTest(
         webEnvironment= SpringBootTest.WebEnvironment.NONE
 )
+@DirtiesContext
 public class StarwarsSchemaBuildWithDistinctTest {
     @SpringBootApplication
     static class TestConfiguration {

--- a/graphql-jpa-query-schema/src/test/java/com/introproventures/graphql/jpa/query/schema/StarwarsSchemaBuildWithDistinctTest.java
+++ b/graphql-jpa-query-schema/src/test/java/com/introproventures/graphql/jpa/query/schema/StarwarsSchemaBuildWithDistinctTest.java
@@ -12,6 +12,8 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
+import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase.Replace;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.context.annotation.Bean;
 import org.springframework.test.annotation.DirtiesContext;
@@ -27,6 +29,7 @@ import graphql.schema.GraphQLSchema;
         webEnvironment= SpringBootTest.WebEnvironment.NONE
 )
 @DirtiesContext
+@AutoConfigureTestDatabase(replace = Replace.ANY)
 public class StarwarsSchemaBuildWithDistinctTest {
     @SpringBootApplication
     static class TestConfiguration {

--- a/graphql-jpa-query-schema/src/test/java/com/introproventures/graphql/jpa/query/schema/StarwarsSchemaBuildWithDistinctTest.java
+++ b/graphql-jpa-query-schema/src/test/java/com/introproventures/graphql/jpa/query/schema/StarwarsSchemaBuildWithDistinctTest.java
@@ -9,28 +9,20 @@ import javax.persistence.EntityManager;
 
 import org.junit.Before;
 import org.junit.Test;
-import org.junit.runner.RunWith;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
-import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
-import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase.Replace;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.context.annotation.Bean;
-import org.springframework.test.annotation.DirtiesContext;
-import org.springframework.test.context.junit4.SpringRunner;
 
+import com.introproventures.graphql.jpa.query.AbstractSpringBootTestSupport;
 import com.introproventures.graphql.jpa.query.schema.impl.GraphQLJpaExecutor;
 import com.introproventures.graphql.jpa.query.schema.impl.GraphQLJpaSchemaBuilder;
 
 import graphql.schema.GraphQLSchema;
 
-@RunWith(SpringRunner.class)
-@SpringBootTest(
-        webEnvironment= SpringBootTest.WebEnvironment.NONE
-)
-@DirtiesContext
-@AutoConfigureTestDatabase(replace = Replace.ANY)
-public class StarwarsSchemaBuildWithDistinctTest {
+@SpringBootTest
+public class StarwarsSchemaBuildWithDistinctTest extends AbstractSpringBootTestSupport {
+    
     @SpringBootApplication
     static class TestConfiguration {
         @Bean

--- a/graphql-jpa-query-schema/src/test/resources/hibernate.properties
+++ b/graphql-jpa-query-schema/src/test/resources/hibernate.properties
@@ -1,7 +1,10 @@
-hibernate.generate_statistics=true
+hibernate.generate_statistics=false
 org.hibernate.stat=DEBUG
 spring.jpa.properties.hibernate.show_sql=false
 spring.jpa.properties.hibernate.format_sql=true
+
+# This should match TimeZone.setDefault(TimeZone.getTimeZone("UTC")); in JVM
+spring.jpa.properties.hibernate.jdbc.time_zone=UTC
 
 logging.level.org.hibernate=info
 #logging.level.org.hibernate.type.descriptor.sql=trace

--- a/pom.xml
+++ b/pom.xml
@@ -221,6 +221,7 @@
                     <systemPropertyVariables>
                         <slf4j.version>${slf4j.version}</slf4j.version>
                         <log4j.version>${log4j.version}</log4j.version>
+                        <user.timezone>UTC</user.timezone>
                     </systemPropertyVariables>
                 </configuration>
             </plugin>


### PR DESCRIPTION
This PR upgrades build configuration to use SB 2.1.11.RELEASE. 

The upgraded Hibernate version now needs to have JDBC timezone to match JVM timezone to support queries with Java `Date` type attributes. 

See for details: https://in.relation.to/2016/09/12/jdbc-time-zone-configuration-property/