### PR TITLE
fix: removed EntityManager.clear() from GraphQLJpaQueryDataFetcher

### DIFF
--- a/graphql-jpa-query-schema/src/main/java/com/introproventures/graphql/jpa/query/schema/impl/GraphQLJpaQueryDataFetcher.java
+++ b/graphql-jpa-query-schema/src/main/java/com/introproventures/graphql/jpa/query/schema/impl/GraphQLJpaQueryDataFetcher.java
@@ -108,10 +108,6 @@ class GraphQLJpaQueryDataFetcher extends QraphQLJpaBaseDataFetcher {
             
             queryField = new Field(fieldName, field.getArguments(), recordsSelection.get().getSelectionSet());
             
-            // Let's clear session persistent context to avoid getting stale objects cached in the same session 
-            // between requests with different search criteria. This looks like a Hibernate bug... 
-            entityManager.clear();
-            
             TypedQuery<?> query = getQuery(queryEnvironment, queryField, isDistinct);
             
             // Let's apply page only if present


### PR DESCRIPTION
This PR removes calling EntityManager.clear() inside GraphQLJpaQueryDataFetcher.get() that causes runtime NPE in Hibernate in order to fix https://github.com/introproventures/graphql-jpa-query/issues/191 

The `EntityManager.clear()` has been added in this commit: https://github.com/introproventures/graphql-jpa-query/pull/96/commits/83c5a84648c8a0a0f566874a6cea78bee2a521ed because of the mentioned problem: https://github.com/introproventures/graphql-jpa-query/pull/96#issuecomment-472544018

The provided test case cannot reproduce the issue anymore: 9e5002bc760e9420f1bcb64726129cea20ed6582

Calling clear method seems to be very invasive, since there are hints provided for Hibernate not to cache any results in memory: https://github.com/introproventures/graphql-jpa-query/blob/7ce947d72b9dc6ce0e64d35dadf0d4b21a3f5dd7/graphql-jpa-query-schema/src/main/java/com/introproventures/graphql/jpa/query/schema/impl/GraphQLJpaQueryDataFetcher.java#L133

Also, this problem could be still relevant in Hibernate versions before 5.3.10. The users may need to call `EntityManager.clear()` before execution of the query if needed.