### PR TITLE
Upgrade graphql-java version to 13.0 

### DIFF
--- a/graphql-jpa-query-autoconfigure/pom.xml
+++ b/graphql-jpa-query-autoconfigure/pom.xml
@@ -14,17 +14,14 @@
       <artifactId>graphql-java</artifactId>
       <optional>true</optional>
     </dependency>
-    
     <dependency>
       <groupId>org.springframework.boot</groupId>
       <artifactId>spring-boot-autoconfigure</artifactId>
     </dependency>
-    
     <dependency>
       <groupId>javax.validation</groupId>
       <artifactId>validation-api</artifactId>    
     </dependency>
-      
     <dependency>
       <groupId>org.hibernate.validator</groupId>
       <artifactId>hibernate-validator</artifactId>
@@ -34,6 +31,18 @@
       <groupId>org.springframework.boot</groupId>
       <artifactId>spring-boot-configuration-processor</artifactId>
       <optional>true</optional>
+    </dependency>
+    <dependency>
+      <groupId>io.github.graphql-java</groupId>
+      <artifactId>graphql-java-annotations</artifactId>
+      <version>7.2.1</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.reflections</groupId>
+      <artifactId>reflections</artifactId>
+      <version>0.9.11</version>
+      <scope>test</scope>
     </dependency>
   </dependencies>
   

--- a/graphql-jpa-query-autoconfigure/src/main/java/com/introproventures/graphql/jpa/query/autoconfigure/GraphQLSchemaFactoryBean.java
+++ b/graphql-jpa-query-autoconfigure/src/main/java/com/introproventures/graphql/jpa/query/autoconfigure/GraphQLSchemaFactoryBean.java
@@ -32,8 +32,8 @@ import graphql.util.TraversalControl;
 import graphql.util.TraverserContext;
 
 public class GraphQLSchemaFactoryBean extends AbstractFactoryBean<GraphQLSchema>{
-	
-	private static final String QUERY_NAME = "Query";
+    
+    private static final String QUERY_NAME = "Query";
     private static final String QUERY_DESCRIPTION = "";
     private static final String SUBSCRIPTION_NAME = "Subscription";
     private static final String SUBSCRIPTION_DESCRIPTION = "";
@@ -42,9 +42,9 @@ public class GraphQLSchemaFactoryBean extends AbstractFactoryBean<GraphQLSchema>
 
     
     private final GraphQLSchema[] managedGraphQLSchemas;
-	
-	private String queryName = QUERY_NAME;
-	private String queryDescription = QUERY_DESCRIPTION;
+    
+    private String queryName = QUERY_NAME;
+    private String queryDescription = QUERY_DESCRIPTION;
 
     private String subscriptionName = SUBSCRIPTION_NAME;
     private String subscriptionDescription = SUBSCRIPTION_DESCRIPTION;
@@ -52,19 +52,19 @@ public class GraphQLSchemaFactoryBean extends AbstractFactoryBean<GraphQLSchema>
     private String mutationName = MUTATION_NAME;
     private String mutationDescription = MUTATION_DESCRIPTION;
     
-	
-	public GraphQLSchemaFactoryBean(GraphQLSchema[] managedGraphQLSchemas) {
-		this.managedGraphQLSchemas = managedGraphQLSchemas;
-	}
+    
+    public GraphQLSchemaFactoryBean(GraphQLSchema[] managedGraphQLSchemas) {
+        this.managedGraphQLSchemas = managedGraphQLSchemas;
+    }
 
-	@Override
-	protected GraphQLSchema createInstance() throws Exception {
-		
-		GraphQLSchema.Builder schemaBuilder = GraphQLSchema.newSchema();
+    @Override
+    protected GraphQLSchema createInstance() throws Exception {
+        
+        GraphQLSchema.Builder schemaBuilder = GraphQLSchema.newSchema();
         GraphQLCodeRegistry.Builder codeRegistryBuilder = GraphQLCodeRegistry.newCodeRegistry();
         TypeTraverser typeTraverser = new TypeTraverser();
-		
-		List<GraphQLFieldDefinition> mutations = Stream.of(managedGraphQLSchemas)
+        
+        List<GraphQLFieldDefinition> mutations = Stream.of(managedGraphQLSchemas)
             .filter(it -> it.getMutationType() != null)
             .peek(schema -> {
                 schema.getCodeRegistry().transform(builderConsumer -> {
@@ -74,13 +74,13 @@ public class GraphQLSchemaFactoryBean extends AbstractFactoryBean<GraphQLSchema>
                                              schema.getMutationType());
                 });
             })
-	        .map(GraphQLSchema::getMutationType)
-			.filter(Objects::nonNull)
-			.map(GraphQLObjectType::getFieldDefinitions)
-			.flatMap(Collection::stream)
-			.collect(Collectors.toList());
-		
-		List<GraphQLFieldDefinition> queries = Stream.of(managedGraphQLSchemas)
+            .map(GraphQLSchema::getMutationType)
+            .filter(Objects::nonNull)
+            .map(GraphQLObjectType::getFieldDefinitions)
+            .flatMap(Collection::stream)
+            .collect(Collectors.toList());
+        
+        List<GraphQLFieldDefinition> queries = Stream.of(managedGraphQLSchemas)
             .filter(it -> Optional.ofNullable(it.getQueryType())
                                   .map(GraphQLType::getName)
                                   .isPresent())
@@ -92,65 +92,65 @@ public class GraphQLSchemaFactoryBean extends AbstractFactoryBean<GraphQLSchema>
                                               schema.getQueryType());
                  });
             })
-			.map(GraphQLSchema::getQueryType)
-			.filter(it -> !it.getName().equals("null")) // filter out null placeholders
-			.map(GraphQLObjectType::getFieldDefinitions)
-			.flatMap(Collection::stream)
-			.collect(Collectors.toList());
+            .map(GraphQLSchema::getQueryType)
+            .filter(it -> !it.getName().equals("null")) // filter out null placeholders
+            .map(GraphQLObjectType::getFieldDefinitions)
+            .flatMap(Collection::stream)
+            .collect(Collectors.toList());
 
-		List<GraphQLFieldDefinition> subscriptions = Stream.of(managedGraphQLSchemas)
+        List<GraphQLFieldDefinition> subscriptions = Stream.of(managedGraphQLSchemas)
             .filter(it -> it.getSubscriptionType() != null)
-		    .peek(schema -> {
+            .peek(schema -> {
                 schema.getCodeRegistry().transform(builderConsumer -> {
                     typeTraverser.depthFirst(new CodeRegistryVisitor(builderConsumer,
                                                                      codeRegistryBuilder,
                                                                      subscriptionName),
                                              schema.getSubscriptionType());
                 });
-		    })
-			.map(GraphQLSchema::getSubscriptionType)
-			.map(GraphQLObjectType::getFieldDefinitions)
-			.flatMap(Collection::stream)
-			.collect(Collectors.toList());
+            })
+            .map(GraphQLSchema::getSubscriptionType)
+            .map(GraphQLObjectType::getFieldDefinitions)
+            .flatMap(Collection::stream)
+            .collect(Collectors.toList());
 
-		if(!mutations.isEmpty())
-			schemaBuilder.mutation(GraphQLObjectType.newObject()
+        if(!mutations.isEmpty())
+            schemaBuilder.mutation(GraphQLObjectType.newObject()
                                                     .name(this.mutationName)
                                                     .description(this.mutationDescription)
-                                			        .fields(mutations));
+                                                    .fields(mutations));
 
-		if(!queries.isEmpty())
-			schemaBuilder.query(GraphQLObjectType.newObject()
-					                             .name(this.queryName)
-					                             .description(this.queryDescription)
-					                             .fields(queries));
+        if(!queries.isEmpty())
+            schemaBuilder.query(GraphQLObjectType.newObject()
+                                                 .name(this.queryName)
+                                                 .description(this.queryDescription)
+                                                 .fields(queries));
 
-		if(!subscriptions.isEmpty())
-			schemaBuilder.subscription(GraphQLObjectType.newObject()
+        if(!subscriptions.isEmpty())
+            schemaBuilder.subscription(GraphQLObjectType.newObject()
                                                         .name(this.subscriptionName)
                                                         .description(this.subscriptionDescription)
-                                    			        .fields(subscriptions));
-		
+                                                        .fields(subscriptions));
+        
         return schemaBuilder.codeRegistry(codeRegistryBuilder.build())
                             .build();
-	}
+    }
 
-	@Override
-	public Class<?> getObjectType() {
-		return GraphQLSchema.class;
-	}
+    @Override
+    public Class<?> getObjectType() {
+        return GraphQLSchema.class;
+    }
 
