### PR TITLE
fix(GH-193): Fixed error in GQL Queries when `total` or `pages` is included with condition `where: NOT_EXISTS` or `EXISTS`

### DIFF
--- a/graphql-jpa-query-schema/src/main/java/com/introproventures/graphql/jpa/query/schema/impl/GraphQLJpaQueryDataFetcher.java
+++ b/graphql-jpa-query-schema/src/main/java/com/introproventures/graphql/jpa/query/schema/impl/GraphQLJpaQueryDataFetcher.java
@@ -182,10 +182,14 @@ class GraphQLJpaQueryDataFetcher extends QraphQLJpaBaseDataFetcher {
         CriteriaQuery<Long> query = cb.createQuery(Long.class);
         Root<?> root = query.from(entityType);
 
+        DataFetchingEnvironment queryEnvironment = DataFetchingEnvironmentBuilder.newDataFetchingEnvironment(environment)
+                                                                                 .root(query)
+                                                                                 .build();
+        
         query.select(cb.count(root));
         
         List<Predicate> predicates = field.getArguments().stream()
-            .map(it -> getPredicate(cb, root, null, environment, it))
+            .map(it -> getPredicate(cb, root, null, queryEnvironment, it))
             .filter(it -> it != null)
             .collect(Collectors.toList());
         

--- a/graphql-jpa-query-schema/src/test/java/com/introproventures/graphql/jpa/query/schema/GraphQLExecutorTests.java
+++ b/graphql-jpa-query-schema/src/test/java/com/introproventures/graphql/jpa/query/schema/GraphQLExecutorTests.java
@@ -862,7 +862,7 @@ public class GraphQLExecutorTests {
                 "  }"+
                 "}";
 
-        String expected = "{Authors={select=[]}}";
+        String expected = "{Authors={total=0, pages=0, select=[]}}";
 
         //when
         Object result = executor.execute(query).getData();
@@ -897,7 +897,7 @@ public class GraphQLExecutorTests {
                 "  }"+
                 "}";
 
-        String expected = "{Authors={select=["
+        String expected = "{Authors={total=3, pages=1, select=["
                 + "{id=4, name=Anton Chekhov, books=["
                 +   "{id=5, title=The Cherry Orchard}, "
                 +   "{id=6, title=The Seagull}, "

--- a/graphql-jpa-query-schema/src/test/java/com/introproventures/graphql/jpa/query/schema/GraphQLExecutorTests.java
+++ b/graphql-jpa-query-schema/src/test/java/com/introproventures/graphql/jpa/query/schema/GraphQLExecutorTests.java
@@ -627,7 +627,7 @@ public class GraphQLExecutorTests {
                 "        title: {LIKE: \"War\"}" + 
                 "      }" + 
                 "    }" + 
-                "  }) {" + 
+                "  }) {" +
                 "    select {" + 
                 "      id" + 
                 "      name" + 
@@ -835,8 +835,82 @@ public class GraphQLExecutorTests {
 
         // then
         assertThat(result.toString()).isEqualTo(expected);
-    }     
-    
+    }
+
+    @Test
+    public void queryTotalForAuthorsWithWhereEXISTSBooksLIKETitleEmpty() {
+        //given
+        String query = "query { "
+                + "Authors(where: {" +
+                "    EXISTS: {" +
+                "      books: {" +
+                "        author: {name: {LIKE: \"Anton\"}}" +
+                "        title: {LIKE: \"War\"}" +
+                "      }" +
+                "    }" +
+                "  }) {" +
+                "    total" +
+                "    pages" +
+                "    select {" +
+                "      id" +
+                "      name" +
+                "      books {" +
+                "        id" +
+                "        title" +
+                "      }" +
+                "    }" +
+                "  }"+
+                "}";
+
+        String expected = "{Authors={select=[]}}";
+
+        //when
+        Object result = executor.execute(query).getData();
+
+        // then
+        assertThat(result.toString()).isEqualTo(expected);
+    }
+
+    @Test
+    public void queryTotalForAuthorsWithWhereBooksNOTEXISTSAuthorLIKENameLeo() {
+        //given
+        String query = "query { "
+                + "  Authors(where: {" +
+                "    books: {" +
+                "      NOT_EXISTS: {" +
+                "        author: {" +
+                "          name: {LIKE: \"Leo\"}" +
+                "        }" +
+                "      }" +
+                "    }" +
+                "  }) {" +
+                "    total" +
+                "    pages" +
+                "    select {" +
+                "      id" +
+                "      name" +
+                "      books {" +
+                "        id" +
+                "        title" +
+                "      }" +
+                "    }" +
+                "  }"+
+                "}";
+
+        String expected = "{Authors={select=["
+                + "{id=4, name=Anton Chekhov, books=["
+                +   "{id=5, title=The Cherry Orchard}, "
+                +   "{id=6, title=The Seagull}, "
+                +   "{id=7, title=Three Sisters}]}"
+                + "]}}";
+
+        //when
+        Object result = executor.execute(query).getData();
+
+        // then
+        assertThat(result.toString()).isEqualTo(expected);
+    }
+
     @Test
     public void queryForAuthorssWithWhereBooksGenreEquals() {
         //given


### PR DESCRIPTION
Fixes https://github.com/introproventures/graphql-jpa-query/issues/193