### PR TITLE
fix: add support for server.servlet.content-path configuration

### DIFF
--- a/graphql-jpa-query-graphiql/src/main/resources/static/graphiql/index.html
+++ b/graphql-jpa-query-graphiql/src/main/resources/static/graphiql/index.html
@@ -101,7 +101,7 @@
       function graphQLFetcher(graphQLParams) {
         // This example expects a GraphQL server at the path /graphql.
         // Change this to point wherever you host your GraphQL server.
-        return fetch('/graphql', {
+        return fetch('./graphql', {
           method: 'post',
           headers: {
             'Accept': 'application/json',


### PR DESCRIPTION
This PR adds support for custom server servlet context path configuration in parent Spring Boot Application.