### PR TITLE
fix(GH-225): Configure shared entity manager for multiple data sources example

### DIFF
--- a/graphql-jpa-query-example-merge/src/main/java/com/introproventures/graphql/jpa/query/example/books/BooksSchemaConfiguration.java
+++ b/graphql-jpa-query-example-merge/src/main/java/com/introproventures/graphql/jpa/query/example/books/BooksSchemaConfiguration.java
@@ -7,11 +7,6 @@ import javax.persistence.EntityManager;
 import javax.persistence.EntityManagerFactory;
 import javax.sql.DataSource;
 
-import com.introproventures.graphql.jpa.query.autoconfigure.GraphQLJpaQueryProperties;
-import com.introproventures.graphql.jpa.query.autoconfigure.GraphQLSchemaConfigurer;
-import com.introproventures.graphql.jpa.query.autoconfigure.GraphQLShemaRegistration;
-import com.introproventures.graphql.jpa.query.schema.impl.GraphQLJpaSchemaBuilder;
-import com.introproventures.graphql.jpa.query.schema.model.book.Book;
 import org.hibernate.cfg.AvailableSettings;
 import org.hibernate.dialect.H2Dialect;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -26,6 +21,13 @@ import org.springframework.core.io.ResourceLoader;
 import org.springframework.jdbc.datasource.init.DataSourceInitializer;
 import org.springframework.jdbc.datasource.init.ResourceDatabasePopulator;
 import org.springframework.orm.jpa.LocalContainerEntityManagerFactoryBean;