-	public GraphQLSchemaFactoryBean setQueryName(String name) {
-		this.queryName = name;
-		
-		return this;
-	}
+    public GraphQLSchemaFactoryBean setQueryName(String name) {
+        this.queryName = name;
+        
+        return this;
+    }
 
-	public GraphQLSchemaFactoryBean setQueryDescription(String description) {
-		this.queryDescription = description;
-		
-		return this;
-	}
+    public GraphQLSchemaFactoryBean setQueryDescription(String description) {
+        this.queryDescription = description;
+        
+        return this;
+    }
 
     public GraphQLSchemaFactoryBean setSubscriptionName(String subscriptionName) {
         this.subscriptionName = subscriptionName;

--- a/graphql-jpa-query-autoconfigure/src/main/java/com/introproventures/graphql/jpa/query/autoconfigure/GraphQLSchemaFactoryBean.java
+++ b/graphql-jpa-query-autoconfigure/src/main/java/com/introproventures/graphql/jpa/query/autoconfigure/GraphQLSchemaFactoryBean.java
@@ -1,15 +1,35 @@
 package com.introproventures.graphql.jpa.query.autoconfigure;
 
+import static graphql.Assert.assertTrue;
+import static graphql.schema.FieldCoordinates.coordinates;
+import static graphql.util.TraversalControl.CONTINUE;
+
+import java.util.Collection;
 import java.util.List;
 import java.util.Objects;
+import java.util.Optional;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 import org.springframework.beans.factory.config.AbstractFactoryBean;
 
+import graphql.Internal;
+import graphql.schema.DataFetcher;
+import graphql.schema.FieldCoordinates;
+import graphql.schema.GraphQLCodeRegistry;
 import graphql.schema.GraphQLFieldDefinition;
+import graphql.schema.GraphQLFieldsContainer;
+import graphql.schema.GraphQLInterfaceType;
 import graphql.schema.GraphQLObjectType;
 import graphql.schema.GraphQLSchema;
+import graphql.schema.GraphQLType;
+import graphql.schema.GraphQLTypeVisitorStub;
+import graphql.schema.GraphQLUnionType;
+import graphql.schema.PropertyDataFetcher;
+import graphql.schema.TypeResolver;
+import graphql.schema.TypeTraverser;
+import graphql.util.TraversalControl;
+import graphql.util.TraverserContext;
 
 public class GraphQLSchemaFactoryBean extends AbstractFactoryBean<GraphQLSchema>{
 	
@@ -41,27 +61,56 @@ public class GraphQLSchemaFactoryBean extends AbstractFactoryBean<GraphQLSchema>
 	protected GraphQLSchema createInstance() throws Exception {
 		
 		GraphQLSchema.Builder schemaBuilder = GraphQLSchema.newSchema();
+        GraphQLCodeRegistry.Builder codeRegistryBuilder = GraphQLCodeRegistry.newCodeRegistry();
+        TypeTraverser typeTraverser = new TypeTraverser();
 		
 		List<GraphQLFieldDefinition> mutations = Stream.of(managedGraphQLSchemas)
-			.map(GraphQLSchema::getMutationType)
+            .filter(it -> it.getMutationType() != null)
+            .peek(schema -> {
+                schema.getCodeRegistry().transform(builderConsumer -> {
+                    typeTraverser.depthFirst(new CodeRegistryVisitor(builderConsumer, 
+                                                                     codeRegistryBuilder, 
+                                                                     mutationName), 
+                                             schema.getMutationType());
+                });
+            })
+	        .map(GraphQLSchema::getMutationType)
 			.filter(Objects::nonNull)
 			.map(GraphQLObjectType::getFieldDefinitions)
-			.flatMap(children -> children.stream())
-			.collect(Collectors.toList());
-
-		List<GraphQLFieldDefinition> queries = Stream.of(managedGraphQLSchemas)
-			.map(GraphQLSchema::getQueryType)
-			.filter(Objects::nonNull)
-			.filter(it -> !it.getName().equals("null")) // filter out null placeholders
-			.map(GraphQLObjectType::getFieldDefinitions)
-			.flatMap(children -> children.stream())
+			.flatMap(Collection::stream)
 			.collect(Collectors.toList());
 		
-		List<GraphQLFieldDefinition> subscriptions = Stream.of(managedGraphQLSchemas)
-			.map(GraphQLSchema::getSubscriptionType)
-			.filter(Objects::nonNull)
+		List<GraphQLFieldDefinition> queries = Stream.of(managedGraphQLSchemas)
+            .filter(it -> Optional.ofNullable(it.getQueryType())
+                                  .map(GraphQLType::getName)
+                                  .isPresent())
+            .peek(schema -> {
+                schema.getCodeRegistry().transform(builderConsumer -> {
+                     typeTraverser.depthFirst(new CodeRegistryVisitor(builderConsumer,
+                                                                      codeRegistryBuilder,
+                                                                      queryName),
+                                              schema.getQueryType());
+                 });
+            })
+			.map(GraphQLSchema::getQueryType)
+			.filter(it -> !it.getName().equals("null")) // filter out null placeholders
 			.map(GraphQLObjectType::getFieldDefinitions)
-			.flatMap(children -> children.stream())
+			.flatMap(Collection::stream)
+			.collect(Collectors.toList());
+
+		List<GraphQLFieldDefinition> subscriptions = Stream.of(managedGraphQLSchemas)
+            .filter(it -> it.getSubscriptionType() != null)
+		    .peek(schema -> {
+                schema.getCodeRegistry().transform(builderConsumer -> {
+                    typeTraverser.depthFirst(new CodeRegistryVisitor(builderConsumer,
+                                                                     codeRegistryBuilder,
+                                                                     subscriptionName),
+                                             schema.getSubscriptionType());
+                });
+		    })
+			.map(GraphQLSchema::getSubscriptionType)
+			.map(GraphQLObjectType::getFieldDefinitions)
+			.flatMap(Collection::stream)
 			.collect(Collectors.toList());
 
 		if(!mutations.isEmpty())
@@ -82,7 +131,8 @@ public class GraphQLSchemaFactoryBean extends AbstractFactoryBean<GraphQLSchema>
                                                         .description(this.subscriptionDescription)
                                     			        .fields(subscriptions));
 		
-		return schemaBuilder.build();
+        return schemaBuilder.codeRegistry(codeRegistryBuilder.build())
+                            .build();
 	}
 
 	@Override
@@ -125,5 +175,57 @@ public class GraphQLSchemaFactoryBean extends AbstractFactoryBean<GraphQLSchema>
 
         return this;
     }
+    
+    /**
+     * This ensure that all fields have data fetchers and that unions and interfaces have type resolvers
+     */
+    @Internal
+    class CodeRegistryVisitor extends GraphQLTypeVisitorStub {
+        private final GraphQLCodeRegistry.Builder source;
+        private final GraphQLCodeRegistry.Builder codeRegistry;
+        private final String root;
 
+        CodeRegistryVisitor(GraphQLCodeRegistry.Builder source,
+                            GraphQLCodeRegistry.Builder codeRegistry, 
+                            String root) {
+            this.source = source;
+            this.codeRegistry = codeRegistry;
+            this.root = root;
+        }
+
+        @Override
+        public TraversalControl visitGraphQLFieldDefinition(GraphQLFieldDefinition node, TraverserContext<GraphQLType> context) {
+            GraphQLFieldsContainer parentContainerType = (GraphQLFieldsContainer) context.getParentContext().thisNode();
+            DataFetcher<?> dataFetcher = source.getDataFetcher(parentContainerType, node);
+            if (dataFetcher == null) {
+                dataFetcher = new PropertyDataFetcher<>(node.getName());
+            }
+            FieldCoordinates coordinates = coordinates(root, node.getName());
+            codeRegistry.dataFetcherIfAbsent(coordinates, dataFetcher);
+            return CONTINUE;
+        }
+
+        @Override
+        public TraversalControl visitGraphQLInterfaceType(GraphQLInterfaceType node, TraverserContext<GraphQLType> context) {
+            TypeResolver typeResolver = codeRegistry.getTypeResolver(node);
+
+            if (typeResolver != null) {
+                codeRegistry.typeResolverIfAbsent(node, typeResolver);
+            }
+            assertTrue(codeRegistry.getTypeResolver(node) != null, "You MUST provide a type resolver for the interface type '" + node.getName() + "'");
+            return CONTINUE;
+        }
+
+        @Override
+        public TraversalControl visitGraphQLUnionType(GraphQLUnionType node, TraverserContext<GraphQLType> context) {
+            TypeResolver typeResolver = codeRegistry.getTypeResolver(node);
+            if (typeResolver != null) {
+                codeRegistry.typeResolverIfAbsent(node, typeResolver);
+            }
+            assertTrue(codeRegistry.getTypeResolver(node) != null, "You MUST provide a type resolver for the union type '" + node.getName() + "'");
+            return CONTINUE;
+        }
+    }
+    
+    
 }

