### PR TITLE
fix(GH-253): Support enable/disable default max result size query pagination

### DIFF
--- a/graphql-jpa-query-schema/src/main/java/com/introproventures/graphql/jpa/query/schema/impl/GraphQLJpaExecutorContext.java
+++ b/graphql-jpa-query-schema/src/main/java/com/introproventures/graphql/jpa/query/schema/impl/GraphQLJpaExecutorContext.java
@@ -62,10 +62,7 @@ public class GraphQLJpaExecutorContext implements GraphQLExecutorContext {
     @Override
     public ExecutionInput.Builder newExecutionInput() {
         DataLoaderRegistry dataLoaderRegistry = newDataLoaderRegistry();
-
-        GraphQLContext context = graphqlContext.get();
-
-        context.put("dataLoaderRegistry", dataLoaderRegistry);
+        GraphQLContext context = newGraphQLContext(dataLoaderRegistry);
 
         return executionInputFactory.create()
                                     .dataLoaderRegistry(dataLoaderRegistry)
@@ -78,6 +75,14 @@ public class GraphQLJpaExecutorContext implements GraphQLExecutorContext {
 
         return GraphQL.newGraphQL(getGraphQLSchema())
                       .instrumentation(instrumentation);
+    }
+
+    public GraphQLContext newGraphQLContext(DataLoaderRegistry dataLoaderRegistry) {
+        GraphQLContext context = graphqlContext.get();
+
+        context.put("dataLoaderRegistry", dataLoaderRegistry);
+
+        return context;
     }
 
     public DataLoaderRegistry newDataLoaderRegistry() {
@@ -97,7 +102,6 @@ public class GraphQLJpaExecutorContext implements GraphQLExecutorContext {
                                                    instrumentation.get());
 
         return new ChainedInstrumentation(list);
-
     }
 
     @Override

--- a/graphql-jpa-query-schema/src/main/java/com/introproventures/graphql/jpa/query/schema/impl/GraphQLJpaSchemaBuilder.java
+++ b/graphql-jpa-query-schema/src/main/java/com/introproventures/graphql/jpa/query/schema/impl/GraphQLJpaSchemaBuilder.java
@@ -129,6 +129,7 @@ public class GraphQLJpaSchemaBuilder implements GraphQLSchemaBuilder {
     private int defaultMaxResults = 100;
     private int defaultFetchSize = 100;
     private int defaultPageLimitSize = 100;
+    private boolean enableDefaultMaxResults = true;
 
     private final Relay relay = new Relay();
 
@@ -264,12 +265,14 @@ public class GraphQLJpaSchemaBuilder implements GraphQLSchemaBuilder {
             dataFetcher = GraphQLJpaRelayDataFetcher.builder()
                                                     .withQueryFactory(queryFactory)
                                                     .withDefaultMaxResults(defaultMaxResults)
+                                                    .withEnableDefaultMaxResults(enableDefaultMaxResults)
                                                     .withDefaultFirstSize(defaultPageLimitSize)
                                                     .build();
         } else {
             dataFetcher = GraphQLJpaQueryDataFetcher.builder()
                                                     .withQueryFactory(queryFactory)
                                                     .withDefaultMaxResults(defaultMaxResults)
+                                                    .withEnableDefaultMaxResults(enableDefaultMaxResults)
                                                     .withDefaultPageLimitSize(defaultPageLimitSize)
                                                     .build();
         }
@@ -1422,6 +1425,16 @@ public class GraphQLJpaSchemaBuilder implements GraphQLSchemaBuilder {
 
     public GraphQLJpaSchemaBuilder defaultFetchSize(int defaultFetchSize) {
         this.defaultFetchSize = defaultFetchSize;
+
+        return this;
+    }
+
+    public boolean isEnableDefaultMaxResults() {
+        return enableDefaultMaxResults;
+    }
+
+    public GraphQLJpaSchemaBuilder enableDefaultMaxResults(boolean enableDefaultMaxResults) {
+        this.enableDefaultMaxResults = enableDefaultMaxResults;
 
         return this;
     }


### PR DESCRIPTION
This PR adds support to enable/disable default max result size query pagination via GraphQLJpaSchemaBuilder.enableDefaultMaxResultSize(boolean) feature toggle. This feature is enabled by default.

Fixes #253