+import org.springframework.orm.jpa.support.SharedEntityManagerBean;
+
+import com.introproventures.graphql.jpa.query.autoconfigure.GraphQLJpaQueryProperties;
+import com.introproventures.graphql.jpa.query.autoconfigure.GraphQLSchemaConfigurer;
+import com.introproventures.graphql.jpa.query.autoconfigure.GraphQLShemaRegistration;
+import com.introproventures.graphql.jpa.query.schema.impl.GraphQLJpaSchemaBuilder;
+import com.introproventures.graphql.jpa.query.schema.model.book.Book;
 
 @Configuration
 public class BooksSchemaConfiguration {
@@ -39,7 +41,6 @@ public class BooksSchemaConfiguration {
     }    
      
     @Bean
-    @Qualifier("bookEntityManager")
     public LocalContainerEntityManagerFactoryBean bookEntityManagerFactory(
             EntityManagerFactoryBuilder builder) {
         Map<String, Object> properties = new HashMap<>();
@@ -71,6 +72,14 @@ public class BooksSchemaConfiguration {
         return dataSourceInitializer;
     }
     
+    
+    @Bean 
+    public SharedEntityManagerBean bookEntityManager(EntityManagerFactory bookEntityManagerFactory) {
+        SharedEntityManagerBean bean =  new SharedEntityManagerBean();
+        bean.setEntityManagerFactory(bookEntityManagerFactory);
+        
+        return bean;
+    }
 
     @Configuration
     public static class GraphQLJpaQuerySchemaConfigurer implements GraphQLSchemaConfigurer {
@@ -80,8 +89,8 @@ public class BooksSchemaConfiguration {
         @Autowired
         private GraphQLJpaQueryProperties properties;
 
-        public GraphQLJpaQuerySchemaConfigurer(@Qualifier("bookEntityManager") EntityManagerFactory entityManager) {
-            this.entityManager = entityManager.createEntityManager();
+        public GraphQLJpaQuerySchemaConfigurer(EntityManager bookEntityManager) {
+            this.entityManager = bookEntityManager;
         }
 
         @Override

--- a/graphql-jpa-query-example-merge/src/main/java/com/introproventures/graphql/jpa/query/example/starwars/StarwarsSchemaConfiguration.java
+++ b/graphql-jpa-query-example-merge/src/main/java/com/introproventures/graphql/jpa/query/example/starwars/StarwarsSchemaConfiguration.java
@@ -7,10 +7,6 @@ import javax.persistence.EntityManager;
 import javax.persistence.EntityManagerFactory;
 import javax.sql.DataSource;
 
-import com.introproventures.graphql.jpa.query.autoconfigure.GraphQLSchemaConfigurer;
-import com.introproventures.graphql.jpa.query.autoconfigure.GraphQLShemaRegistration;
-import com.introproventures.graphql.jpa.query.schema.impl.GraphQLJpaSchemaBuilder;
-import com.introproventures.graphql.jpa.query.schema.model.starwars.Droid;
 import org.hibernate.cfg.AvailableSettings;
 import org.hibernate.dialect.H2Dialect;
 import org.springframework.beans.factory.annotation.Qualifier;
@@ -25,6 +21,12 @@ import org.springframework.core.io.ResourceLoader;
 import org.springframework.jdbc.datasource.init.DataSourceInitializer;
 import org.springframework.jdbc.datasource.init.ResourceDatabasePopulator;
 import org.springframework.orm.jpa.LocalContainerEntityManagerFactoryBean;
+import org.springframework.orm.jpa.support.SharedEntityManagerBean;
+
+import com.introproventures.graphql.jpa.query.autoconfigure.GraphQLSchemaConfigurer;
+import com.introproventures.graphql.jpa.query.autoconfigure.GraphQLShemaRegistration;
+import com.introproventures.graphql.jpa.query.schema.impl.GraphQLJpaSchemaBuilder;
+import com.introproventures.graphql.jpa.query.schema.model.starwars.Droid;
 
 @Configuration
 public class StarwarsSchemaConfiguration {
@@ -38,7 +40,7 @@ public class StarwarsSchemaConfiguration {
     }    
      
     @Bean
-    public DataSourceInitializer starWarsDataSourceInitializer(@Qualifier("starWarsDataSource") DataSource starWarsDataSource) {
+    public DataSourceInitializer starWarsDataSourceInitializer(DataSource starWarsDataSource) {
         DataSourceInitializer dataSourceInitializer = new DataSourceInitializer();
         ResourceLoader resourceLoader = new DefaultResourceLoader();
         
@@ -54,7 +56,6 @@ public class StarwarsSchemaConfiguration {
     
     @Bean
     @Primary
-    @Qualifier("starWarsEntityManager")
     public LocalContainerEntityManagerFactoryBean starWarsEntityManagerFactory(
             EntityManagerFactoryBuilder builder) {
         
@@ -73,13 +74,20 @@ public class StarwarsSchemaConfiguration {
                 .build();
     }    
 
+    @Bean 
+    public SharedEntityManagerBean starWarsEntityManager(EntityManagerFactory entityManager) {
+        SharedEntityManagerBean bean =  new SharedEntityManagerBean();
+        bean.setEntityManagerFactory(entityManager);
+        
+        return bean;
+    }    
     @Configuration
     public static class GraphQLJpaQuerySchemaConfigurer implements GraphQLSchemaConfigurer {
 
         private final EntityManager entityManager;
 
-        public GraphQLJpaQuerySchemaConfigurer(@Qualifier("starWarsEntityManager") EntityManagerFactory entityManager) {
-            this.entityManager = entityManager.createEntityManager();
+        public GraphQLJpaQuerySchemaConfigurer(EntityManager starWarsEntityManager) {
+            this.entityManager = starWarsEntityManager;
         }
 
         @Override

--- a/graphql-jpa-query-schema/src/main/java/com/introproventures/graphql/jpa/query/schema/impl/GraphQLJpaExecutor.java
+++ b/graphql-jpa-query-schema/src/main/java/com/introproventures/graphql/jpa/query/schema/impl/GraphQLJpaExecutor.java
@@ -23,6 +23,7 @@ import javax.transaction.Transactional;
 import javax.transaction.Transactional.TxType;
 
 import com.introproventures.graphql.jpa.query.schema.GraphQLExecutor;
+
 import graphql.ExecutionInput;
 import graphql.ExecutionResult;
 import graphql.GraphQL;
@@ -52,7 +53,7 @@ public class GraphQLJpaExecutor implements GraphQLExecutor {
      * @see org.activiti.services.query.qraphql.jpa.QraphQLExecutor#execute(java.lang.String)
      */
     @Override
-    @Transactional(TxType.SUPPORTS)
+    @Transactional(TxType.REQUIRES_NEW)
     public ExecutionResult execute(String query) {
         return execute(query, Collections.emptyMap());
     }
@@ -61,7 +62,7 @@ public class GraphQLJpaExecutor implements GraphQLExecutor {
      * @see org.activiti.services.query.qraphql.jpa.QraphQLExecutor#execute(java.lang.String, java.util.Map)
      */
     @Override
-    @Transactional(TxType.SUPPORTS)
+    @Transactional(TxType.REQUIRES_NEW)
     public ExecutionResult execute(String query, Map<String, Object> arguments) {
     	
     	ExecutionInput executionInput = ExecutionInput.newExecutionInput()


### PR DESCRIPTION
Fixes https://github.com/introproventures/graphql-jpa-query/issues/225

As described in https://docs.jboss.org/hibernate/core/4.0/hem/en-US/html/transactions.html#transactions-basics-issues Never use the anti-patterns entitymanager-per-user-session or entitymanager-per-application (of course, there are rare exceptions to this rule, e.g. entitymanager-per-application might be acceptable in a desktop application, with manual flushing of the persistence context). Note that some of the following issues might also appear with the recommended patterns, make sure you understand the implications before making a design decision:

* An entity manager is not thread-safe. Things which are supposed to work concurrently, like HTTP requests, session beans, or Swing workers, will cause race conditions if an EntityManager instance would be shared. If you keep your Hibernate EntityManager in your HttpSession (discussed later), you should consider synchronizing access to your Http session. Otherwise, a user that clicks reload fast enough may use the same EntityManager in two concurrently running threads. You will very likely have provisions for this case already in place, for other non-threadsafe but session-scoped objects.

* An exception thrown by the Entity Manager means you have to rollback your database transaction and close the EntityManager immediately (discussed later in more detail). If your EntityManager is bound to the application, you have to stop the application. Rolling back the database transaction doesn't put your business objects back into the state they were at the start of the transaction. This means the database state and the business objects do get out of sync. Usually this is not a problem, because exceptions are not recoverable and you have to start over your unit of work after rollback anyway.

* The persistence context caches every object that is in managed state (watched and checked for dirty state by Hibernate). This means it grows endlessly until you get an OutOfMemoryException, if you keep it open for a long time or simply load too much data. One solution for this is some kind batch processing with regular flushing of the persistence context, but you should consider using a database stored procedure if you need mass data operations. Some solutions for this problem are shown in Chapter 7, Batch processing. Keeping a persistence context open for the duration of a user session also means a high probability of stale data, which you have to know about and control appropriately.

Therefore, it is recommended to instrument GraphQL JPA Query Schema Builder with it is own shared EntityManager proxy that uses it's own database connection pool to isolate it from any Mutation side that may use same transaction. 

With Spring, this can be achieved with `@PersistentContext` annotation when autowiring `EntityManager` instance or with `SharedEntityManagerBean` if there is a need to create multiple data sources for different persistent units.

With shared EntityManager proxy enabled, each query request will create its own instance of EntityManager inside new transaction to execute query, and then automatically closes EntityManager instance to release any resources when transaction request is executed. 








