### PR TITLE
fix(GH-220): Cannot nest multiple queries on the same table

### DIFF
--- a/graphql-jpa-query-example-model-starwars/src/main/java/com/introproventures/graphql/jpa/query/schema/model/starwars/Character.java
+++ b/graphql-jpa-query-example-model-starwars/src/main/java/com/introproventures/graphql/jpa/query/schema/model/starwars/Character.java
@@ -30,6 +30,7 @@ import javax.persistence.ManyToMany;
 import javax.persistence.OrderBy;
 
 import com.introproventures.graphql.jpa.query.annotation.GraphQLDescription;
+
 import lombok.EqualsAndHashCode;
 import lombok.Getter;
 import lombok.Setter;
@@ -40,7 +41,7 @@ import lombok.ToString;
 @Getter
 @Setter
 @ToString
-@EqualsAndHashCode(exclude={"appearsIn","friends"}) // Fixes NPE in Hibernate when initializing loaded collections #1
+@EqualsAndHashCode(exclude={"appearsIn","friends", "friendsOf"}) // Fixes NPE in Hibernate when initializing loaded collections #1
 public abstract class Character {
 
     @Id
@@ -58,6 +59,10 @@ public abstract class Character {
     @OrderBy("name ASC")
     Set<Character> friends; 
 
+    @ManyToMany(fetch=FetchType.LAZY, mappedBy = "friends")
+    @OrderBy("name ASC")
+    Set<Character> friendsOf;     
+    
     @GraphQLDescription("What Star Wars episodes does this character appear in")
     @ElementCollection(targetClass = Episode.class, fetch=FetchType.LAZY)
     @Enumerated(EnumType.ORDINAL)

--- a/graphql-jpa-query-schema/src/main/java/com/introproventures/graphql/jpa/query/schema/impl/GraphQLJpaQueryDataFetcher.java
+++ b/graphql-jpa-query-schema/src/main/java/com/introproventures/graphql/jpa/query/schema/impl/GraphQLJpaQueryDataFetcher.java
@@ -46,14 +46,12 @@ import graphql.schema.GraphQLObjectType;
 class GraphQLJpaQueryDataFetcher extends QraphQLJpaBaseDataFetcher {
 
     private boolean defaultDistinct = true;
-    private boolean isShouldClearContext = true;
 	
     protected static final String HIBERNATE_QUERY_PASS_DISTINCT_THROUGH = "hibernate.query.passDistinctThrough";
     protected static final String ORG_HIBERNATE_CACHEABLE = "org.hibernate.cacheable";
     protected static final String ORG_HIBERNATE_FETCH_SIZE = "org.hibernate.fetchSize";
     protected static final String ORG_HIBERNATE_READ_ONLY = "org.hibernate.readOnly";
     protected static final String JAVAX_PERSISTENCE_FETCHGRAPH = "javax.persistence.fetchgraph";
-    protected static final String HIBERNATE_CACHE_USE_QUERY_CACHE = "hibernate.cache.use_query_cache";
 
     private GraphQLJpaQueryDataFetcher(EntityManager entityManager, EntityType<?> entityType, boolean toManyDefaultOptional) {
         super(entityManager, entityType, toManyDefaultOptional);
@@ -62,11 +60,9 @@ class GraphQLJpaQueryDataFetcher extends QraphQLJpaBaseDataFetcher {
     public GraphQLJpaQueryDataFetcher(EntityManager entityManager, 
                                       EntityType<?> entityType, 
                                       boolean defaultDistinct,
-                                      boolean toManyDefaultOptional,
-                                      boolean isShouldClearContext) {
+                                      boolean toManyDefaultOptional) {
         super(entityManager, entityType, toManyDefaultOptional);
         this.defaultDistinct = defaultDistinct;
-        this.isShouldClearContext = isShouldClearContext;
     }
 
     public boolean isDefaultDistinct() {
@@ -123,20 +119,16 @@ class GraphQLJpaQueryDataFetcher extends QraphQLJpaBaseDataFetcher {
             // Let' try reduce overhead and disable all caching
             query.setHint(ORG_HIBERNATE_READ_ONLY, true);
             query.setHint(ORG_HIBERNATE_FETCH_SIZE, 1000);
-            query.setHint(ORG_HIBERNATE_CACHEABLE, true);
+            query.setHint(ORG_HIBERNATE_CACHEABLE, false);
             
             // Let's not pass distinct if enabled to have better performance
             if(isDistinct) {
                 query.setHint(HIBERNATE_QUERY_PASS_DISTINCT_THROUGH, false);
             }
-            
-            if(isShouldClearContext) {
-                entityManager.clear();
-            }
 
             // Let's execute query 
             List<?> resultList = query.getResultList(); 
-
+                            
             // Let's remove any duplicate references for root entities 
             if(isDistinct) {
                 resultList = resultList.stream()
@@ -247,7 +239,4 @@ class GraphQLJpaQueryDataFetcher extends QraphQLJpaBaseDataFetcher {
         }
     }
 
-    public boolean isShouldClearContext() {
-        return isShouldClearContext;
-    }
 }

--- a/graphql-jpa-query-schema/src/main/java/com/introproventures/graphql/jpa/query/schema/impl/GraphQLJpaQueryDataFetcher.java
+++ b/graphql-jpa-query-schema/src/main/java/com/introproventures/graphql/jpa/query/schema/impl/GraphQLJpaQueryDataFetcher.java
@@ -124,7 +124,6 @@ class GraphQLJpaQueryDataFetcher extends QraphQLJpaBaseDataFetcher {
             query.setHint(ORG_HIBERNATE_READ_ONLY, true);
             query.setHint(ORG_HIBERNATE_FETCH_SIZE, 1000);
             query.setHint(ORG_HIBERNATE_CACHEABLE, true);
-            query.setHint(HIBERNATE_CACHE_USE_QUERY_CACHE, true);
             
             // Let's not pass distinct if enabled to have better performance
             if(isDistinct) {

--- a/graphql-jpa-query-schema/src/main/java/com/introproventures/graphql/jpa/query/schema/impl/GraphQLJpaSchemaBuilder.java
+++ b/graphql-jpa-query-schema/src/main/java/com/introproventures/graphql/jpa/query/schema/impl/GraphQLJpaSchemaBuilder.java
@@ -332,7 +332,7 @@ public class GraphQLJpaSchemaBuilder implements GraphQLSchemaBuilder {
                                           .build()            
             )
             .fields(managedType.getAttributes().stream()
-                                               .filter(this::isValidAssociation)    
+                                               .filter(Attribute::isAssociation)
                                                .filter(this::isNotIgnored)
                                                .filter(this::isNotIgnoredFilter)
                                                .map(this::getWhereInputRelationField)
@@ -404,7 +404,7 @@ public class GraphQLJpaSchemaBuilder implements GraphQLSchemaBuilder {
                                                .collect(Collectors.toList())
             )
             .fields(managedType.getAttributes().stream()
-                                               .filter(this::isValidAssociation)    
+                                               .filter(Attribute::isAssociation)
                                                .filter(this::isNotIgnored)
                                                .filter(this::isNotIgnoredFilter)
                                                .map(this::getWhereInputRelationField)
@@ -898,11 +898,6 @@ public class GraphQLJpaSchemaBuilder implements GraphQLSchemaBuilder {
                 attribute.getPersistentAttributeType() == Attribute.PersistentAttributeType.ELEMENT_COLLECTION ||
                 attribute.getPersistentAttributeType() == Attribute.PersistentAttributeType.EMBEDDED;
     }
-
-    protected final boolean isValidAssociation(Attribute<?,?> attribute) {
-        return isOneToMany(attribute) || isToOne(attribute);
-    }
-
 
     private String getSchemaDescription(Attribute<?,?> attribute) {
         return EntityIntrospector.introspect(attribute.getDeclaringType())

--- a/graphql-jpa-query-schema/src/main/java/com/introproventures/graphql/jpa/query/schema/impl/GraphQLJpaSchemaBuilder.java
+++ b/graphql-jpa-query-schema/src/main/java/com/introproventures/graphql/jpa/query/schema/impl/GraphQLJpaSchemaBuilder.java
@@ -114,8 +114,7 @@ public class GraphQLJpaSchemaBuilder implements GraphQLSchemaBuilder {
     private boolean isUseDistinctParameter = false;
     private boolean isDefaultDistinct = true;
     // the many end is a collection, and it is always optional by default (empty collection)
-    private boolean toManyDefaultOptional = true;
-    private boolean isShouldClearContext = true;
+    private boolean toManyDefaultOptional = true; 
 
     public GraphQLJpaSchemaBuilder(EntityManager entityManager) {
         this.entityManager = entityManager;
@@ -207,8 +206,7 @@ public class GraphQLJpaSchemaBuilder implements GraphQLSchemaBuilder {
                 .dataFetcher(new GraphQLJpaQueryDataFetcher(entityManager, 
                                                             entityType, 
                                                             isDefaultDistinct, 
-                                                            toManyDefaultOptional,
-                                                            isShouldClearContext))
+                                                            toManyDefaultOptional))
                 .argument(paginationArgument)
                 .argument(getWhereArgument(entityType));
         if (isUseDistinctParameter) {
@@ -1164,10 +1162,6 @@ public class GraphQLJpaSchemaBuilder implements GraphQLSchemaBuilder {
     
     public void setToManyDefaultOptional(boolean toManyDefaultOptional) {
         this.toManyDefaultOptional = toManyDefaultOptional;
-    }
-
-    public void setShouldClearContext(boolean isShouldClearContext) {
-        this.isShouldClearContext = isShouldClearContext;
     }
     
 }

--- a/graphql-jpa-query-schema/src/main/java/com/introproventures/graphql/jpa/query/schema/impl/GraphQLJpaSchemaBuilder.java
+++ b/graphql-jpa-query-schema/src/main/java/com/introproventures/graphql/jpa/query/schema/impl/GraphQLJpaSchemaBuilder.java
@@ -853,7 +853,9 @@ public class GraphQLJpaSchemaBuilder implements GraphQLSchemaBuilder {
             Type foreignType = ((PluralAttribute) attribute).getElementType();
             
             if(foreignType.getPersistenceType() == Type.PersistenceType.BASIC) {
-            	return new GraphQLList(getGraphQLTypeFromJavaType(foreignType.getJavaType()));
+                GraphQLType graphQLType = getGraphQLTypeFromJavaType(foreignType.getJavaType());
+                
+            	return input ? graphQLType : new GraphQLList(graphQLType);
             }
         }
 

--- a/graphql-jpa-query-schema/src/main/java/com/introproventures/graphql/jpa/query/schema/impl/GraphQLJpaSchemaBuilder.java
+++ b/graphql-jpa-query-schema/src/main/java/com/introproventures/graphql/jpa/query/schema/impl/GraphQLJpaSchemaBuilder.java
@@ -114,7 +114,8 @@ public class GraphQLJpaSchemaBuilder implements GraphQLSchemaBuilder {
     private boolean isUseDistinctParameter = false;
     private boolean isDefaultDistinct = true;
     // the many end is a collection, and it is always optional by default (empty collection)
-    private boolean toManyDefaultOptional = true; 
+    private boolean toManyDefaultOptional = true;
+    private boolean isShouldClearContext = true;
 
     public GraphQLJpaSchemaBuilder(EntityManager entityManager) {
         this.entityManager = entityManager;
@@ -206,7 +207,8 @@ public class GraphQLJpaSchemaBuilder implements GraphQLSchemaBuilder {
                 .dataFetcher(new GraphQLJpaQueryDataFetcher(entityManager, 
                                                             entityType, 
                                                             isDefaultDistinct, 
-                                                            toManyDefaultOptional))
+                                                            toManyDefaultOptional,
+                                                            isShouldClearContext))
                 .argument(paginationArgument)
                 .argument(getWhereArgument(entityType));
         if (isUseDistinctParameter) {
@@ -1162,6 +1164,10 @@ public class GraphQLJpaSchemaBuilder implements GraphQLSchemaBuilder {
     
     public void setToManyDefaultOptional(boolean toManyDefaultOptional) {
         this.toManyDefaultOptional = toManyDefaultOptional;
+    }
+
+    public void setShouldClearContext(boolean isShouldClearContext) {
+        this.isShouldClearContext = isShouldClearContext;
     }
     
 }

--- a/graphql-jpa-query-schema/src/test/java/com/introproventures/graphql/jpa/query/schema/GraphQLExecutorListCriteriaTests.java
+++ b/graphql-jpa-query-schema/src/test/java/com/introproventures/graphql/jpa/query/schema/GraphQLExecutorListCriteriaTests.java
@@ -20,8 +20,6 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 import javax.persistence.EntityManager;
 
-import com.introproventures.graphql.jpa.query.schema.impl.GraphQLJpaExecutor;
-import com.introproventures.graphql.jpa.query.schema.impl.GraphQLJpaSchemaBuilder;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -32,6 +30,9 @@ import org.springframework.context.annotation.Bean;
 import org.springframework.test.context.TestPropertySource;
 import org.springframework.test.context.junit4.SpringRunner;
 import org.springframework.util.Assert;
+
+import com.introproventures.graphql.jpa.query.schema.impl.GraphQLJpaExecutor;
+import com.introproventures.graphql.jpa.query.schema.impl.GraphQLJpaSchemaBuilder;
 
 
 @RunWith(SpringRunner.class)
@@ -75,6 +76,45 @@ public class GraphQLExecutorListCriteriaTests {
                 "        genre: {IN: NOVEL}" + 
                 "        title: {LIKE: \"War\"}" +
                 "      }]" +
+                "    }" + 
+                "  }) {" + 
+                "    select {" + 
+                "      id" + 
+                "      name" + 
+                "      books {" + 
+                "        id" + 
+                "        title" + 
+                "        genre" + 
+                "      }" + 
+                "    }" + 
+                "  }" +
+                "}";
+
+        String expected = "{Authors={select=["
+                + "{id=1, name=Leo Tolstoy, books=["
+                +   "{id=2, title=War and Peace, genre=NOVEL}"
+                + "]"
+                + "}]}}";
+
+        //when:
+        Object result = executor.execute(query).getData();
+
+        //then:
+        assertThat(result.toString()).isEqualTo(expected);
+    }    
+    
+    @Test
+    public void queryWithWhereInsideOneToManyRelationsWithExplictANDEXISTS() {
+        //given:
+        String query = "query { "
+                + "Authors(where: {" +
+                "    EXISTS: {" +
+                "      books: {" + 
+                "        AND: [{ "+
+                "          genre: {IN: NOVEL}" + 
+                "          title: {LIKE: \"War\"}" +
+                "        }]" +
+                "      }" + 
                 "    }" + 
                 "  }) {" + 
                 "    select {" + 
@@ -437,8 +477,8 @@ public class GraphQLExecutorListCriteriaTests {
 
         String expected = "{Authors={select=["
                 + "{id=1, name=Leo Tolstoy, books=["
-                +   "{id=2, title=War and Peace}, "
-                +   "{id=3, title=Anna Karenina}]}"
+                +   "{id=2, title=War and Peace}"
+                + "]}"
                 + "]}}";
 
         //when:
@@ -479,7 +519,8 @@ public class GraphQLExecutorListCriteriaTests {
         String expected = "{Authors={select=["
                 + "{id=1, name=Leo Tolstoy, books=["
                 +   "{id=2, title=War and Peace}, "
-                +   "{id=3, title=Anna Karenina}]}"
+                +   "{id=3, title=Anna Karenina}]}, "
+                + "{id=8, name=Igor Dianov, books=[]}"
                 + "]}}";
 
         //when:

--- a/graphql-jpa-query-schema/src/test/java/com/introproventures/graphql/jpa/query/schema/StarwarsQueryExecutorTests.java
+++ b/graphql-jpa-query-schema/src/test/java/com/introproventures/graphql/jpa/query/schema/StarwarsQueryExecutorTests.java
@@ -1710,18 +1710,18 @@ public class StarwarsQueryExecutorTests {
         
         //given:
         String query = "{" + 
-                "  Droids(where: {\n" + 
-                "    friends: {friends:{name:{EQ:\"Leia Organa\"}}}\n" + 
-                "  }) {\n" + 
-                "     select {\n" + 
-                "      name\n" + 
-                "      friends {\n" + 
-                "        name\n" + 
-                "        friends {\n" + 
-                "          name\n" + 
-                "        }\n" + 
-                "      }\n" + 
-                "    } \n" + 
+                "  Droids(where: {" + 
+                "    friends: {friends:{name:{EQ:\"Leia Organa\"}}}" + 
+                "  }) {" + 
+                "     select {" + 
+                "      name" + 
+                "      friends {" + 
+                "        name" + 
+                "        friends {" + 
+                "          name" + 
+                "        }" + 
+                "      }" + 
+                "    } " + 
                 "  } " + 
                 "}";
 
@@ -1751,18 +1751,18 @@ public class StarwarsQueryExecutorTests {
         
         //given:
         String query = "{" + 
-                "  Droids(where: {\n" + 
-                "    friends: {EXISTS: {friends:{name:{EQ:\"Leia Organa\"}}}}\n" + 
-                "  }) {\n" + 
-                "     select {\n" + 
-                "      name\n" + 
-                "      friends {\n" + 
-                "        name\n" + 
-                "        friends {\n" + 
-                "          name\n" + 
-                "        }\n" + 
-                "      }\n" + 
-                "    } \n" + 
+                "  Droids(where: {" + 
+                "    friends: {EXISTS: {friends:{name:{EQ:\"Leia Organa\"}}}}" + 
+                "  }) {" + 
+                "     select {" + 
+                "      name" + 
+                "      friends {" + 
+                "        name" + 
+                "        friends {" + 
+                "          name" + 
+                "        }" + 
+                "      }" + 
+                "    } " + 
                 "  } " + 
                 "}";
 

--- a/graphql-jpa-query-schema/src/test/java/com/introproventures/graphql/jpa/query/schema/StarwarsQueryExecutorTests.java
+++ b/graphql-jpa-query-schema/src/test/java/com/introproventures/graphql/jpa/query/schema/StarwarsQueryExecutorTests.java
@@ -1614,5 +1614,91 @@ public class StarwarsQueryExecutorTests {
         assertThat(result.toString()).isEqualTo(expected);
     }       
         
+    @Test
+    public void queryEmbeddedWhereWithNestedPluralAssociationsNOT_EXISTS() {
+        
+        //given:
+        String query = "{" + 
+                "  Droids {" + 
+                "     select {" + 
+                "      name" + 
+                "      friends(where:{" + 
+                "         NOT_EXISTS: {friends:{name:{EQ:\"Leia Organa\"}}}" + 
+                "      }) {" + 
+                "        name" + 
+                "        friends {" + 
+                "          name" + 
+                "        }" + 
+                "      }" + 
+                "    } " + 
+                "  }" + 
+                "}";
+
+        String expected = "{Droids={select=["
+                + "{name=C-3PO, friends=["
+                +   "{name=Leia Organa, friends=["
+                +       "{name=C-3PO}, "
+                +       "{name=Han Solo}, "
+                +       "{name=Luke Skywalker}, "
+                +       "{name=R2-D2}"
+                +   "]}]}, "
+                + "{name=R2-D2, friends=["
+                +   "{name=Leia Organa, friends=["
+                +       "{name=C-3PO}, "
+                +       "{name=Han Solo}, "
+                +       "{name=Luke Skywalker}, "
+                +       "{name=R2-D2}]}"
+                + "]}"
+                + "]}}";
+
+        //when:
+        Object result = executor.execute(query).getData();
+
+        //then:
+        assertThat(result.toString()).isEqualTo(expected);
+    }      
     
+    @Test
+    public void queryEmbeddedWhereWithRecursivePluralAssociationsNOT_EXISTS() {
+        
+        //given:
+        String query = "{" + 
+                "  Droids(where: {" + 
+                "    friends: {NOT_EXISTS: {friends:{name:{EQ:\"Leia Organa\"}}}}" + 
+                "  }) {" + 
+                "     select {" + 
+                "      name" + 
+                "      friends {" + 
+                "        name" + 
+                "        friends {" + 
+                "          name" + 
+                "        }" + 
+                "      }" + 
+                "    } " + 
+                "  }" + 
+                "}";
+
+        String expected = "{Droids={select=["
+                + "{name=C-3PO, friends=["
+                +   "{name=Leia Organa, friends=["
+                +       "{name=C-3PO}, "
+                +       "{name=Han Solo}, "
+                +       "{name=Luke Skywalker}, "
+                +       "{name=R2-D2}"
+                +   "]}]}, "
+                + "{name=R2-D2, friends=["
+                +   "{name=Leia Organa, friends=["
+                +       "{name=C-3PO}, "
+                +       "{name=Han Solo}, "
+                +       "{name=Luke Skywalker}, "
+                +       "{name=R2-D2}]}"
+                + "]}"
+                + "]}}";
+
+        //when:
+        Object result = executor.execute(query).getData();
+
+        //then:
+        assertThat(result.toString()).isEqualTo(expected);
+    }      
 }

--- a/graphql-jpa-query-schema/src/test/java/com/introproventures/graphql/jpa/query/schema/StarwarsQueryExecutorTests.java
+++ b/graphql-jpa-query-schema/src/test/java/com/introproventures/graphql/jpa/query/schema/StarwarsQueryExecutorTests.java
@@ -1079,6 +1079,55 @@ public class StarwarsQueryExecutorTests {
                 +   "}"
                 + "}, "
                 + "friends=["
+                +   "{name=Leia Organa}"
+                + "]}"
+                + "]}}";
+
+        //when:
+        Object result = executor.execute(query).getData();
+
+        //then:
+        assertThat(result.toString()).isEqualTo(expected);
+    }
+
+    @Test
+    public void queryFilterNestedManyToManyRelationCriteriaWithEXISTS() {
+        //given:
+        String query = "query {" +
+                "    Humans(where: {" +
+                "      EXISTS: {" +
+                "        friends: { name: { LIKE: \"Leia\" } } " + 
+                "        favoriteDroid: { primaryFunction: { function: { EQ: \"Protocol\" } } }" +
+                "      }"+
+                "    }) {" + 
+                "      select {" + 
+                "        id" + 
+                "        name" + 
+                "        homePlanet" + 
+                "        favoriteDroid {" + 
+                "          name" + 
+                "          primaryFunction {" + 
+                "            function" + 
+                "          }" + 
+                "        }" + 
+                "        friends {" + 
+                "          name" + 
+                "        }" + 
+                "      }" + 
+                "    }  " +
+                "}";
+
+        String expected = "{Humans={select=[{"
+                + "id=1000, "
+                + "name=Luke Skywalker, "
+                + "homePlanet=Tatooine, "
+                + "favoriteDroid={"
+                +   "name=C-3PO, "
+                +   "primaryFunction={"
+                +       "function=Protocol"
+                +   "}"
+                + "}, "
+                + "friends=["
                 +   "{name=C-3PO}, "
                 +   "{name=Han Solo}, "
                 +   "{name=Leia Organa}, "
@@ -1278,8 +1327,7 @@ public class StarwarsQueryExecutorTests {
                 + "{id=1000, name=Luke Skywalker}, "
                 + "{id=1001, name=Darth Vader}, "
                 + "{id=1002, name=Han Solo}, "
-                + "{id=1003, name=Leia Organa}, "
-                + "{id=1004, name=Wilhuff Tarkin}"
+                + "{id=1003, name=Leia Organa}"
                 + "]}}";
 
         //when:
@@ -1502,5 +1550,69 @@ public class StarwarsQueryExecutorTests {
         //then:
         assertThat(result.toString()).isEqualTo(expected);
     }       
+
+    @Test
+    public void queryEmbeddedWhereWithPluralAssociations() {
+        
+        //given:
+        String query = "{ "
+                + "Droids {" + 
+                "    select {" + 
+                "      name" + 
+                "      friends(where:{" + 
+                "        NOT_EXISTS:{ friends:{name:{EQ:\"R2-D2\"}}}" + 
+                "      }) {" + 
+                "        name" + 
+                "        friends {" + 
+                "          name" + 
+                "        }" + 
+                "      }" + 
+                "    } " + 
+                "  } " + 
+                "}";
+
+        String expected = "{Droids={select=["
+                + "{name=C-3PO, friends=["
+                +   "{name=R2-D2, friends=["
+                +       "{name=Han Solo}, "
+                +       "{name=Leia Organa}, "
+                +       "{name=Luke Skywalker}"
+                +   "]}"
+                + "]}]}}";
+
+        //when:
+        Object result = executor.execute(query).getData();
+
+        //then:
+        assertThat(result.toString()).isEqualTo(expected);
+    }       
+    
+    @Test
+    public void queryEmbeddedWhereWithPluralAssociationsNOT_EXISTS() {
+        
+        //given:
+        String query = "{" + 
+                "  Humans {" + 
+                "    select {" + 
+                "      name" + 
+                "      friends(where: {appearsIn: {NIN: [THE_FORCE_AWAKENS]}}) {" + 
+                "        name" + 
+                "      }" + 
+                "    }" + 
+                "  }" + 
+                "}";
+
+        String expected = "{Humans={select=["
+                + "{name=Darth Vader, friends=[{name=Wilhuff Tarkin}]}, "
+                + "{name=Wilhuff Tarkin, friends=[{name=Darth Vader}]}"
+                + "]}}";
+
+        //when:
+        Object result = executor.execute(query).getData();
+
+        //then:
+        assertThat(result.toString()).isEqualTo(expected);
+    }       
+        
     
 }

--- a/graphql-jpa-query-schema/src/test/java/com/introproventures/graphql/jpa/query/schema/StarwarsQueryExecutorTests.java
+++ b/graphql-jpa-query-schema/src/test/java/com/introproventures/graphql/jpa/query/schema/StarwarsQueryExecutorTests.java
@@ -27,7 +27,6 @@ import javax.persistence.EntityManager;
 import javax.persistence.Query;
 import javax.transaction.Transactional;
 
-import org.junit.Ignore;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -1740,21 +1739,19 @@ public class StarwarsQueryExecutorTests {
         assertThat(result.toString()).isEqualTo(expected);
     }   
     
-    // FIXME
     @Test
-    @Ignore
-    public void queryEmbeddedWhereWithRecursivePluralAssociationsBug() {
+    public void queryEmbeddedWhereWithManyToManyAssociations() {
         
         //given:
         String query = "{" + 
                 "  Droids(where: {" + 
-                "    friends: {friends:{name:{EQ:\"Leia Organa\"}}}" + 
+                "    friends: {friendsOf:{name:{EQ:\"Leia Organa\"}}}" + 
                 "  }) {" + 
                 "     select {" + 
                 "      name" + 
                 "      friends {" + 
                 "        name" + 
-                "        friends {" + 
+                "        friendsOf {" + 
                 "          name" + 
                 "        }" + 
                 "      }" + 
@@ -1764,14 +1761,15 @@ public class StarwarsQueryExecutorTests {
 
         String expected = "{Droids={select=["
                 + "{name=C-3PO, friends=["
-                +   "{name=Han Solo, friends=[{name=Leia Organa}]}, "
-                +   "{name=Luke Skywalker, friends=[{name=Leia Organa}]}, "
-                +   "{name=R2-D2, friends=[{name=Leia Organa}" // should include only Leia Organa as friends
-                + "]}]}, "
+                +   "{name=Han Solo, friendsOf=[{name=Leia Organa}]}, "
+                +   "{name=Luke Skywalker, friendsOf=[{name=Leia Organa}]}, "
+                +   "{name=R2-D2, friendsOf=[{name=Leia Organa}]}"
+                + "]}, "
                 + "{name=R2-D2, friends=["
-                //+   "{name=Leia Organa, friends=[{name=C-3PO}, {name=Han Solo}, {name=Luke Skywalker}, {name=R2-D2}]}, " // should not be in the result
-                +   "{name=Han Solo, friends=[{name=Leia Organa}]}, "
-                +   "{name=Luke Skywalker, friends=[{name=Leia Organa}]}]}]}}";
+                +   "{name=Han Solo, friendsOf=[{name=Leia Organa}]}, "
+                +   "{name=Luke Skywalker, friendsOf=[{name=Leia Organa}]}"
+                + "]}"
+                + "]}}";
 
         //when:
         Object result = executor.execute(query).getData();
@@ -1780,22 +1778,17 @@ public class StarwarsQueryExecutorTests {
         assertThat(result.toString()).isEqualTo(expected);
     }  
     
-    
-    // FIXME
     @Test
-    @Ignore
-    public void queryEmbeddedWhereWithRecursivePluralAssociationsEXISTSBug() {
+    public void queryEmbeddedWhereWithManyToManyAssociationsUsingEXISTS() {
         
         //given:
         String query = "{" + 
-                "  Droids(where: {" + 
-                "    friends: {EXISTS: {friends:{name:{EQ:\"Leia Organa\"}}}}" + 
-                "  }) {" + 
+                "  Droids {" + 
                 "     select {" + 
                 "      name" + 
-                "      friends {" + 
+                "      friends(where: {EXISTS: {friendsOf:{name:{EQ:\"Leia Organa\"}}}}) {" + 
                 "        name" + 
-                "        friends {" + 
+                "        friendsOf {" + 
                 "          name" + 
                 "        }" + 
                 "      }" + 
@@ -1805,14 +1798,12 @@ public class StarwarsQueryExecutorTests {
 
         String expected = "{Droids={select=["
                 + "{name=C-3PO, friends=["
-                +   "{name=Han Solo, friends=[{name=Leia Organa}, {name=Luke Skywalker}, {name=R2-D2}]}, "
-                +   "{name=Luke Skywalker, friends=[{name=C-3PO}, {name=Han Solo}, {name=Leia Organa}, {name=R2-D2}]}, "
-                +   "{name=R2-D2, friends=[{name=Han Solo}, {name=Leia Organa}, {name=Luke Skywalker}]}"
+                +   "{name=Han Solo, friendsOf=[{name=C-3PO}, {name=Leia Organa}, {name=Luke Skywalker}, {name=R2-D2}]}, "
+                +   "{name=Luke Skywalker, friendsOf=[{name=C-3PO}, {name=Han Solo}, {name=Leia Organa}, {name=R2-D2}]}, "
+                +   "{name=R2-D2, friendsOf=[{name=C-3PO}, {name=Han Solo}, {name=Leia Organa}, {name=Luke Skywalker}]}"
                 + "]}, "
-                + "{name=R2-D2, friends=["
-                +   "{name=Han Solo, friends=[{name=Leia Organa}, {name=Luke Skywalker}, {name=R2-D2}]}, "
-                //+   "{name=Leia Organa, friends=[{name=C-3PO}, {name=Han Solo}, {name=Luke Skywalker}, {name=R2-D2}]}, " // should not be in the result 
-                +   "{name=Luke Skywalker, friends=[{name=C-3PO}, {name=Han Solo}, {name=Leia Organa}, {name=R2-D2}]}"
+                +   "{name=R2-D2, friends=[{name=Han Solo, friendsOf=[{name=C-3PO}, {name=Leia Organa}, {name=Luke Skywalker}, {name=R2-D2}]}, "
+                +   "{name=Luke Skywalker, friendsOf=[{name=C-3PO}, {name=Han Solo}, {name=Leia Organa}, {name=R2-D2}]}"
                 + "]}"
                 + "]}}";
 

--- a/graphql-jpa-query-schema/src/test/java/com/introproventures/graphql/jpa/query/schema/StarwarsQueryExecutorTests.java
+++ b/graphql-jpa-query-schema/src/test/java/com/introproventures/graphql/jpa/query/schema/StarwarsQueryExecutorTests.java
@@ -1323,7 +1323,7 @@ public class StarwarsQueryExecutorTests {
                 "  Humans {" + 
                 "    select {" + 
                 "      name" + 
-                "      friends(where: {appearsIn: {EQ: [THE_FORCE_AWAKENS]}}) {" + 
+                "      friends(where: {appearsIn: {EQ: THE_FORCE_AWAKENS}}) {" + 
                 "        name" + 
                 "      }" + 
                 "    }" + 
@@ -1430,7 +1430,7 @@ public class StarwarsQueryExecutorTests {
                 "  Humans {" + 
                 "    select {" + 
                 "      name" + 
-                "      friends(where: {appearsIn: {NE: [THE_FORCE_AWAKENS]}}) {" + 
+                "      friends(where: {appearsIn: {NE: THE_FORCE_AWAKENS}}) {" + 
                 "        name" + 
                 "      }" + 
                 "    }" + 


### PR DESCRIPTION
This PR fixes the query and mapping problem with nested recursive queries in where search criterias with `@ManyToMany` mapping on Character entity.  

For example, when mapping "author" / "book" as many-to-many, we need "authors" collection on Book and "books" collection on Author. In our case,  "Character" entity represents both ends of a relationship; so we need "friends to" and "friend of" collections. 

We can still use the same association table, but note that friendsOf is mappedBy `friends`. 

```java
@Entity
@GraphQLDescription("Abstract representation of an entity in the Star Wars Universe")
@Getter
@Setter
@ToString
@EqualsAndHashCode(exclude={"appearsIn","friends", "friendsOf"}) // Fixes NPE in Hibernate when initializing loaded collections #1
public abstract class Character {

    @Id
    @GraphQLDescription("Primary Key for the Character Class")
    String id;

    @GraphQLDescription("Name of the character")
    String name;

    @GraphQLDescription("Who are the known friends to this character")
    @ManyToMany(fetch=FetchType.LAZY)
    @JoinTable(name="character_friends",
            joinColumns=@JoinColumn(name="source_id", referencedColumnName="id"),
            inverseJoinColumns=@JoinColumn(name="friend_id", referencedColumnName="id"))
    @OrderBy("name ASC")
    Set<Character> friends; 

    @GraphQLDescription("Who are the known friends of this character")
    @ManyToMany(fetch=FetchType.LAZY, mappedBy = "friends")
    @OrderBy("name ASC")
    Set<Character> friendsOf;     
    
    @GraphQLDescription("What Star Wars episodes does this character appear in")
    @ElementCollection(targetClass = Episode.class, fetch=FetchType.LAZY)
    @Enumerated(EnumType.ORDINAL)
    @OrderBy
    Set<Episode> appearsIn;
    
    Character() {}

}
```

The "friends" and "friendsOf" collections may or may not match (depending on whether "friendship" is mutual or not).

After fixing the relationship, the following query returns correct result:
```
query {
  Droids {
     select {
      name
      friends(where: {friendsOf:{name: {EQ: "Luke Skywalker"}}}) {
        name
        friendsOf {
          name
        }
      }
    }
  }
}
```

**Generated JPQL:** 
```
select distinct droid from Droid as droid 
left join fetch droid.friends as generatedAlias0 
left join fetch generatedAlias0.friendsOf as generatedAlias1 
where generatedAlias1.name='Luke Skywalker'
order by droid.id asc
```

**Result:**
```json
{
  "data": {
    "Droids": {
      "select": [
        {
          "name": "C-3PO",
          "friends": [
            {
              "name": "Han Solo",
              "friendsOf": [
                {
                  "name": "Luke Skywalker"
                }
              ]
            },
            {
              "name": "Leia Organa",
              "friendsOf": [
                {
                  "name": "Luke Skywalker"
                }
              ]
            },
            {
              "name": "R2-D2",
              "friendsOf": [
                {
                  "name": "Luke Skywalker"
                }
              ]
            }
          ]
        },
        {
          "name": "R2-D2",
          "friends": [
            {
              "name": "Han Solo",
              "friendsOf": [
                {
                  "name": "Luke Skywalker"
                }
              ]
            },
            {
              "name": "Leia Organa",
              "friendsOf": [
                {
                  "name": "Luke Skywalker"
                }
              ]
            }
          ]
        }
      ]
    }
  }
}
```

In the process, I have realized that regular root where expressions were adding extra joins instead of reusing existing fetch joins from the selection graph. I have fixed that and also enabled EXISTS predicate expressions on all relations to provide support for the previous behavior using subsquery expressions, i.e.

**with WHERE**
```java
   @Test
    public void queryAuthorBooksWithExplictOptional() {
        //given
        String query = "query { "
                + "Authors(" + 
                "    where: {" + 
                "      books: {" + 
                "        title: {LIKE: \"War\"}" + 
                "      }" + 
                "    }" + 
                "  ) {" + 
                "    select {" + 
                "      id" + 
                "      name" + 
                "      books(optional: true) {" + 
                "        id" + 
                "        title(orderBy: ASC)" + 
                "        genre" + 
                "      }" + 
                "    }" + 
                "  }"
                + "}";
        
        String expected = "{Authors={select=["
                + "{id=1, name=Leo Tolstoy, books=["
                + "{id=2, title=War and Peace, genre=NOVEL}]}"
                + "]}}";

        //when
        Object result = executor.execute(query).getData();

        // then
        assertThat(result.toString()).isEqualTo(expected);
    }
```
**With WHERE EXISTS**
```java
   @Test
    public void queryAuthorBooksWithExplictOptionalEXISTS() {
        //given
        String query = "query { "
                + "Authors(" + 
                "    where: {" +
                "      EXISTS: {" +
                "        books: {" + 
                "          title: {LIKE: \"War\"}" + 
                "        }" + 
                "      }" + 
                "    }" + 
                "  ) {" + 
                "    select {" + 
                "      id" + 
                "      name" + 
                "      books(optional: true) {" + 
                "        id" + 
                "        title(orderBy: ASC)" + 
                "        genre" + 
                "      }" + 
                "    }" + 
                "  }"
                + "}";
        
        String expected = "{Authors={select=["
                + "{id=1, name=Leo Tolstoy, books=[" 
                +    "{id=3, title=Anna Karenina, genre=NOVEL}, " +
                +    "{id=2, title=War and Peace, genre=NOVEL}]}"
                + "]}}";

        //when
        Object result = executor.execute(query).getData();

        // then
        assertThat(result.toString()).isEqualTo(expected);
    }    
```
It also fixes the problem with double wrapping of plural attribute types in GraphQL list type.

So, to summarize, all where root criteria expressions will now apply restrictions on the fetch joins. It will make results of the query filtered using joins and filter results in collections. 

Count queries with apply restrictions on regular joins instead of fetch join for better performance.

There is expanded support to use EXISTS subquery for all relationship types to bridge for the old where criteria expressions. You can see changes in the tests

Fixes https://github.com/introproventures/graphql-jpa-query/issues/220