### PR TITLE
feat(GH-226): Support logging of the generated JPQL query string with debug log level 

### DIFF
--- a/graphql-jpa-query-example-merge/src/main/resources/application.yml
+++ b/graphql-jpa-query-example-merge/src/main/resources/application.yml
@@ -31,3 +31,7 @@ books:
   username: sa
   password: 
   driverClassName: org.h2.Driver
+
+logging:
+  level:
+    com.introproventures.graphql.jpa.query.schema: DEBUG

--- a/graphql-jpa-query-schema/src/main/java/com/introproventures/graphql/jpa/query/schema/impl/GraphQLJpaQueryDataFetcher.java
+++ b/graphql-jpa-query-schema/src/main/java/com/introproventures/graphql/jpa/query/schema/impl/GraphQLJpaQueryDataFetcher.java
@@ -256,11 +256,11 @@ class GraphQLJpaQueryDataFetcher extends QraphQLJpaBaseDataFetcher {
             java.lang.reflect.Field queryStringField = ReflectionUtil.getField(queryImpl.getClass(),
                                                                                "queryString");
                                                     
-            if(!queryStringField.canAccess(queryImpl)) {        
-                ReflectionUtil.forceAccess(queryStringField);
-            }
+            ReflectionUtil.forceAccess(queryStringField);
             
-            return String.class.cast(queryStringField.get(queryImpl));
+            return queryStringField.get(queryImpl)
+                                   .toString();
+            
         } catch (Exception ignored) {
             logger.error("Error getting JPQL string", ignored);
         }

--- a/graphql-jpa-query-schema/src/main/java/com/introproventures/graphql/jpa/query/schema/impl/GraphQLJpaQueryDataFetcher.java
+++ b/graphql-jpa-query-schema/src/main/java/com/introproventures/graphql/jpa/query/schema/impl/GraphQLJpaQueryDataFetcher.java
@@ -133,7 +133,7 @@ class GraphQLJpaQueryDataFetcher extends QraphQLJpaBaseDataFetcher {
                 query.setHint(HIBERNATE_QUERY_PASS_DISTINCT_THROUGH, false);
             }
             if (logger.isDebugEnabled()) {
-                logger.info("JPQL Query String: {}", getJPQLQueryString(query));
+                logger.info("\nGraphQL JPQL Query String:\n    {}", getJPQLQueryString(query));
             }
 
             // Let's execute query 

--- a/graphql-jpa-query-schema/src/test/resources/application.properties
+++ b/graphql-jpa-query-schema/src/test/resources/application.properties
@@ -1,0 +1,1 @@
+logging.level.com.introproventures.graphql.jpa.query.schema=DEBUG


### PR DESCRIPTION
Fixes https://github.com/introproventures/graphql-jpa-query/issues/226

Configured by DEBUG logging level on `com.introproventures.graphql.jpa.query.schema` package.

```
logging:
  level:
    com.introproventures.graphql.jpa.query.schema: DEBUG
```

Then, log output will produce:

```
2019-12-14 17:27:36.865  INFO 5868 --- [nio-8080-exec-8] c.i.g.j.q.s.i.GraphQLJpaQueryDataFetcher : 
GraphQL JPQL Query String:
    select distinct droid from Droid as droid left join fetch droid.friends as generatedAlias0 left join fetch generatedAlias0.friendsOf as generatedAlias1 where generatedAlias1.name=:param0 order by droid.id asc
```