### PR TITLE
feat(GH-224): Added support for entity path class name prefix in GraphQLJpaSchemaBuilder

### DIFF
--- a/graphql-jpa-query-schema/src/main/java/com/introproventures/graphql/jpa/query/schema/impl/GraphQLJpaSchemaBuilder.java
+++ b/graphql-jpa-query-schema/src/main/java/com/introproventures/graphql/jpa/query/schema/impl/GraphQLJpaSchemaBuilder.java
@@ -131,6 +131,8 @@ public class GraphQLJpaSchemaBuilder implements GraphQLSchemaBuilder {
     
     private final Relay relay = new Relay();
     
+    private final List<String> entityPaths = new ArrayList<>();
+    
     public GraphQLJpaSchemaBuilder(EntityManager entityManager) {
         this.entityManager = entityManager;
     }
@@ -1064,7 +1066,12 @@ public class GraphQLJpaSchemaBuilder implements GraphQLSchemaBuilder {
     }
     
     private boolean isNotIgnored(EntityType<?> entityType) {
-        return isNotIgnored(entityType.getJavaType());
+        return isNotIgnored(entityType.getJavaType()) && isNotIgnored(entityType.getJavaType().getName());
+    }
+    
+    private boolean isNotIgnored(String name) {
+        return entityPaths.isEmpty() || entityPaths.stream()
+                                                   .anyMatch(prefix -> name.startsWith(prefix));
     }
 
     private boolean isNotIgnored(Member member) {
@@ -1276,13 +1283,16 @@ public class GraphQLJpaSchemaBuilder implements GraphQLSchemaBuilder {
     }
 
     @Override
-    public GraphQLSchemaBuilder entityPath(String path) {
+    public GraphQLJpaSchemaBuilder entityPath(String path) {
         Assert.assertNotNull(path, "path is null");
+        
+        entityPaths.add(path);
+        
         return this;
     }
 
     @Override
-    public GraphQLSchemaBuilder namingStrategy(NamingStrategy instance) {
+    public GraphQLJpaSchemaBuilder namingStrategy(NamingStrategy instance) {
         Assert.assertNotNull(instance, "instance is null");
         
         this.namingStrategy = instance;

--- a/graphql-jpa-query-schema/src/test/java/com/introproventures/graphql/jpa/query/schema/BooksSchemaBuildTest.java
+++ b/graphql-jpa-query-schema/src/test/java/com/introproventures/graphql/jpa/query/schema/BooksSchemaBuildTest.java
@@ -33,6 +33,9 @@ import org.springframework.context.annotation.Bean;
 
 import com.introproventures.graphql.jpa.query.AbstractSpringBootTestSupport;
 import com.introproventures.graphql.jpa.query.schema.impl.GraphQLJpaSchemaBuilder;
+import com.introproventures.graphql.jpa.query.schema.model.book.Author;
+import com.introproventures.graphql.jpa.query.schema.model.book.Book;
+import com.introproventures.graphql.jpa.query.schema.model.uuid.Thing;
 
 import graphql.schema.GraphQLFieldDefinition;
 import graphql.schema.GraphQLList;
@@ -44,9 +47,13 @@ public class BooksSchemaBuildTest extends AbstractSpringBootTestSupport {
     @SpringBootApplication
     static class TestConfiguration {
         @Bean
-        public GraphQLJpaSchemaBuilder graphQLSchemaBuilder(EntityManager entityManager) {
+        public GraphQLSchemaBuilder graphQLSchemaBuilder(EntityManager entityManager) {
             return new GraphQLJpaSchemaBuilder(entityManager)
                 .name("BooksExampleSchema")
+                .entityPath(Book.class.getName())
+                .entityPath(Author.class.getName())
+                .entityPath(Author.class.getName())
+                .entityPath(Thing.class.getPackageName())
                 .description("Books Example Schema");
         }
     }
@@ -88,6 +95,21 @@ public class BooksSchemaBuildTest extends AbstractSpringBootTestSupport {
             .isNotNull();
     }
 
+    @Test
+    public void correctlyBuildsSchemaForEntitiesWithEntityPath() {
+        //when
+        GraphQLSchema schema = builder.build();
+
+        // then
+        assertThat(schema)
+            .describedAs("Ensure the result is returned")
+            .isNotNull();
+        
+        assertThat(schema.getQueryType()
+                         .getFieldDefinitions()).extracting(GraphQLFieldDefinition::getName)
+                                                .containsOnly("Book", "Books", "Author", "Authors", "Thing", "Things");
+    }    
+    
     @Test
     public void correctlyDerivesToManyOptionalFromGivenEntities() {
         //when

--- a/graphql-jpa-query-schema/src/test/java/com/introproventures/graphql/jpa/query/schema/BooksSchemaBuildTest.java
+++ b/graphql-jpa-query-schema/src/test/java/com/introproventures/graphql/jpa/query/schema/BooksSchemaBuildTest.java
@@ -35,6 +35,8 @@ import com.introproventures.graphql.jpa.query.AbstractSpringBootTestSupport;
 import com.introproventures.graphql.jpa.query.schema.impl.GraphQLJpaSchemaBuilder;
 import com.introproventures.graphql.jpa.query.schema.model.book.Author;
 import com.introproventures.graphql.jpa.query.schema.model.book.Book;
+import com.introproventures.graphql.jpa.query.schema.model.book_superclass.SuperAuthor;
+import com.introproventures.graphql.jpa.query.schema.model.book_superclass.SuperBook;
 import com.introproventures.graphql.jpa.query.schema.model.uuid.Thing;
 
 import graphql.schema.GraphQLFieldDefinition;
@@ -51,8 +53,10 @@ public class BooksSchemaBuildTest extends AbstractSpringBootTestSupport {
             return new GraphQLJpaSchemaBuilder(entityManager)
                 .name("BooksExampleSchema")
                 .entityPath(Book.class.getName())
+                .entityPath(SuperBook.class.getName())
+                .entityPath(SuperAuthor.class.getName())
                 .entityPath(Author.class.getName())
-                .entityPath(Thing.class.getPackageName())
+                .entityPath(Thing.class.getPackage().getName())
                 .description("Books Example Schema");
         }
     }
@@ -106,7 +110,7 @@ public class BooksSchemaBuildTest extends AbstractSpringBootTestSupport {
         
         assertThat(schema.getQueryType()
                          .getFieldDefinitions()).extracting(GraphQLFieldDefinition::getName)
-                                                .containsOnly("Book", "Books", "Author", "Authors", "Thing", "Things");
+                                                .containsOnly("Book", "Books", "Author", "Authors", "Thing", "Things", "SuperBook", "SuperBooks", "SuperAuthor", "SuperAuthors");
     }    
     
     @Test

--- a/graphql-jpa-query-schema/src/test/java/com/introproventures/graphql/jpa/query/schema/BooksSchemaBuildTest.java
+++ b/graphql-jpa-query-schema/src/test/java/com/introproventures/graphql/jpa/query/schema/BooksSchemaBuildTest.java
@@ -52,7 +52,6 @@ public class BooksSchemaBuildTest extends AbstractSpringBootTestSupport {
                 .name("BooksExampleSchema")
                 .entityPath(Book.class.getName())
                 .entityPath(Author.class.getName())
-                .entityPath(Author.class.getName())
                 .entityPath(Thing.class.getPackageName())
                 .description("Books Example Schema");
         }


### PR DESCRIPTION
This PR  adds support to configure list of entities with matching entity class path prefixes to be included in the result schema, i.e.

```java
        @Bean
        public GraphQLSchemaBuilder graphQLSchemaBuilder(EntityManager entityManager) {
            return new GraphQLJpaSchemaBuilder(entityManager)
                .name("BooksExampleSchema")
                .entityPath(Book.class.getName())
                .entityPath(Author.class.getName())
                .entityPath(Thing.class.getPackageName())
                .description("Books Example Schema");
        }
    
```

Fixes #224