### PR TITLE
fix(GH-198): adedd support for fetching optional element collections elements

### DIFF
--- a/graphql-jpa-query-example-merge/src/main/resources/books.sql
+++ b/graphql-jpa-query-example-merge/src/main/resources/books.sql
@@ -7,3 +7,16 @@ insert into book (id, title, author_id, genre) values (5, 'The Cherry Orchard', 
 insert into book (id, title, author_id, genre) values (6, 'The Seagull', 4, 'PLAY');
 insert into book (id, title, author_id, genre) values (7, 'Three Sisters', 4, 'PLAY');
 insert into author (id, name, genre) values (8, 'Igor Dianov', 'JAVA');
+
+insert into book_tags (book_id, tags) values (2, 'war'), (2, 'piece');
+insert into book_tags (book_id, tags) values (3, 'anna'), (3, 'karenina');
+insert into book_tags (book_id, tags) values (5, 'cherry'), (5, 'orchard');
+insert into book_tags (book_id, tags) values (6, 'seagull');
+insert into book_tags (book_id, tags) values (7, 'three'), (7, 'sisters');
+
+insert into author_phone_numbers(phone_number, author_id) values
+	('1-123-1234', 1),
+	('1-123-5678', 1),
+	('4-123-1234', 4),
+	('4-123-5678', 4);
+	

--- a/graphql-jpa-query-example-model-books/src/main/java/com/introproventures/graphql/jpa/query/schema/model/book/Book.java
+++ b/graphql-jpa-query-example-model-books/src/main/java/com/introproventures/graphql/jpa/query/schema/model/book/Book.java
@@ -17,18 +17,29 @@
 package com.introproventures.graphql.jpa.query.schema.model.book;
 
 import java.util.Date;
+import java.util.LinkedHashSet;
+import java.util.Set;
 
-import javax.persistence.*;
+import javax.persistence.ElementCollection;
+import javax.persistence.Entity;
+import javax.persistence.EnumType;
+import javax.persistence.Enumerated;
+import javax.persistence.FetchType;
+import javax.persistence.Id;
+import javax.persistence.ManyToOne;
+import javax.persistence.Transient;
 
+import com.introproventures.graphql.jpa.query.annotation.GraphQLDescription;
 import com.introproventures.graphql.jpa.query.annotation.GraphQLIgnore;
 import com.introproventures.graphql.jpa.query.annotation.GraphQLIgnoreFilter;
 import com.introproventures.graphql.jpa.query.annotation.GraphQLIgnoreOrder;
+
 import lombok.Data;
 import lombok.EqualsAndHashCode;
 
 @Data
 @Entity
-@EqualsAndHashCode(exclude="author")
+@EqualsAndHashCode(exclude= {"author", "tags"})
 public class Book {
 	@Id
 	Long id;
@@ -38,6 +49,10 @@ public class Book {
 	@GraphQLIgnoreOrder
 	@GraphQLIgnoreFilter
 	String description;
+	
+	@ElementCollection(fetch = FetchType.LAZY)
+	@GraphQLDescription("A set of user-defined tags")
+	private Set<String> tags = new LinkedHashSet<>();	
 
 	@ManyToOne(fetch=FetchType.LAZY, optional = false)
 	Author author;

--- a/graphql-jpa-query-schema/src/main/java/com/introproventures/graphql/jpa/query/schema/impl/QraphQLJpaBaseDataFetcher.java
+++ b/graphql-jpa-query-schema/src/main/java/com/introproventures/graphql/jpa/query/schema/impl/QraphQLJpaBaseDataFetcher.java
@@ -218,20 +218,20 @@ class QraphQLJpaBaseDataFetcher implements DataFetcher<Object> {
                         // Let's do fugly conversion 
                         // the many end is a collection, and it is always optional by default (empty collection)
                         isOptional = optionalArgument.map(it -> getArgumentValue(environment, it, Boolean.class))
-                                                             .orElse(toManyDefaultOptional);
+                                                     .orElse(toManyDefaultOptional);
 
-                        // Let's apply join to retrieve associated collection
-                        fetch = reuseFetch(from, selectedField.getName(), isOptional);
-
-                        // Let's fetch element collections to avoid filtering their values used where search criteria
                         GraphQLObjectType objectType = getObjectType(environment);
                         EntityType<?> entityType = getEntityType(objectType);
 
                         PluralAttribute<?, ?, ?> attribute = (PluralAttribute<?, ?, ?>) entityType.getAttribute(selectedField.getName());
                         
+                        // Let's join fetch element collections to avoid filtering their values used where search criteria
                         if(PersistentAttributeType.ELEMENT_COLLECTION == attribute.getPersistentAttributeType()) {
-                            from.fetch(selectedField.getName());
-                        }                    
+                            from.fetch(selectedField.getName(), JoinType.LEFT);
+                        } else {
+                            // Let's apply fetch join to retrieve associated plural attributes
+                            fetch = reuseFetch(from, selectedField.getName(), isOptional);
+                        }
                     }
                     // Let's build join fetch graph to avoid Hibernate error: 
                     // "query specified join fetching, but the owner of the fetched association was not present in the select list"

--- a/graphql-jpa-query-schema/src/test/java/com/introproventures/graphql/jpa/query/schema/GraphQLExecutorTests.java
+++ b/graphql-jpa-query-schema/src/test/java/com/introproventures/graphql/jpa/query/schema/GraphQLExecutorTests.java
@@ -1616,7 +1616,7 @@ public class GraphQLExecutorTests {
     @Test
     public void queryOptionalElementCollections() {
         //given
-        String query = "{ Author(id: 8) { id name phoneNumbers books { id title } } }";
+        String query = "{ Author(id: 8) { id name phoneNumbers books { id title tags } } }";
         
         String expected = "{Author={id=8, name=Igor Dianov, phoneNumbers=[], books=[]}}";
 

--- a/graphql-jpa-query-schema/src/test/java/com/introproventures/graphql/jpa/query/schema/GraphQLExecutorTests.java
+++ b/graphql-jpa-query-schema/src/test/java/com/introproventures/graphql/jpa/query/schema/GraphQLExecutorTests.java
@@ -1611,4 +1611,41 @@ public class GraphQLExecutorTests {
                               "War and Peace")
                 );
     }
+    
+    // https://github.com/introproventures/graphql-jpa-query/issues/198
+    @Test
+    public void queryOptionalElementCollections() {
+        //given
+        String query = "{ Author(id: 8) { id name, phoneNumbers } }";
+        
+        String expected = "{Author={id=8, name=Igor Dianov, phoneNumbers=[]}}";
+
+        //when
+        Object result = executor.execute(query).getData();
+
+        // then
+        assertThat(result.toString()).isEqualTo(expected);
+    }    
+    
+    @Test
+    public void queryElementCollectionsWithWhereCriteriaExpression() {
+        //given:
+        String query = "query {" + 
+                "  Books(where: {tags: {EQ: \"war\"}}) {" + 
+                "    select {" + 
+                "      id" + 
+                "      title" + 
+                "      tags" + 
+                "    }" + 
+                "  }" + 
+                "}";
+
+        String expected = "{Books={select=[{id=2, title=War and Peace, tags=[piece, war]}]}}";
+
+        //when:
+        Object result = executor.execute(query).getData();
+
+        //then:
+        assertThat(result.toString()).isEqualTo(expected);
+    } 
 }

--- a/graphql-jpa-query-schema/src/test/java/com/introproventures/graphql/jpa/query/schema/GraphQLExecutorTests.java
+++ b/graphql-jpa-query-schema/src/test/java/com/introproventures/graphql/jpa/query/schema/GraphQLExecutorTests.java
@@ -1616,9 +1616,9 @@ public class GraphQLExecutorTests {
     @Test
     public void queryOptionalElementCollections() {
         //given
-        String query = "{ Author(id: 8) { id name, phoneNumbers } }";
+        String query = "{ Author(id: 8) { id name phoneNumbers books { id title } } }";
         
-        String expected = "{Author={id=8, name=Igor Dianov, phoneNumbers=[]}}";
+        String expected = "{Author={id=8, name=Igor Dianov, phoneNumbers=[], books=[]}}";
 
         //when
         Object result = executor.execute(query).getData();

--- a/graphql-jpa-query-schema/src/test/resources/data.sql
+++ b/graphql-jpa-query-schema/src/test/resources/data.sql
@@ -126,6 +126,12 @@ insert into book (id, title, author_id, genre, publication_date, description)
 values (7, 'Three Sisters', 4, 'PLAY', '1900-01-01', 'The play is sometimes included on the short list of Chekhov''s outstanding plays, along with The Cherry Orchard, The Seagull and Uncle Vanya.[1]');
 insert into author (id, name, genre) values (8, 'Igor Dianov', 'JAVA');
 
+insert into book_tags (book_id, tags) values (2, 'war'), (2, 'piece');
+insert into book_tags (book_id, tags) values (3, 'anna'), (3, 'karenina');
+insert into book_tags (book_id, tags) values (5, 'cherry'), (5, 'orchard');
+insert into book_tags (book_id, tags) values (6, 'seagull');
+insert into book_tags (book_id, tags) values (7, 'three'), (7, 'sisters');
+
 insert into author_phone_numbers(phone_number, author_id) values
 	('1-123-1234', 1),
 	('1-123-5678', 1),


### PR DESCRIPTION
This PR fixes fetching plural attributes annotated with `@ElementCollection` to use left outer join that makes collection elements optional should associated collection elements data set be empty, i.e. given

```java
public class Author {
	@Id
	Long id;

	String name;

	@OneToMany(mappedBy="author", fetch=FetchType.LAZY)
	@OrderBy("id ASC")
	Set<Book> books;
	
	@ElementCollection(fetch=FetchType.LAZY) 
	@CollectionTable(name = "author_phone_numbers", joinColumns = @JoinColumn(name = "author_id")) 
	@Column(name = "phone_number")
	private Set<String> phoneNumbers = new HashSet<>();	
	
	@Enumerated(EnumType.STRING)
	Genre genre;	
}

``` 
When executing the following query with author containing empty `phoneNumbers` selection:

```
query {
  Author(id: 8) {
    id
    name
    phoneNumbers
    books {
      id
      title
      tags
    }
  }
}
```
The expected result should return the following Json: 

```json
{
  "data": {
    "Author": {
      "id": 8,
      "name": "Igor Dianov",
      "phoneNumbers": [],
      "books": []
    },
  }
}
```

It is also possible to use where criteria expressions to fetch the selection that satisfies search criteria with values in the element collection, i.e. given query,

```
query {
  Books(where: {tags: {EQ: "war"}}) {
    select {
      id
      title
      tags
    }
  }
}
```
The expected result should be

```json
{
  "data": {
    "Books": {
      "select": [
        {
          "id": 2,
          "title": "War and Peace",
          "tags": [
            "piece",
            "war"
          ]
        }
      ]
    }
  }
}
```


Also fixes https://github.com/introproventures/graphql-jpa-query/issues/198