### PR TITLE
fix(GH-216): One-to-many queries joins the same tables twice 

### DIFF
--- a/graphql-jpa-query-schema/src/main/java/com/introproventures/graphql/jpa/query/schema/impl/GraphQLJpaQueryDataFetcher.java
+++ b/graphql-jpa-query-schema/src/main/java/com/introproventures/graphql/jpa/query/schema/impl/GraphQLJpaQueryDataFetcher.java
@@ -21,7 +21,6 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.stream.Collectors;
 
-import javax.persistence.EntityGraph;
 import javax.persistence.EntityManager;
 import javax.persistence.TypedQuery;
 import javax.persistence.criteria.CriteriaBuilder;
@@ -117,14 +116,6 @@ class GraphQLJpaQueryDataFetcher extends QraphQLJpaBaseDataFetcher {
                 	.setFirstResult((page.page - 1) * page.size);
             }
             
-            // Let's create entity graph from selection
-            // When using fetchgraph all relationships are considered to be lazy regardless of annotation, 
-            // and only the elements of the provided graph are loaded. This particularly useful when running 
-            // reports on certain objects and you don't want a lot of the stuff that's normally flagged to 
-            // load via eager annotations.
-            EntityGraph<?> graph = buildEntityGraph(queryField);
-            query.setHint(JAVAX_PERSISTENCE_FETCHGRAPH, graph);
-
             // Let' try reduce overhead and disable all caching
             query.setHint(ORG_HIBERNATE_READ_ONLY, true);
             query.setHint(ORG_HIBERNATE_FETCH_SIZE, 1000);

--- a/graphql-jpa-query-schema/src/main/java/com/introproventures/graphql/jpa/query/schema/impl/GraphQLJpaSimpleDataFetcher.java
+++ b/graphql-jpa-query-schema/src/main/java/com/introproventures/graphql/jpa/query/schema/impl/GraphQLJpaSimpleDataFetcher.java
@@ -20,7 +20,6 @@ import java.util.List;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
-import javax.persistence.EntityGraph;
 import javax.persistence.EntityManager;
 import javax.persistence.NoResultException;
 import javax.persistence.metamodel.EntityType;
@@ -48,12 +47,7 @@ class GraphQLJpaSimpleDataFetcher extends QraphQLJpaBaseDataFetcher {
             flattenEmbeddedIdArguments(field);
             
             try {
-                // Create entity graph from selection
-                EntityGraph<?> entityGraph = buildEntityGraph(field);
-                
-                return super.getQuery(environment, field, true)
-                    .setHint("javax.persistence.fetchgraph", entityGraph)
-                    .getSingleResult();
+                return getQuery(environment, field, true).getSingleResult();
                 
             } catch (NoResultException ignored) {
                 // do nothing

--- a/graphql-jpa-query-schema/src/main/java/com/introproventures/graphql/jpa/query/schema/impl/QraphQLJpaBaseDataFetcher.java
+++ b/graphql-jpa-query-schema/src/main/java/com/introproventures/graphql/jpa/query/schema/impl/QraphQLJpaBaseDataFetcher.java
@@ -40,9 +40,7 @@ import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 import java.util.stream.Stream;
 
-import javax.persistence.EntityGraph;
 import javax.persistence.EntityManager;
-import javax.persistence.Subgraph;
 import javax.persistence.TypedQuery;
 import javax.persistence.criteria.AbstractQuery;
 import javax.persistence.criteria.CriteriaBuilder;
@@ -1145,44 +1143,6 @@ class QraphQLJpaBaseDataFetcher implements DataFetcher<Object> {
         }
         return fieldDefinition;
     }
-
-    protected Subgraph<?> buildSubgraph(Field field, Subgraph<?> subgraph) {
-
-        selections(field).forEach(it ->{
-            if(hasSelectionSet(it)) {
-                Subgraph<?> sg = subgraph.addSubgraph(it.getName());
-                buildSubgraph(it, sg);
-            } else {
-                if(!TYPENAME.equals(it.getName()))
-                    subgraph.addAttributeNodes(it.getName());
-            }
-        });
-
-        return subgraph;
-    };
-
-
-    protected EntityGraph<?> buildEntityGraph(Field root) {
-
-        EntityGraph<?> entityGraph = this.entityManager.createEntityGraph(entityType.getJavaType());
-
-        selections(root)
-            .forEach(it -> {
-                if(hasSelectionSet(it) 
-                		&& hasNoArguments(it) 
-                		&& isManagedType(entityType.getAttribute(it.getName()))
-                ) {
-                    Subgraph<?> sg = entityGraph.addSubgraph(it.getName());
-                    buildSubgraph(it, sg);
-                } else {
-                    if(isPersistent(entityType, it.getName()))
-                        entityGraph.addAttributeNodes(it.getName());
-                }
-            });
-
-        return entityGraph;
-    };
-
     
     protected final boolean isManagedType(Attribute<?,?> attribute) {
     	return attribute.getPersistentAttributeType() != PersistentAttributeType.EMBEDDED 


### PR DESCRIPTION
This PR removes redundant entity graph hint causing duplicate joins on the same tables. 

Fixes https://github.com/introproventures/graphql-jpa-query/issues/216

Given GraphQL query:

```
query { 
  Humans(where:{id:{EQ: "1000"}}) {
    select {
      name, homePlanet, friends { name } 
    }
  }
}
```

Then generated JPQL query

```
select distinct human 
from Human as human left join fetch human.friends as generatedAlias0 
where human.id=:param0 order by human.id asc
```

is transformed by Hibernate into SQL query:

```
    select
        human0_.id as id2_0_0_,
        character2_.id as id2_0_1_,
        human0_.name as name3_0_0_,
        human0_.favorite_droid_id as favorite6_0_0_,
        human0_.gender_code_id as gender_c7_0_0_,
        human0_.homePlanet as homePlan4_0_0_,
        character2_.name as name3_0_1_,
        character2_.primary_function as primary_5_0_1_,
        character2_.favorite_droid_id as favorite6_0_1_,
        character2_.gender_code_id as gender_c7_0_1_,
        character2_.homePlanet as homePlan4_0_1_,
        character2_.DTYPE as DTYPE1_0_1_,
        friends1_.source_id as source_i1_2_0__,
        friends1_.friend_id as friend_i2_2_0__ 
    from
        Character human0_ 
    left outer join
        character_friends friends1_ 
            on human0_.id=friends1_.source_id 
    left outer join
        Character character2_ 
            on friends1_.friend_id=character2_.id 
    where
        human0_.DTYPE='Human' 
        and human0_.id=? 
    order by
        human0_.id asc,
        character2_.name asc

```