--- a/graphql-jpa-query-autoconfigure/src/test/java/com/introproventures/graphql/jpa/query/autoconfigure/GraphQLSchemaAutoConfigurationTest.java
+++ b/graphql-jpa-query-autoconfigure/src/test/java/com/introproventures/graphql/jpa/query/autoconfigure/GraphQLSchemaAutoConfigurationTest.java
@@ -6,9 +6,13 @@ import java.util.Map;
 
 import graphql.GraphQL;
 import graphql.Scalars;
+import graphql.schema.DataFetcher;
+import graphql.schema.FieldCoordinates;
+import graphql.schema.GraphQLCodeRegistry;
 import graphql.schema.GraphQLFieldDefinition;
 import graphql.schema.GraphQLObjectType;
 import graphql.schema.GraphQLSchema;
+
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -36,6 +40,7 @@ public class GraphQLSchemaAutoConfigurationTest {
 
             @Override
             public void configure(GraphQLShemaRegistration registry) {
+
                 GraphQLObjectType mutation = GraphQLObjectType.newObject()
                         .name("mutation")
                         .field(GraphQLFieldDefinition.newFieldDefinition()
@@ -44,12 +49,17 @@ public class GraphQLSchemaAutoConfigurationTest {
                                 .dataFetcher(environment -> {
                                     return "hello world";
                                 }))
-                        .build(); 
-                
+                        .build();
+
+                GraphQLCodeRegistry codeRegistry = GraphQLCodeRegistry.newCodeRegistry()
+                    .dataFetcher(FieldCoordinates.coordinates("mutation", "greet"), (DataFetcher<String>) environment -> "hello world")
+                    .build();
+
                 GraphQLSchema graphQLSchema = GraphQLSchema.newSchema()
                         .query(GraphQLObjectType.newObject().name("null"))
                         .mutation(mutation)
-                        .build();                
+                        .codeRegistry(codeRegistry)
+                    .build();
                 
                 registry.register(graphQLSchema);
             }
@@ -67,10 +77,16 @@ public class GraphQLSchemaAutoConfigurationTest {
                                 .dataFetcher(environment -> {
                                     return "world";
                                 }))
-                        .build(); 
-                
-                GraphQLSchema graphQLSchema = GraphQLSchema.newSchema()
+                        .build();
+
+              GraphQLCodeRegistry codeRegistry = GraphQLCodeRegistry.newCodeRegistry()
+                  .dataFetcher(FieldCoordinates.coordinates("query", "hello"), (DataFetcher<String>) environment -> "world")
+                  .build();
+
+
+              GraphQLSchema graphQLSchema = GraphQLSchema.newSchema()
                         .query(query)
+                        .codeRegistry(codeRegistry)
                         .build();                
                 
                 registry.register(graphQLSchema);

--- a/graphql-jpa-query-autoconfigure/src/test/java/com/introproventures/graphql/jpa/query/autoconfigure/GraphQLSchemaAutoConfigurationTest.java
+++ b/graphql-jpa-query-autoconfigure/src/test/java/com/introproventures/graphql/jpa/query/autoconfigure/GraphQLSchemaAutoConfigurationTest.java
@@ -1,22 +1,39 @@
 package com.introproventures.graphql.jpa.query.autoconfigure;
 
+import static graphql.annotations.AnnotationsSchemaCreator.newAnnotationsSchema;
 import static graphql.schema.GraphQLFieldDefinition.newFieldDefinition;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import java.util.Collections;
 import java.util.Map;
+import java.util.Set;
+import java.util.stream.Collectors;
 
 import org.junit.Test;
 import org.junit.runner.RunWith;
+import org.reflections.Reflections;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.context.SpringBootTest.WebEnvironment;
+import org.springframework.context.annotation.Configuration;
 import org.springframework.stereotype.Component;
 import org.springframework.test.context.junit4.SpringRunner;
+import org.springframework.util.StringUtils;
+
+import com.introproventures.graphql.jpa.query.autoconfigure.support.AdditionalGraphQLType;
+import com.introproventures.graphql.jpa.query.autoconfigure.support.MutationRoot;
+import com.introproventures.graphql.jpa.query.autoconfigure.support.QueryRoot;
+import com.introproventures.graphql.jpa.query.autoconfigure.support.SubscriptionRoot;
 
 import graphql.GraphQL;
 import graphql.Scalars;
+import graphql.annotations.AnnotationsSchemaCreator;
+import graphql.annotations.annotationTypes.GraphQLField;
+import graphql.annotations.annotationTypes.GraphQLInvokeDetached;
+import graphql.annotations.annotationTypes.GraphQLName;
+import graphql.annotations.annotationTypes.directives.definition.GraphQLDirectiveDefinition;
 import graphql.schema.FieldCoordinates;
 import graphql.schema.GraphQLCodeRegistry;
 import graphql.schema.GraphQLFieldDefinition;
@@ -36,7 +53,87 @@ public class GraphQLSchemaAutoConfigurationTest {
     
     @SpringBootApplication
     static class Application {
+        
+        @Configuration
+        static class GraphQLAnnotationsSchemaConfigurer implements GraphQLSchemaConfigurer {
+            @Autowired(required = false)
+            private QueryRoot queryRoot = new NullQuery();
 
+            @Autowired(required = false)
+            private MutationRoot mutationRoot;
+
+            @Autowired(required = false)
+            private SubscriptionRoot subscriptionRoot;
+
+            @Autowired(required = false)
+            private Set<AdditionalGraphQLType> additionalGraphQLTypes;
+
+            @Value("${directives.package:}")
+            private String directivesPackage;
+
+            @Override
+            public void configure(GraphQLShemaRegistration registry) {
+                AnnotationsSchemaCreator.Builder builder = newAnnotationsSchema();
+                builder.query(queryRoot.getClass());
+                if (mutationRoot != null) {
+                    builder.mutation(mutationRoot.getClass());
+                }
+                if (subscriptionRoot != null) {
+                    builder.subscription(subscriptionRoot.getClass());
+                }
+
+                if(!StringUtils.isEmpty(directivesPackage)) {
+                    Reflections reflections = new Reflections(directivesPackage);
+    
+                    Set<Class<?>> directiveDeclarations = reflections.getTypesAnnotatedWith(GraphQLDirectiveDefinition.class);
+    
+                    builder.directives(directiveDeclarations);
+                }
+
+                if (additionalGraphQLTypes!=null) {
+                    builder.additionalTypes(additionalGraphQLTypes.stream()
+                                                                  .map(AdditionalGraphQLType::getClass)
+                                                                  .collect(Collectors.toSet()));
+                }
+
+                registry.register(builder.build());
+            }
+            
+            @GraphQLName("null")
+            class NullQuery implements QueryRoot {
+                
+            }
+        }
+        
+        @Component
+        public static class AnnotatedMutation implements MutationRoot {
+            
+             @GraphQLField
+             @GraphQLInvokeDetached
+             public String salut(@GraphQLName("name") String name) {
+                 return "Salut, " + name + "!";
+             }
+        }
+        
+        @Component
+        public static class AnnotatedQuery implements QueryRoot {
+             @GraphQLField
+             @GraphQLInvokeDetached
+             public Greeting greeting(@GraphQLName("name") String name) {
+                 return new Greeting("Hi, " + name + "!");
+             }
+             
+            public static class Greeting {
+
+                @GraphQLField
+                public String value;
+
+                public Greeting(String value) {
+                    this.value = value;
+                }
+            }
+        }
+        
         @Component
         static class MutationGraphQLSchemaConfigurer implements GraphQLSchemaConfigurer {
 
@@ -81,7 +178,7 @@ public class GraphQLSchemaAutoConfigurationTest {
                                                                                       .dataFetcher(new StaticDataFetcher("world")))
                                                            .field(newFieldDefinition().name("hello2")
                                                                                       .type(Scalars.GraphQLString))
-                                                           .field(newFieldDefinition().name("greetings")
+                                                           .field(newFieldDefinition().name("hello3")
                                                                                       .type(GraphQLObjectType.newObject()
                                                                                                              .name("Hello3")
                                                                                                              .field(newFieldDefinition().name("canada")
@@ -93,7 +190,7 @@ public class GraphQLSchemaAutoConfigurationTest {
                 GraphQLCodeRegistry codeRegistry = GraphQLCodeRegistry.newCodeRegistry()
                                                                       .dataFetcher(FieldCoordinates.coordinates(query.getName(), "hello2"),
                                                                                    new StaticDataFetcher("world2"))
-                                                                      .dataFetcher(FieldCoordinates.coordinates(query.getName(), "greetings"),
+                                                                      .dataFetcher(FieldCoordinates.coordinates(query.getName(), "hello3"),
                                                                                    new StaticDataFetcher(Collections.emptyMap()))
                                                                       .dataFetcher(FieldCoordinates.coordinates("Hello3", "america"),
                                                                                    new StaticDataFetcher("Hi!"))
@@ -113,27 +210,54 @@ public class GraphQLSchemaAutoConfigurationTest {
 
     @Test
     public void contextLoads() {
-        // given
-        GraphQL graphQL = GraphQL.newGraphQL(graphQLSchema).build();
-
-        // when
-        Map<String, Object> result = graphQL.execute("query {hello}").getData();
-        Map<String, Object> result2 = graphQL.execute("mutation {greet}").getData();
-        Map<String, Object> result3 = graphQL.execute("mutation {greet2}").getData();
-        Map<String, Object> result4 = graphQL.execute("query {hello2}").getData();
-        Map<String, Object> result5 = graphQL.execute("query { greetings { america canada } }").getData();
-        
-        // then
-        assertThat(result.toString()).isEqualTo("{hello=world}");
-        assertThat(result2.toString()).isEqualTo("{greet=hello world}");
-        assertThat(result3.toString()).isEqualTo("{greet2=hello world2}");
-        assertThat(result4.toString()).isEqualTo("{hello2=world2}");
-        assertThat(result5.toString()).isEqualTo("{greetings={america=Hi!, canada=Eh?}}");
-        
         assertThat(graphQLSchema.getQueryType())
                 .extracting(GraphQLObjectType::getName, GraphQLObjectType::getDescription)
                 .containsExactly("GraphQLBooks", "GraphQL Books Schema Description");
         	
+    }
+    
+    @Test
+    public void querySchemaConfigurer() {
+        // given
+        GraphQL graphQL = GraphQL.newGraphQL(graphQLSchema).build();
+
+        // when
+        Map<String, Object> query1 = graphQL.execute("query {hello}").getData();
+        Map<String, Object> query2 = graphQL.execute("query {hello2}").getData();
+        Map<String, Object> query3 = graphQL.execute("query {hello3 { america canada } }").getData();
+        
+        // then
+        assertThat(query1.toString()).isEqualTo("{hello=world}");
+        assertThat(query2.toString()).isEqualTo("{hello2=world2}");
+        assertThat(query3.toString()).isEqualTo("{hello3={america=Hi!, canada=Eh?}}");
+    }
+
+    @Test
+    public void mutationSchemaConfigurer() {
+        // given
+        GraphQL graphQL = GraphQL.newGraphQL(graphQLSchema).build();
+
+        // when
+        Map<String, Object> query1 = graphQL.execute("mutation {greet}").getData();
+        Map<String, Object> query2 = graphQL.execute("mutation {greet2}").getData();
+        
+        // then
+        assertThat(query1.toString()).isEqualTo("{greet=hello world}");
+        assertThat(query2.toString()).isEqualTo("{greet2=hello world2}");
+    }
+
+    @Test
+    public void annotatedSchemaConfigurer() {
+        // given
+        GraphQL graphQL = GraphQL.newGraphQL(graphQLSchema).build();
+
+        // when
+        Map<String, Object> mutation = graphQL.execute("mutation { salut(name: \"dude\") }").getData();
+        Map<String, Object> query = graphQL.execute("query { greeting(name: \"dude\") { value } }").getData();
+        
+        // then
+        assertThat(mutation.toString()).isEqualTo("{salut=Salut, dude!}");
+        assertThat(query.toString()).isEqualTo("{greeting={value=Hi, dude!}}");
     }
     
 

--- a/graphql-jpa-query-autoconfigure/src/test/java/com/introproventures/graphql/jpa/query/autoconfigure/support/AdditionalGraphQLType.java
+++ b/graphql-jpa-query-autoconfigure/src/test/java/com/introproventures/graphql/jpa/query/autoconfigure/support/AdditionalGraphQLType.java
@@ -1,0 +1,5 @@
+package com.introproventures.graphql.jpa.query.autoconfigure.support;
+
+
+public interface AdditionalGraphQLType {
+}

--- a/graphql-jpa-query-autoconfigure/src/test/java/com/introproventures/graphql/jpa/query/autoconfigure/support/MutationRoot.java
+++ b/graphql-jpa-query-autoconfigure/src/test/java/com/introproventures/graphql/jpa/query/autoconfigure/support/MutationRoot.java
@@ -1,0 +1,5 @@
+package com.introproventures.graphql.jpa.query.autoconfigure.support;
+
+
+public interface MutationRoot {
+}

--- a/graphql-jpa-query-autoconfigure/src/test/java/com/introproventures/graphql/jpa/query/autoconfigure/support/QueryRoot.java
+++ b/graphql-jpa-query-autoconfigure/src/test/java/com/introproventures/graphql/jpa/query/autoconfigure/support/QueryRoot.java
@@ -1,0 +1,5 @@
+package com.introproventures.graphql.jpa.query.autoconfigure.support;
+
+
+public interface QueryRoot {
+}

--- a/graphql-jpa-query-autoconfigure/src/test/java/com/introproventures/graphql/jpa/query/autoconfigure/support/SubscriptionRoot.java
+++ b/graphql-jpa-query-autoconfigure/src/test/java/com/introproventures/graphql/jpa/query/autoconfigure/support/SubscriptionRoot.java
@@ -1,0 +1,5 @@
+package com.introproventures.graphql.jpa.query.autoconfigure.support;
+
+
+public interface SubscriptionRoot {
+}

--- a/graphql-jpa-query-boot-starter/src/test/java/com/introproventures/graphql/jpa/query/starter/GraphQLJpaQueryStarterIT.java
+++ b/graphql-jpa-query-boot-starter/src/test/java/com/introproventures/graphql/jpa/query/starter/GraphQLJpaQueryStarterIT.java
@@ -40,8 +40,6 @@ import com.fasterxml.jackson.databind.JsonMappingException;
 import com.introproventures.graphql.jpa.query.starter.Result.GraphQLError;
 import com.introproventures.graphql.jpa.query.web.GraphQLController.GraphQLQueryRequest;
 
-import lombok.Data;
-
 @RunWith(SpringRunner.class)
 @SpringBootTest(webEnvironment = WebEnvironment.RANDOM_PORT)
 public class GraphQLJpaQueryStarterIT {
@@ -106,28 +104,64 @@ public class GraphQLJpaQueryStarterIT {
     }
 }
 
-@Data
 class Result {
 
     Map<String, Object> data;
     List<GraphQLError> errors;
     Map<Object, Object> extensions;
     
-    @Data    
     static class GraphQLError {
 
         String message;
         List<SourceLocation> locations;
         Map<String, Object> extensions;
+        
+        public String getMessage() {
+            return message;
+        }
+        
+        public List<SourceLocation> getLocations() {
+            return locations;
+        }
+        
+        public Map<String, Object> getExtensions() {
+            return extensions;
+        }
     }
 
-    @Data
     static class SourceLocation {
 
         int line;
         int column;
         String sourceName;
         
+        public int getLine() {
+            return line;
+        }
+        
+        public int getColumn() {
+            return column;
+        }
+        
+        public String getSourceName() {
+            return sourceName;
+        }
+        
+    }
+
+    
+    public Map<String, Object> getData() {
+        return data;
+    }
+
+    
+    public List<GraphQLError> getErrors() {
+        return errors;
+    }
+
+    
+    public Map<Object, Object> getExtensions() {
+        return extensions;
     }    
 }
 

--- a/graphql-jpa-query-boot-starter/src/test/java/com/introproventures/graphql/jpa/query/starter/GraphQLJpaQueryStarterIT.java
+++ b/graphql-jpa-query-boot-starter/src/test/java/com/introproventures/graphql/jpa/query/starter/GraphQLJpaQueryStarterIT.java
@@ -86,11 +86,31 @@ public class GraphQLJpaQueryStarterIT {
 
 @Value
 class Result implements ExecutionResult {
-	Map<String, Object>   data;
-	List<GraphQLError>				   errors;
-	Map<Object, Object>                extensions;
-	
-	@Override
+	Map<String, Object> data;
+	List<GraphQLError> errors;
+	Map<Object, Object> extensions;
+
+  @Override
+  public List<GraphQLError> getErrors() {
+    return errors;
+  }
+
+  @Override
+  public <T> T getData() {
+    return null;
+  }
+
+  @Override
+  public boolean isDataPresent() {
+    return data != null;
+  }
+
+  @Override
+  public Map<Object, Object> getExtensions() {
+    return extensions;
+  }
+
+  @Override
 	public Map<String, Object> toSpecification() {
 		return new HashMap<>();
 	}	

--- a/graphql-jpa-query-dependencies/pom.xml
+++ b/graphql-jpa-query-dependencies/pom.xml
@@ -10,7 +10,7 @@
     <packaging>pom</packaging>
 
     <properties>
-        <graphql-java.version>11.0</graphql-java.version>
+        <graphql-java.version>13.0</graphql-java.version>
         <hibernate-jpa-2.1-api.version>1.0.0.Final</hibernate-jpa-2.1-api.version>
         <evo-inflector.version>1.2.2</evo-inflector.version>
         <javax.interceptor-api.version>1.2.2</javax.interceptor-api.version>

--- a/graphql-jpa-query-schema/src/main/java/com/introproventures/graphql/jpa/query/schema/JavaScalars.java
+++ b/graphql-jpa-query-schema/src/main/java/com/introproventures/graphql/jpa/query/schema/JavaScalars.java
@@ -43,6 +43,9 @@ import java.util.TimeZone;
 import java.util.UUID;
 import java.util.stream.Collectors;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 import graphql.Assert;
 import graphql.Scalars;
 import graphql.language.ArrayValue;
@@ -60,9 +63,6 @@ import graphql.schema.Coercing;
 import graphql.schema.CoercingParseValueException;
 import graphql.schema.CoercingSerializeException;
 import graphql.schema.GraphQLScalarType;
-
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 /**
  * Provides Registry to resolve GraphQL Query Java Scalar Types
@@ -109,18 +109,18 @@ public class JavaScalars {
 
         scalarsRegistry.put(BigDecimal.class, Scalars.GraphQLBigDecimal);
 
-        scalarsRegistry.put(LocalDateTime.class, toScalarType("LocalDateTime", "LocalDateTime type", new GraphQLLocalDateTimeCoercing()));
-        scalarsRegistry.put(LocalDate.class, toScalarType("LocalDate", "LocalDate type", new GraphQLLocalDateCoercing()));
-        scalarsRegistry.put(LocalTime.class, toScalarType("LocalTime", "LocalTime type", new GraphQLLocalTimeCoercing()));
-        scalarsRegistry.put(Date.class, toScalarType("Date", "Date type", new GraphQLDateCoercing()));
-        scalarsRegistry.put(UUID.class, toScalarType("UUID", "UUID type", new GraphQLUUIDCoercing()));
-        scalarsRegistry.put(Object.class, toScalarType("Object", "Object type", new GraphQLObjectCoercing()));
-        scalarsRegistry.put(java.sql.Date.class, toScalarType("SqlDate", "SQL Date type", new GraphQLSqlDateCoercing()));
-        scalarsRegistry.put(java.sql.Timestamp.class, toScalarType("SqlTimestamp", "SQL Timestamp type", new GraphQLSqlTimestampCoercing()));
-        scalarsRegistry.put(Byte[].class, toScalarType("ByteArray", "ByteArray type", new GraphQLLOBCoercing()));
-        scalarsRegistry.put(Instant.class, toScalarType("Instant", "Instant type", new GraphQLInstantCoercing()));
-        scalarsRegistry.put(ZonedDateTime.class, toScalarType("ZonedDateTime", "ZonedDateTime type", new GraphQLZonedDateTimeCoercing()));
-        scalarsRegistry.put(OffsetDateTime.class, toScalarType("OffsetDateTime", "OffsetDateTime type", new GraphQLOffsetDateTimeCoercing()));
+        scalarsRegistry.put(LocalDateTime.class, newScalarType("LocalDateTime", "LocalDateTime type", new GraphQLLocalDateTimeCoercing()));
+        scalarsRegistry.put(LocalDate.class, newScalarType("LocalDate", "LocalDate type", new GraphQLLocalDateCoercing()));
+        scalarsRegistry.put(LocalTime.class, newScalarType("LocalTime", "LocalTime type", new GraphQLLocalTimeCoercing()));
+        scalarsRegistry.put(Date.class, newScalarType("Date", "Date type", new GraphQLDateCoercing()));
+        scalarsRegistry.put(UUID.class, newScalarType("UUID", "UUID type", new GraphQLUUIDCoercing()));
+        scalarsRegistry.put(Object.class, newScalarType("Object", "Object type", new GraphQLObjectCoercing()));
+        scalarsRegistry.put(java.sql.Date.class, newScalarType("SqlDate", "SQL Date type", new GraphQLSqlDateCoercing()));
+        scalarsRegistry.put(java.sql.Timestamp.class, newScalarType("SqlTimestamp", "SQL Timestamp type", new GraphQLSqlTimestampCoercing()));
+        scalarsRegistry.put(Byte[].class, newScalarType("ByteArray", "ByteArray type", new GraphQLLOBCoercing()));
+        scalarsRegistry.put(Instant.class, newScalarType("Instant", "Instant type", new GraphQLInstantCoercing()));
+        scalarsRegistry.put(ZonedDateTime.class, newScalarType("ZonedDateTime", "ZonedDateTime type", new GraphQLZonedDateTimeCoercing()));
+        scalarsRegistry.put(OffsetDateTime.class, newScalarType("OffsetDateTime", "OffsetDateTime type", new GraphQLOffsetDateTimeCoercing()));
     }
 
     public static GraphQLScalarType of(Class<?> key) {
@@ -131,15 +131,14 @@ public class JavaScalars {
         String typeName = key.getSimpleName();
         String description = typeName+" Scalar Object Type";
         
-        return toScalarType(typeName, description ,new GraphQLObjectCoercing());
+        return newScalarType(typeName, description ,new GraphQLObjectCoercing());
     }
 
-    public static <T extends Coercing> GraphQLScalarType toScalarType(String name, String description, T coercing) {
-        return newScalar()
-          .name(name)
-          .description(description)
-          .coercing(coercing)
-          .build();
+    public static <T extends Coercing> GraphQLScalarType newScalarType(String name, String description, T coercing) {
+        return newScalar().name(name)
+                          .description(description)
+                          .coercing(coercing)
+                          .build();
     }
 
     public static JavaScalars register(Class<?> key, GraphQLScalarType value) {

--- a/graphql-jpa-query-schema/src/main/java/com/introproventures/graphql/jpa/query/schema/JavaScalars.java
+++ b/graphql-jpa-query-schema/src/main/java/com/introproventures/graphql/jpa/query/schema/JavaScalars.java
@@ -15,6 +15,8 @@
  */
 package com.introproventures.graphql.jpa.query.schema;
 
+import static graphql.schema.GraphQLScalarType.newScalar;
+
 import java.math.BigDecimal;
 import java.math.BigInteger;
 import java.nio.charset.StandardCharsets;
@@ -41,9 +43,6 @@ import java.util.TimeZone;
 import java.util.UUID;
 import java.util.stream.Collectors;
 
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
 import graphql.Assert;
 import graphql.Scalars;
 import graphql.language.ArrayValue;
@@ -61,6 +60,9 @@ import graphql.schema.Coercing;
 import graphql.schema.CoercingParseValueException;
 import graphql.schema.CoercingSerializeException;
 import graphql.schema.GraphQLScalarType;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * Provides Registry to resolve GraphQL Query Java Scalar Types
@@ -107,29 +109,37 @@ public class JavaScalars {
 
         scalarsRegistry.put(BigDecimal.class, Scalars.GraphQLBigDecimal);
 
-        scalarsRegistry.put(LocalDateTime.class, new GraphQLScalarType("LocalDateTime", "LocalDateTime type", new GraphQLLocalDateTimeCoercing()));
-        scalarsRegistry.put(LocalDate.class, new GraphQLScalarType("LocalDate", "LocalDate type", new GraphQLLocalDateCoercing()));
-        scalarsRegistry.put(LocalTime.class, new GraphQLScalarType("LocalTime", "LocalTime type", new GraphQLLocalTimeCoercing()));
-        scalarsRegistry.put(Date.class, new GraphQLScalarType("Date", "Date type", new GraphQLDateCoercing()));
-        scalarsRegistry.put(UUID.class, new GraphQLScalarType("UUID", "UUID type", new GraphQLUUIDCoercing()));
-        scalarsRegistry.put(Object.class, new GraphQLScalarType("Object", "Object type", new GraphQLObjectCoercing()));
-        scalarsRegistry.put(java.sql.Date.class, new GraphQLScalarType("SqlDate", "SQL Date type", new GraphQLSqlDateCoercing()));
-        scalarsRegistry.put(java.sql.Timestamp.class, new GraphQLScalarType("SqlTimestamp", "SQL Timestamp type", new GraphQLSqlTimestampCoercing()));
-        scalarsRegistry.put(Byte[].class, new GraphQLScalarType("ByteArray", "ByteArray type", new GraphQLLOBCoercing()));
-        scalarsRegistry.put(Instant.class, new GraphQLScalarType("Instant", "Instant type", new GraphQLInstantCoercing()));
-        scalarsRegistry.put(ZonedDateTime.class, new GraphQLScalarType("ZonedDateTime", "ZonedDateTime type", new GraphQLZonedDateTimeCoercing()));
-        scalarsRegistry.put(OffsetDateTime.class, new GraphQLScalarType("OffsetDateTime", "OffsetDateTime type", new GraphQLOffsetDateTimeCoercing()));
+        scalarsRegistry.put(LocalDateTime.class, toScalarType("LocalDateTime", "LocalDateTime type", new GraphQLLocalDateTimeCoercing()));
+        scalarsRegistry.put(LocalDate.class, toScalarType("LocalDate", "LocalDate type", new GraphQLLocalDateCoercing()));
+        scalarsRegistry.put(LocalTime.class, toScalarType("LocalTime", "LocalTime type", new GraphQLLocalTimeCoercing()));
+        scalarsRegistry.put(Date.class, toScalarType("Date", "Date type", new GraphQLDateCoercing()));
+        scalarsRegistry.put(UUID.class, toScalarType("UUID", "UUID type", new GraphQLUUIDCoercing()));
+        scalarsRegistry.put(Object.class, toScalarType("Object", "Object type", new GraphQLObjectCoercing()));
+        scalarsRegistry.put(java.sql.Date.class, toScalarType("SqlDate", "SQL Date type", new GraphQLSqlDateCoercing()));
+        scalarsRegistry.put(java.sql.Timestamp.class, toScalarType("SqlTimestamp", "SQL Timestamp type", new GraphQLSqlTimestampCoercing()));
+        scalarsRegistry.put(Byte[].class, toScalarType("ByteArray", "ByteArray type", new GraphQLLOBCoercing()));
+        scalarsRegistry.put(Instant.class, toScalarType("Instant", "Instant type", new GraphQLInstantCoercing()));
+        scalarsRegistry.put(ZonedDateTime.class, toScalarType("ZonedDateTime", "ZonedDateTime type", new GraphQLZonedDateTimeCoercing()));
+        scalarsRegistry.put(OffsetDateTime.class, toScalarType("OffsetDateTime", "OffsetDateTime type", new GraphQLOffsetDateTimeCoercing()));
     }
 
     public static GraphQLScalarType of(Class<?> key) {
         return scalarsRegistry.computeIfAbsent(key, JavaScalars::computeGraphQLScalarType);
     }
-    
+
     protected static GraphQLScalarType computeGraphQLScalarType(Class<?> key) {
         String typeName = key.getSimpleName();
         String description = typeName+" Scalar Object Type";
         
-        return new GraphQLScalarType(typeName, description, new GraphQLObjectCoercing());
+        return toScalarType(typeName, description ,new GraphQLObjectCoercing());
+    }
+
+    public static <T extends Coercing> GraphQLScalarType toScalarType(String name, String description, T coercing) {
+        return newScalar()
+          .name(name)
+          .description(description)
+          .coercing(coercing)
+          .build();
     }
 
     public static JavaScalars register(Class<?> key, GraphQLScalarType value) {

--- a/graphql-jpa-query-schema/src/main/java/com/introproventures/graphql/jpa/query/schema/impl/DataFetchingEnvironmentBuilder.java
+++ b/graphql-jpa-query-schema/src/main/java/com/introproventures/graphql/jpa/query/schema/impl/DataFetchingEnvironmentBuilder.java
@@ -1,0 +1,25 @@
+package com.introproventures.graphql.jpa.query.schema.impl;
+
+import graphql.execution.ExecutionContext;
+import graphql.schema.DataFetchingEnvironment;
+import graphql.schema.DataFetchingEnvironmentImpl;
+
+/**
+ * Wrapper utility class to bridge between Graphql-java11 and Graphql-java13 Api changes  
+ * 
+ */
+class DataFetchingEnvironmentBuilder {
+    
+    public static DataFetchingEnvironmentImpl.Builder newDataFetchingEnvironment(DataFetchingEnvironment environment) {
+        return DataFetchingEnvironmentImpl.newDataFetchingEnvironment(environment);
+    }
+
+    public static DataFetchingEnvironmentImpl.Builder newDataFetchingEnvironment() {
+        return DataFetchingEnvironmentImpl.newDataFetchingEnvironment();
+    }
+
+    public static DataFetchingEnvironmentImpl.Builder newDataFetchingEnvironment(ExecutionContext executionContext) {
+        return DataFetchingEnvironmentImpl.newDataFetchingEnvironment(executionContext);
+    }
+    
+}

--- a/graphql-jpa-query-schema/src/main/java/com/introproventures/graphql/jpa/query/schema/impl/GraphQLJpaExecutor.java
+++ b/graphql-jpa-query-schema/src/main/java/com/introproventures/graphql/jpa/query/schema/impl/GraphQLJpaExecutor.java
@@ -18,6 +18,7 @@ package com.introproventures.graphql.jpa.query.schema.impl;
 
 import java.util.Collections;
 import java.util.Map;
+import java.util.Optional;
 
 import javax.transaction.Transactional;
 import javax.transaction.Transactional.TxType;
@@ -64,10 +65,12 @@ public class GraphQLJpaExecutor implements GraphQLExecutor {
     @Override
     @Transactional(TxType.REQUIRES_NEW)
     public ExecutionResult execute(String query, Map<String, Object> arguments) {
+        Map<String, Object> variables = Optional.ofNullable(arguments)
+                                                .orElseGet(Collections::emptyMap);
     	
     	ExecutionInput executionInput = ExecutionInput.newExecutionInput()
     			.query(query)
-    			.variables(arguments)
+    			.variables(variables)
     			.build();
     	
         return graphQL.execute(executionInput);

--- a/graphql-jpa-query-schema/src/main/java/com/introproventures/graphql/jpa/query/schema/impl/GraphQLJpaQueryDataFetcher.java
+++ b/graphql-jpa-query-schema/src/main/java/com/introproventures/graphql/jpa/query/schema/impl/GraphQLJpaQueryDataFetcher.java
@@ -39,7 +39,6 @@ import graphql.language.Argument;
 import graphql.language.BooleanValue;
 import graphql.language.Field;
 import graphql.schema.DataFetchingEnvironment;
-import graphql.schema.DataFetchingEnvironmentImpl;
 import graphql.schema.GraphQLObjectType;
 
 /**
@@ -109,7 +108,7 @@ class GraphQLJpaQueryDataFetcher extends QraphQLJpaBaseDataFetcher {
                 Optional.of(getFieldDef(environment.getGraphQLSchema(), (GraphQLObjectType)environment.getParentType(), field))
                     .map(it -> (GraphQLObjectType) it.getType())
                     .map(it -> it.getFieldDefinition(GraphQLJpaSchemaBuilder.QUERY_SELECT_PARAM_NAME))
-                    .map(it -> DataFetchingEnvironmentImpl.newDataFetchingEnvironment(environment)
+                    .map(it -> DataFetchingEnvironmentBuilder.newDataFetchingEnvironment(environment)
                                                              .fieldType(it.getType())
                                                              .build()
                     ).orElse(environment);
@@ -185,7 +184,7 @@ class GraphQLJpaQueryDataFetcher extends QraphQLJpaBaseDataFetcher {
         CriteriaQuery<Long> query = cb.createQuery(Long.class);
         Root<?> root = query.from(entityType);
 
-        DataFetchingEnvironment queryEnvironment = DataFetchingEnvironmentImpl.newDataFetchingEnvironment(environment)
+        DataFetchingEnvironment queryEnvironment = DataFetchingEnvironmentBuilder.newDataFetchingEnvironment(environment)
                                                                                  .root(query)
                                                                                  .build();
         

--- a/graphql-jpa-query-schema/src/main/java/com/introproventures/graphql/jpa/query/schema/impl/GraphQLJpaSchemaBuilder.java
+++ b/graphql-jpa-query-schema/src/main/java/com/introproventures/graphql/jpa/query/schema/impl/GraphQLJpaSchemaBuilder.java
@@ -38,9 +38,6 @@ import javax.persistence.metamodel.PluralAttribute;
 import javax.persistence.metamodel.SingularAttribute;
 import javax.persistence.metamodel.Type;
 
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
 import com.introproventures.graphql.jpa.query.annotation.GraphQLIgnore;
 import com.introproventures.graphql.jpa.query.annotation.GraphQLIgnoreFilter;
 import com.introproventures.graphql.jpa.query.annotation.GraphQLIgnoreOrder;
@@ -49,7 +46,6 @@ import com.introproventures.graphql.jpa.query.schema.JavaScalars;
 import com.introproventures.graphql.jpa.query.schema.NamingStrategy;
 import com.introproventures.graphql.jpa.query.schema.impl.EntityIntrospector.EntityIntrospectionResult.AttributePropertyDescriptor;
 import com.introproventures.graphql.jpa.query.schema.impl.PredicateFilter.Criteria;
-
 import graphql.Assert;
 import graphql.Scalars;
 import graphql.schema.Coercing;
@@ -68,6 +64,9 @@ import graphql.schema.GraphQLSchema;
 import graphql.schema.GraphQLType;
 import graphql.schema.GraphQLTypeReference;
 import graphql.schema.PropertyDataFetcher;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * JPA specific schema builder implementation of {code #GraphQLSchemaBuilder} interface
@@ -161,7 +160,7 @@ public class GraphQLJpaSchemaBuilder implements GraphQLSchemaBuilder {
                 .description(getSchemaDescription(entityType))
                 .type(getObjectType(entityType))
                 .dataFetcher(new GraphQLJpaSimpleDataFetcher(entityManager, entityType, toManyDefaultOptional))
-                .argument(entityType.getAttributes().stream()
+                .arguments(entityType.getAttributes().stream()
                     .filter(this::isValidInput)
                     .filter(this::isNotIgnored)
                     .filter(this::isIdentity)
@@ -704,8 +703,8 @@ public class GraphQLJpaSchemaBuilder implements GraphQLSchemaBuilder {
         return EntityIntrospector.introspect(managedType)
                                  .getTransientPropertyDescriptors()
                                  .stream()
-                                 .filter(AttributePropertyDescriptor::isNotIgnored)
-                                 .map(this::getJavaFieldDefinition)
+                                  .filter(AttributePropertyDescriptor::isNotIgnored)
+                                  .map(this::getJavaFieldDefinition)
                                  .collect(Collectors.toList());
     }
     
@@ -777,7 +776,7 @@ public class GraphQLJpaSchemaBuilder implements GraphQLSchemaBuilder {
                 .description(getSchemaDescription(attribute))
                 .type(type)
                 .dataFetcher(dataFetcher)
-                .argument(arguments)
+                .arguments(arguments)
                 .build();
     }
     

--- a/graphql-jpa-query-schema/src/main/java/com/introproventures/graphql/jpa/query/schema/impl/GraphQLJpaSimpleDataFetcher.java
+++ b/graphql-jpa-query-schema/src/main/java/com/introproventures/graphql/jpa/query/schema/impl/GraphQLJpaSimpleDataFetcher.java
@@ -40,11 +40,11 @@ class GraphQLJpaSimpleDataFetcher extends QraphQLJpaBaseDataFetcher {
     @Override
     public Object get(DataFetchingEnvironment environment) {
         
-        Field field = environment.getFields().iterator().next();
+        Field field = environment.getField();
 
         if(!field.getArguments().isEmpty()) {
             
-            flattenEmbeddedIdArguments(field);
+            field = flattenEmbeddedIdArguments(field);
             
             try {
                 return getQuery(environment, field, true).getSingleResult();
@@ -58,7 +58,7 @@ class GraphQLJpaSimpleDataFetcher extends QraphQLJpaBaseDataFetcher {
         return null;
     }
 
-	private void flattenEmbeddedIdArguments(Field field) {
+	private Field flattenEmbeddedIdArguments(Field field) {
 		// manage object arguments (EmbeddedId)
 		final List<Argument> argumentsWhereObjectsAreFlattened = field.getArguments()
 				.stream()
@@ -74,6 +74,7 @@ class GraphQLJpaSimpleDataFetcher extends QraphQLJpaBaseDataFetcher {
 					}
 				})
 				.collect(Collectors.toList());
-		field.setArguments(argumentsWhereObjectsAreFlattened);
+		return field.transform(builder ->
+        builder.arguments(argumentsWhereObjectsAreFlattened));
 	}
 }

--- a/graphql-jpa-query-schema/src/main/java/com/introproventures/graphql/jpa/query/schema/impl/QraphQLJpaBaseDataFetcher.java
+++ b/graphql-jpa-query-schema/src/main/java/com/introproventures/graphql/jpa/query/schema/impl/QraphQLJpaBaseDataFetcher.java
@@ -62,6 +62,7 @@ import javax.persistence.metamodel.SingularAttribute;
 
 import com.introproventures.graphql.jpa.query.annotation.GraphQLDefaultOrderBy;
 import com.introproventures.graphql.jpa.query.schema.impl.PredicateFilter.Criteria;
+
 import graphql.GraphQLException;
 import graphql.execution.ValuesResolver;
 import graphql.language.Argument;
@@ -81,7 +82,6 @@ import graphql.language.Value;
 import graphql.language.VariableReference;
 import graphql.schema.DataFetcher;
 import graphql.schema.DataFetchingEnvironment;
-import graphql.schema.DataFetchingEnvironmentImpl;
 import graphql.schema.GraphQLArgument;
 import graphql.schema.GraphQLFieldDefinition;
 import graphql.schema.GraphQLList;
@@ -133,7 +133,7 @@ class QraphQLJpaBaseDataFetcher implements DataFetcher<Object> {
         CriteriaQuery<?> query = cb.createQuery((Class<?>) entityType.getJavaType());
         Root<?> from = query.from(entityType);
 
-        DataFetchingEnvironment queryEnvironment = DataFetchingEnvironmentImpl.newDataFetchingEnvironment(environment)
+        DataFetchingEnvironment queryEnvironment = DataFetchingEnvironmentBuilder.newDataFetchingEnvironment(environment)
                                                                                  .root(query)
                                                                                  .build();
         from.alias(from.getModel().getName().toLowerCase());
@@ -421,7 +421,7 @@ class QraphQLJpaBaseDataFetcher implements DataFetcher<Object> {
         Map<String, Object> predicateArguments = new LinkedHashMap<>();
         predicateArguments.put(logical.name(), environment.getArguments());
         
-        DataFetchingEnvironment predicateDataFetchingEnvironment = DataFetchingEnvironmentImpl.newDataFetchingEnvironment(environment)
+        DataFetchingEnvironment predicateDataFetchingEnvironment = DataFetchingEnvironmentBuilder.newDataFetchingEnvironment(environment)
                                                                                                  .arguments(predicateArguments)
                                                                                                  .build();
         Argument predicateArgument = new Argument(logical.name(), whereValue);
@@ -765,7 +765,7 @@ class QraphQLJpaBaseDataFetcher implements DataFetcher<Object> {
         Map<String, Object> valueArguments = new LinkedHashMap<String,Object>();
         valueArguments.put(objectField.getName(), environment.getArgument(argument.getName()));
         
-        DataFetchingEnvironment dataFetchingEnvironment = DataFetchingEnvironmentImpl.newDataFetchingEnvironment(environment)
+        DataFetchingEnvironment dataFetchingEnvironment = DataFetchingEnvironmentBuilder.newDataFetchingEnvironment(environment)
                                                                                         .arguments(valueArguments)
                                                                                         .build();
         
@@ -777,7 +777,7 @@ class QraphQLJpaBaseDataFetcher implements DataFetcher<Object> {
     }
 
     protected final DataFetchingEnvironment argumentEnvironment(DataFetchingEnvironment environment,  Map<String, Object> arguments) {
-        return DataFetchingEnvironmentImpl.newDataFetchingEnvironment(environment)
+        return DataFetchingEnvironmentBuilder.newDataFetchingEnvironment(environment)
                                              .arguments(arguments)
                                              .build();
     }
@@ -785,13 +785,13 @@ class QraphQLJpaBaseDataFetcher implements DataFetcher<Object> {
     protected final DataFetchingEnvironment argumentEnvironment(DataFetchingEnvironment environment, Argument argument) {
         Map<String, Object> arguments = environment.getArgument(argument.getName());
         
-        return DataFetchingEnvironmentImpl.newDataFetchingEnvironment(environment)
+        return DataFetchingEnvironmentBuilder.newDataFetchingEnvironment(environment)
                                              .arguments(arguments)
                                              .build();
     }
 
     protected final DataFetchingEnvironment wherePredicateEnvironment(DataFetchingEnvironment environment, GraphQLFieldDefinition fieldDefinition, Map<String, Object> arguments) {
-        return DataFetchingEnvironmentImpl.newDataFetchingEnvironment(environment)
+        return DataFetchingEnvironmentBuilder.newDataFetchingEnvironment(environment)
                                              .arguments(arguments)
                                              .fieldDefinition(fieldDefinition)
                                              .fieldType(fieldDefinition.getType())

--- a/graphql-jpa-query-schema/src/main/java/com/introproventures/graphql/jpa/query/schema/impl/QraphQLJpaBaseDataFetcher.java
+++ b/graphql-jpa-query-schema/src/main/java/com/introproventures/graphql/jpa/query/schema/impl/QraphQLJpaBaseDataFetcher.java
@@ -1164,7 +1164,7 @@ class QraphQLJpaBaseDataFetcher implements DataFetcher<Object> {
     @SuppressWarnings( "unchecked" )
     protected final <R extends Value<?>> R getObjectFieldValue(ObjectValue objectValue, String fieldName) {
         return (R) getObjectField(objectValue, fieldName).map(ObjectField::getValue)
-                                                         .orElse(NullValue.newNullValue().build());
+                                                         .orElse(NullValue.Null);
     }
 
     @SuppressWarnings( "unchecked" )

--- a/graphql-jpa-query-schema/src/test/java/com/introproventures/graphql/jpa/query/converter/GraphQLJpaConverterTests.java
+++ b/graphql-jpa-query-schema/src/test/java/com/introproventures/graphql/jpa/query/converter/GraphQLJpaConverterTests.java
@@ -122,7 +122,7 @@ public class GraphQLJpaConverterTests extends AbstractSpringBootTestSupport {
         CriteriaQuery<TaskVariableEntity> criteria = cb.createQuery(TaskVariableEntity.class);
         Root<TaskVariableEntity> taskVariable = criteria.from(TaskVariableEntity.class);
         
-        Boolean object = new Boolean(true); 
+        Boolean object = Boolean.TRUE;
 
         VariableValue<Boolean> variableValue = new VariableValue<>(object);
         criteria.select(taskVariable)
@@ -151,7 +151,7 @@ public class GraphQLJpaConverterTests extends AbstractSpringBootTestSupport {
         Predicate isOwner = cb.in(taskVariables.get("task")).value(task);
 
         Predicate var1 = cb.and(cb.equal(taskVariables.get("name"), "variable2"), 
-                                cb.equal(taskVariables.get("value"), new VariableValue<>(new Boolean(true))));
+                                cb.equal(taskVariables.get("value"), new VariableValue<>(Boolean.TRUE)));
 
         Predicate var2 = cb.and(cb.equal(taskVariables.get("name"), "variable1"), 
                                 cb.equal(taskVariables.get("value"), new VariableValue<>(new String("data"))));
@@ -181,7 +181,7 @@ public class GraphQLJpaConverterTests extends AbstractSpringBootTestSupport {
         Join<TaskEntity, TaskVariableEntity> taskVariables = taskCorrelation.join("variables");
         
         Predicate var1 = cb.and(cb.equal(taskVariables.get("name"), "variable2"), 
-                                cb.equal(taskVariables.get("value"), new VariableValue<>(new Boolean(true))));
+                                cb.equal(taskVariables.get("value"), new VariableValue<>(Boolean.TRUE)));
 
         Predicate var2 = cb.and(cb.equal(taskVariables.get("name"), "variable1"), 
                                 cb.equal(taskVariables.get("value"), new VariableValue<>(new String("data"))));
@@ -211,7 +211,7 @@ public class GraphQLJpaConverterTests extends AbstractSpringBootTestSupport {
         Join<TaskEntity, TaskVariableEntity> taskVariables = taskCorrelation.join("variables");
         
         Predicate var1 = cb.and(cb.equal(taskVariables.get("name"), "variable2"), 
-                                cb.equal(taskVariables.get("value"), new VariableValue<>(new Boolean(true))));
+                                cb.equal(taskVariables.get("value"), new VariableValue<>(Boolean.TRUE)));
 
         Predicate var2 = cb.and(cb.equal(taskVariables.get("name"), "variable1"), 
                                 cb.equal(taskVariables.get("value"), new VariableValue<>(new String("data"))));
@@ -243,7 +243,7 @@ public class GraphQLJpaConverterTests extends AbstractSpringBootTestSupport {
         Join<TaskEntity, TaskVariableEntity> taskVariables = taskCorrelation.join("variables");
         
         Predicate var1 = cb.and(cb.equal(taskVariables.get("name"), "variable2"), 
-                                cb.equal(taskVariables.get("value"), new VariableValue<>(new Boolean(true))));
+                                cb.equal(taskVariables.get("value"), new VariableValue<>(Boolean.TRUE)));
 
         Predicate var2 = cb.and(cb.equal(taskVariables.get("name"), "variable1"), 
                                 cb.equal(taskVariables.get("value"), new VariableValue<>(new String("data"))));

--- a/graphql-jpa-query-schema/src/test/java/com/introproventures/graphql/jpa/query/schema/GraphQLExecutorTests.java
+++ b/graphql-jpa-query-schema/src/test/java/com/introproventures/graphql/jpa/query/schema/GraphQLExecutorTests.java
@@ -2150,5 +2150,20 @@ public class GraphQLExecutorTests extends AbstractSpringBootTestSupport {
 
         //then:
         assertThat(result.toString()).isEqualTo(expected);
-    } 
+    }
+    
+    @Test
+    public void queryWithNullVarables() {
+        //given
+        String query = "{ Author(id: 1) { id name } }";
+        
+        String expected = "{Author={id=1, name=Leo Tolstoy}}";
+
+        //when
+        Object result = executor.execute(query, null).getData();
+
+        // then
+        assertThat(result.toString()).isEqualTo(expected);
+    }
+    
 }

--- a/graphql-jpa-query-schema/src/test/java/com/introproventures/graphql/jpa/query/schema/JavaScalarsTest.java
+++ b/graphql-jpa-query-schema/src/test/java/com/introproventures/graphql/jpa/query/schema/JavaScalarsTest.java
@@ -16,22 +16,31 @@
 
 package com.introproventures.graphql.jpa.query.schema;
 
-import static graphql.schema.GraphQLScalarType.newScalar;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.fail;
 
-import java.time.*;
+import java.time.Instant;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.LocalTime;
+import java.time.Month;
+import java.time.OffsetDateTime;
+import java.time.ZoneId;
+import java.time.ZoneOffset;
+import java.time.ZonedDateTime;
 import java.util.Map;
 import java.util.concurrent.TimeUnit;
 
+import org.junit.Test;
+
 import com.introproventures.graphql.jpa.query.converter.model.VariableValue;
 import com.introproventures.graphql.jpa.query.schema.JavaScalars.GraphQLObjectCoercing;
+
 import graphql.language.StringValue;
 import graphql.schema.Coercing;
 import graphql.schema.CoercingParseValueException;
 import graphql.schema.CoercingSerializeException;
 import graphql.schema.GraphQLScalarType;
-import org.junit.Test;
 
 public class JavaScalarsTest {
 
@@ -197,7 +206,10 @@ public class JavaScalarsTest {
     @Test
     public void testRegisterJavaScalarWithObjectCoercing() {
         //given
-        JavaScalars.register(Map.class, newScalar().name("Map").description("Map Object Type").coercing(new GraphQLObjectCoercing()).build());
+        GraphQLScalarType graphQLScalarType = JavaScalars.newScalarType("Map", 
+                                                                        "Map Object Type", 
+                                                                        new GraphQLObjectCoercing());
+        JavaScalars.register(Map.class, graphQLScalarType);
 
         //when
         GraphQLScalarType scalarType = JavaScalars.of(Map.class);

--- a/graphql-jpa-query-schema/src/test/java/com/introproventures/graphql/jpa/query/schema/JavaScalarsTest.java
+++ b/graphql-jpa-query-schema/src/test/java/com/introproventures/graphql/jpa/query/schema/JavaScalarsTest.java
@@ -16,6 +16,7 @@
 
 package com.introproventures.graphql.jpa.query.schema;
 
+import static graphql.schema.GraphQLScalarType.newScalar;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.fail;
 
@@ -196,7 +197,7 @@ public class JavaScalarsTest {
     @Test
     public void testRegisterJavaScalarWithObjectCoercing() {
         //given
-        JavaScalars.register(Map.class, new GraphQLScalarType("Map", "Map Object Type", new GraphQLObjectCoercing()));
+        JavaScalars.register(Map.class, newScalar().name("Map").description("Map Object Type").coercing(new GraphQLObjectCoercing()).build());
 
         //when
         GraphQLScalarType scalarType = JavaScalars.of(Map.class);


### PR DESCRIPTION
This PR is a fork from https://github.com/introproventures/graphql-jpa-query/pull/205 that adds  the following changes to original commit:

* refactor: added DataFetchingEnvironmentBuilder wrapper class …
* refactor(JavaScalars): Renamed method toScalarType to newScalarType
* fix: Resolved NPE with nullable arguments in GraphQLJpaExecutor.execute
* polish: Replaced NullValue builder() with `NullValue.Null`instance
* refactor: Removed ExecutionResult implementation from GraphQLJpaQueryStarterIT
* feat: added support to merge CodeRegistries
* feat: added test example for graphql-java-annotations library