### PR TITLE
feat: add initial support for restricted keys query provider implementation

### DIFF
--- a/graphql-jpa-query-boot-starter/src/main/java/com/introproventures/graphql/jpa/query/boot/autoconfigure/GraphQLJpaQueryAutoConfiguration.java
+++ b/graphql-jpa-query-boot-starter/src/main/java/com/introproventures/graphql/jpa/query/boot/autoconfigure/GraphQLJpaQueryAutoConfiguration.java
@@ -34,9 +34,11 @@ import com.introproventures.graphql.jpa.query.schema.GraphQLExecutionInputFactor
 import com.introproventures.graphql.jpa.query.schema.GraphQLExecutor;
 import com.introproventures.graphql.jpa.query.schema.GraphQLExecutorContextFactory;
 import com.introproventures.graphql.jpa.query.schema.GraphQLSchemaBuilder;
+import com.introproventures.graphql.jpa.query.schema.RestrictedKeysProvider;
 import com.introproventures.graphql.jpa.query.schema.impl.GraphQLJpaExecutor;
 import com.introproventures.graphql.jpa.query.schema.impl.GraphQLJpaExecutorContextFactory;
 import com.introproventures.graphql.jpa.query.schema.impl.GraphQLJpaSchemaBuilder;
+
 import graphql.GraphQL;
 import graphql.GraphQLContext;
 import graphql.execution.instrumentation.Instrumentation;
@@ -55,8 +57,13 @@ public class GraphQLJpaQueryAutoConfiguration {
         @Bean
         @ConditionalOnMissingBean
         @ConditionalOnSingleCandidate(EntityManagerFactory.class)
-        public GraphQLSchemaBuilder graphQLJpaSchemaBuilder(final EntityManagerFactory entityManagerFactory) {
-            return new GraphQLJpaSchemaBuilder(entityManagerFactory.createEntityManager());
+        public GraphQLSchemaBuilder graphQLJpaSchemaBuilder(final EntityManagerFactory entityManagerFactory,
+                                                            ObjectProvider<RestrictedKeysProvider> restrictedKeysProvider) {
+            GraphQLJpaSchemaBuilder bean = new GraphQLJpaSchemaBuilder(entityManagerFactory.createEntityManager());
+            
+            restrictedKeysProvider.ifAvailable(bean::restrictedKeysProvider);
+            
+            return bean;
         }
 
         @Bean

--- a/graphql-jpa-query-boot-starter/src/test/java/com/introproventures/graphql/jpa/query/boot/test/boot/autoconfigure/GraphQLJpaQueryAutoConfigurationTest.java
+++ b/graphql-jpa-query-boot-starter/src/test/java/com/introproventures/graphql/jpa/query/boot/test/boot/autoconfigure/GraphQLJpaQueryAutoConfigurationTest.java
@@ -34,6 +34,7 @@ import com.introproventures.graphql.jpa.query.boot.test.starter.model.Author;
 import com.introproventures.graphql.jpa.query.schema.GraphQLExecutionInputFactory;
 import com.introproventures.graphql.jpa.query.schema.GraphQLExecutor;
 import com.introproventures.graphql.jpa.query.schema.GraphQLSchemaBuilder;
+import com.introproventures.graphql.jpa.query.schema.RestrictedKeysProvider;
 import com.introproventures.graphql.jpa.query.schema.impl.GraphQLJpaExecutor;
 import com.introproventures.graphql.jpa.query.schema.impl.GraphQLJpaExecutorContextFactory;
 import com.introproventures.graphql.jpa.query.schema.impl.GraphQLJpaSchemaBuilder;
@@ -63,6 +64,8 @@ public class GraphQLJpaQueryAutoConfigurationTest {
         @MockBean
         private Supplier<GraphQLContext> graphqlContext;
         
+        @MockBean
+        private RestrictedKeysProvider restrictedKeysProvider;
     }
     
     @Autowired(required=false)
@@ -85,6 +88,9 @@ public class GraphQLJpaQueryAutoConfigurationTest {
 
     @Autowired
     private ObjectProvider<Supplier<GraphQLContext>> graphqlContext;   
+
+    @Autowired
+    private ObjectProvider<RestrictedKeysProvider> restrictedKeysObjectProvider;   
     
     @Autowired
     private GraphQLSchema graphQLSchema;
@@ -96,6 +102,9 @@ public class GraphQLJpaQueryAutoConfigurationTest {
         
         assertThat(graphQLSchemaBuilder).isNotNull()
                                         .isInstanceOf(GraphQLJpaSchemaBuilder.class);
+
+        assertThat(GraphQLJpaSchemaBuilder.class.cast(graphQLSchemaBuilder)
+                                                .getRestrictedKeysProvider()).isEqualTo(restrictedKeysObjectProvider.getObject());
         
         assertThat(executorContextFactory).isNotNull()
                                           .isInstanceOf(GraphQLJpaExecutorContextFactory.class);

--- a/graphql-jpa-query-schema/pom.xml
+++ b/graphql-jpa-query-schema/pom.xml
@@ -78,6 +78,18 @@
         </dependency>
 
         <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-security</artifactId>
+            <scope>test</scope>
+        </dependency>        
+
+        <dependency>
+            <groupId>org.springframework.security</groupId>
+            <artifactId>spring-security-test</artifactId>
+            <scope>test</scope>
+        </dependency>   
+
+        <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
             <scope>test</scope>

--- a/graphql-jpa-query-schema/src/main/java/com/introproventures/graphql/jpa/query/schema/RestrictedKeysProvider.java
+++ b/graphql-jpa-query-schema/src/main/java/com/introproventures/graphql/jpa/query/schema/RestrictedKeysProvider.java
@@ -1,0 +1,12 @@
+package com.introproventures.graphql.jpa.query.schema;
+
+import java.util.List;
+import java.util.Optional;
+import java.util.function.Function;
+
+import com.introproventures.graphql.jpa.query.schema.impl.EntityIntrospector.EntityIntrospectionResult;
+
+@FunctionalInterface
+public interface RestrictedKeysProvider extends Function<EntityIntrospectionResult, Optional<List<Object>>> {
+
+}

--- a/graphql-jpa-query-schema/src/main/java/com/introproventures/graphql/jpa/query/schema/RestrictedKeysProvider.java
+++ b/graphql-jpa-query-schema/src/main/java/com/introproventures/graphql/jpa/query/schema/RestrictedKeysProvider.java
@@ -6,6 +6,16 @@ import java.util.function.Function;
 
 import com.introproventures.graphql.jpa.query.schema.impl.EntityIntrospector.EntityIntrospectionResult;
 
+/**
+ * The RestrictedKeysProvider functional interface should provide a list of restricted keys in order to filter records  
+ * at runtime based on user security context based on EntityIntrospection descriptor. 
+ * 
+ * The return argument uses Optional<List<Object>> return type. 
+ * The non-empty list will restrict the query to provided keys
+ * The empty Optional will block running the query and return empty result. 
+ * The empty list will run the query unrestricted. 
+ *
+ */
 @FunctionalInterface
 public interface RestrictedKeysProvider extends Function<EntityIntrospectionResult, Optional<List<Object>>> {
 

--- a/graphql-jpa-query-schema/src/main/java/com/introproventures/graphql/jpa/query/schema/RestrictedKeysProvider.java
+++ b/graphql-jpa-query-schema/src/main/java/com/introproventures/graphql/jpa/query/schema/RestrictedKeysProvider.java
@@ -10,13 +10,22 @@ import com.introproventures.graphql.jpa.query.schema.impl.EntityIntrospector.Ent
  * The RestrictedKeysProvider functional interface should provide a list of restricted keys in order to filter records  
  * at runtime based on user security context based on EntityIntrospection descriptor. 
  * 
- * The return argument uses Optional<List<Object>> return type. 
+ * The return argument uses Optional<List<Object>> return type:
  * The non-empty list will restrict the query to provided keys
- * The empty Optional will block running the query and return empty result. 
  * The empty list will run the query unrestricted. 
+ * The empty Optional will block running the query and return empty result. 
  *
  */
 @FunctionalInterface
 public interface RestrictedKeysProvider extends Function<EntityIntrospectionResult, Optional<List<Object>>> {
 
+    /**
+     * Applies this restricted keys provider function to the given argument of entityDescriptor.
+     *
+     * @param entityDescriptor the function argument
+     * @return the function result with optional list of keys
+     */
+    @Override
+    Optional<List<Object>> apply(EntityIntrospectionResult entityDescriptor);
+    
 }

--- a/graphql-jpa-query-schema/src/main/java/com/introproventures/graphql/jpa/query/schema/impl/GraphQLJpaQueryDataFetcher.java
+++ b/graphql-jpa-query-schema/src/main/java/com/introproventures/graphql/jpa/query/schema/impl/GraphQLJpaQueryDataFetcher.java
@@ -74,9 +74,9 @@ class GraphQLJpaQueryDataFetcher implements DataFetcher<PagedResult<Object>> {
         final PagedResult.Builder<Object> pagedResult = PagedResult.builder()
                                                                    .withOffset(firstResult)
                                                                    .withLimit(maxResults);
+        Optional<List<Object>> restrictedKeys = queryFactory.getRestrictedKeys(environment);
+        
         if (recordsSelection.isPresent()) {
-            Optional<List<Object>> restrictedKeys = queryFactory.getRestrictedKeys(environment);
-
             if (restrictedKeys.isPresent()) {
                 final List<Object> queryKeys = new ArrayList<>();
                 
@@ -98,7 +98,8 @@ class GraphQLJpaQueryDataFetcher implements DataFetcher<PagedResult<Object>> {
         }
 
         if (totalSelection.isPresent() || pagesSelection.isPresent()) {
-            final Long total = queryFactory.queryTotalCount(environment);
+            final Long total = queryFactory.queryTotalCount(environment, 
+                                                            restrictedKeys);
 
             pagedResult.withTotal(total);
         }

--- a/graphql-jpa-query-schema/src/main/java/com/introproventures/graphql/jpa/query/schema/impl/GraphQLJpaQueryDataFetcher.java
+++ b/graphql-jpa-query-schema/src/main/java/com/introproventures/graphql/jpa/query/schema/impl/GraphQLJpaQueryDataFetcher.java
@@ -23,7 +23,7 @@ import static com.introproventures.graphql.jpa.query.support.GraphQLSupport.getP
 import static com.introproventures.graphql.jpa.query.support.GraphQLSupport.getSelectionField;
 import static com.introproventures.graphql.jpa.query.support.GraphQLSupport.searchByFieldName;
 
-import java.util.Collections;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
 
@@ -75,16 +75,23 @@ class GraphQLJpaQueryDataFetcher implements DataFetcher<PagedResult<Object>> {
                                                                    .withOffset(firstResult)
                                                                    .withLimit(maxResults);
         if (recordsSelection.isPresent()) {
-            List<Object> keys = Collections.emptyList();
+            Optional<List<Object>> restrictedKeys = queryFactory.getRestrictedKeys(environment);
 
-            if (pageArgument.isPresent() || enableDefaultMaxResults) {
-                keys = queryFactory.queryKeys(environment, firstResult, maxResults);
-            }
-
-            final List<Object> resultList = queryFactory.queryResultList(environment,
-                                                                         maxResults,
-                                                                         keys);
-            pagedResult.withSelect(resultList);
+            if (restrictedKeys.isPresent()) {
+                final List<Object> queryKeys = new ArrayList<>();
+                
+                if (pageArgument.isPresent() || enableDefaultMaxResults) {
+                    queryKeys.addAll(queryFactory.queryKeys(environment,
+                                                            firstResult,
+                                                            maxResults,
+                                                            restrictedKeys.get()));
+                }
+    
+                final List<Object> resultList = queryFactory.queryResultList(environment,
+                                                                             maxResults,
+                                                                             queryKeys);
+                pagedResult.withSelect(resultList);
+            } 
         }
 
         if (totalSelection.isPresent() || pagesSelection.isPresent()) {

--- a/graphql-jpa-query-schema/src/main/java/com/introproventures/graphql/jpa/query/schema/impl/GraphQLJpaQueryDataFetcher.java
+++ b/graphql-jpa-query-schema/src/main/java/com/introproventures/graphql/jpa/query/schema/impl/GraphQLJpaQueryDataFetcher.java
@@ -85,6 +85,9 @@ class GraphQLJpaQueryDataFetcher implements DataFetcher<PagedResult<Object>> {
                                                             firstResult,
                                                             maxResults,
                                                             restrictedKeys.get()));
+                } 
+                else {
+                    queryKeys.addAll(restrictedKeys.get());
                 }
     
                 final List<Object> resultList = queryFactory.queryResultList(environment,

--- a/graphql-jpa-query-schema/src/main/java/com/introproventures/graphql/jpa/query/schema/impl/GraphQLJpaQueryFactory.java
+++ b/graphql-jpa-query-schema/src/main/java/com/introproventures/graphql/jpa/query/schema/impl/GraphQLJpaQueryFactory.java
@@ -49,7 +49,6 @@ import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
 import java.util.function.Function;
-import java.util.function.Supplier;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 import java.util.stream.Stream;
@@ -214,15 +213,6 @@ public final class GraphQLJpaQueryFactory {
         return keysQuery.getResultList();
     }
 
-    class DefaultKeysSupplier implements Supplier<Optional<List<Object>>> {
-
-        @Override
-        public Optional<List<Object>> get() {
-            // TODO Auto-generated method stub
-            return null;
-        }
-    }
-    
     public List<Object> queryResultList(DataFetchingEnvironment environment,
                                            int maxResults,
                                            List<Object> keys) {

--- a/graphql-jpa-query-schema/src/main/java/com/introproventures/graphql/jpa/query/schema/impl/GraphQLJpaQueryFactory.java
+++ b/graphql-jpa-query-schema/src/main/java/com/introproventures/graphql/jpa/query/schema/impl/GraphQLJpaQueryFactory.java
@@ -270,14 +270,25 @@ public final class GraphQLJpaQueryFactory {
 
         final DataFetchingEnvironment queryEnvironment = getQueryEnvironment(environment,
                                                                              queryField);
-
-        TypedQuery<Object> query = getQuery(queryEnvironment, queryEnvironment.getField(), true);
-
-        if (logger.isDebugEnabled()) {
-            logger.info("\nGraphQL JPQL Single Result Query String:\n    {}", getJPQLQueryString(query));
+        
+        Optional<List<Object>> restrictedKeys = getRestrictedKeys(queryEnvironment);
+        
+        if (restrictedKeys.isPresent()) {
+    
+            TypedQuery<Object> query = getQuery(queryEnvironment, 
+                                                queryEnvironment.getField(), 
+                                                true, 
+                                                restrictedKeys.get()
+                                                              .toArray());
+    
+            if (logger.isDebugEnabled()) {
+                logger.info("\nGraphQL JPQL Single Result Query String:\n    {}", getJPQLQueryString(query));
+            }
+    
+            return query.getSingleResult();
         }
-
-        return query.getSingleResult();
+        
+        return null;
     }
 
     public Long queryTotalCount(DataFetchingEnvironment environment,

--- a/graphql-jpa-query-schema/src/main/java/com/introproventures/graphql/jpa/query/schema/impl/GraphQLJpaQueryFactory.java
+++ b/graphql-jpa-query-schema/src/main/java/com/introproventures/graphql/jpa/query/schema/impl/GraphQLJpaQueryFactory.java
@@ -2030,7 +2030,7 @@ public final class GraphQLJpaQueryFactory {
     }
 
     
-    public Function<EntityIntrospectionResult, Optional<List<Object>>> getRestrictedKeysProvider() {
+    public RestrictedKeysProvider getRestrictedKeysProvider() {
         return restrictedKeysProvider;
     }
 }

--- a/graphql-jpa-query-schema/src/main/java/com/introproventures/graphql/jpa/query/schema/impl/GraphQLJpaQueryFactory.java
+++ b/graphql-jpa-query-schema/src/main/java/com/introproventures/graphql/jpa/query/schema/impl/GraphQLJpaQueryFactory.java
@@ -171,7 +171,7 @@ public final class GraphQLJpaQueryFactory {
           Optional<List<Object>> restrictedKeys = restrictedKeysProvider.apply(entityDescriptor);
           List<Object> restrictedKeysValues = new ArrayList<>(); 
           
-          if (restrictedKeys.isPresent() && hasIdAttribute()) {
+          if (restrictedKeys.isPresent()) {
               restrictedKeys.get()
                             .stream()
                             .filter(key -> !"*".equals(key))

--- a/graphql-jpa-query-schema/src/main/java/com/introproventures/graphql/jpa/query/schema/impl/GraphQLJpaSchemaBuilder.java
+++ b/graphql-jpa-query-schema/src/main/java/com/introproventures/graphql/jpa/query/schema/impl/GraphQLJpaSchemaBuilder.java
@@ -30,6 +30,7 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.function.Supplier;
 import java.util.stream.Collectors;
@@ -55,6 +56,7 @@ import com.introproventures.graphql.jpa.query.annotation.GraphQLIgnoreOrder;
 import com.introproventures.graphql.jpa.query.schema.GraphQLSchemaBuilder;
 import com.introproventures.graphql.jpa.query.schema.JavaScalars;
 import com.introproventures.graphql.jpa.query.schema.NamingStrategy;
+import com.introproventures.graphql.jpa.query.schema.RestrictedKeysProvider;
 import com.introproventures.graphql.jpa.query.schema.impl.EntityIntrospector.EntityIntrospectionResult.AttributePropertyDescriptor;
 import com.introproventures.graphql.jpa.query.schema.impl.PredicateFilter.Criteria;
 import com.introproventures.graphql.jpa.query.schema.relay.GraphQLJpaRelayDataFetcher;
@@ -131,6 +133,8 @@ public class GraphQLJpaSchemaBuilder implements GraphQLSchemaBuilder {
     private int defaultFetchSize = 100;
     private int defaultPageLimitSize = 100;
     private boolean enableDefaultMaxResults = true;
+    
+    private RestrictedKeysProvider restrictedKeysProvider = (entityDescriptor) -> Optional.of(Collections.emptyList());
 
     private final Relay relay = new Relay();
 
@@ -218,6 +222,7 @@ public class GraphQLJpaSchemaBuilder implements GraphQLSchemaBuilder {
                                                                     .withEntityObjectType(entityObjectType)
                                                                     .withSelectNodeName(entityObjectType.getName())
                                                                     .withToManyDefaultOptional(toManyDefaultOptional)
+                                                                    .withRestrictedKeysProvider(restrictedKeysProvider)
                                                                     .build();
 
         DataFetcher<Object> dataFetcher = GraphQLJpaSimpleDataFetcher.builder()
@@ -260,6 +265,7 @@ public class GraphQLJpaSchemaBuilder implements GraphQLSchemaBuilder {
                                                                     .withToManyDefaultOptional(toManyDefaultOptional)
                                                                     .withDefaultDistinct(isDefaultDistinct)
                                                                     .withDefaultFetchSize(defaultFetchSize)
+                                                                    .withRestrictedKeysProvider(restrictedKeysProvider)
                                                                     .build();
 
         if(enableRelay) {
@@ -337,6 +343,7 @@ public class GraphQLJpaSchemaBuilder implements GraphQLSchemaBuilder {
                                                                     .withSelectNodeName(SELECT_DISTINCT_PARAM_NAME)
                                                                     .withToManyDefaultOptional(toManyDefaultOptional)
                                                                     .withDefaultDistinct(isDefaultDistinct)
+                                                                    .withRestrictedKeysProvider(restrictedKeysProvider)
                                                                     .build();
 
         DataFetcher<Object> dataFetcher = GraphQLJpaStreamDataFetcher.builder()
@@ -923,6 +930,7 @@ public class GraphQLJpaSchemaBuilder implements GraphQLSchemaBuilder {
                                                                                   .withEntityObjectType(entityObjectType)
                                                                                   .withSelectNodeName(entityObjectType.getName())
                                                                                   .withDefaultDistinct(isDefaultDistinct)
+                                                                                  .withRestrictedKeysProvider(restrictedKeysProvider)
                                                                                   .build();
 
             String dataLoaderKey = baseEntity.getName() + "." + attribute.getName();
@@ -958,6 +966,7 @@ public class GraphQLJpaSchemaBuilder implements GraphQLSchemaBuilder {
                                                                                   .withEntityObjectType(entityObjectType)
                                                                                   .withSelectNodeName(entityObjectType.getName())
                                                                                   .withDefaultDistinct(isDefaultDistinct)
+                                                                                  .withRestrictedKeysProvider(restrictedKeysProvider)
                                                                                   .build();
 
             String dataLoaderKey = baseEntity.getName() + "." + attribute.getName();
@@ -1452,6 +1461,12 @@ public class GraphQLJpaSchemaBuilder implements GraphQLSchemaBuilder {
     public GraphQLJpaSchemaBuilder enableDefaultMaxResults(boolean enableDefaultMaxResults) {
         this.enableDefaultMaxResults = enableDefaultMaxResults;
 
+        return this;
+    }
+    
+    public GraphQLJpaSchemaBuilder restrictedKeysProvider(RestrictedKeysProvider restrictedKeysProvider) {
+        this.restrictedKeysProvider = restrictedKeysProvider;
+        
         return this;
     }
 

--- a/graphql-jpa-query-schema/src/main/java/com/introproventures/graphql/jpa/query/schema/impl/GraphQLJpaSchemaBuilder.java
+++ b/graphql-jpa-query-schema/src/main/java/com/introproventures/graphql/jpa/query/schema/impl/GraphQLJpaSchemaBuilder.java
@@ -1470,4 +1470,8 @@ public class GraphQLJpaSchemaBuilder implements GraphQLSchemaBuilder {
         return this;
     }
 
+    public RestrictedKeysProvider  getRestrictedKeysProvider() {
+        return restrictedKeysProvider;
+    }    
+    
 }

--- a/graphql-jpa-query-schema/src/main/java/com/introproventures/graphql/jpa/query/schema/relay/GraphQLJpaRelayDataFetcher.java
+++ b/graphql-jpa-query-schema/src/main/java/com/introproventures/graphql/jpa/query/schema/relay/GraphQLJpaRelayDataFetcher.java
@@ -49,7 +49,7 @@ public class GraphQLJpaRelayDataFetcher implements DataFetcher<Page<Object>> {
         final Integer first = firstArgument.orElse(defaultFirstSize);
 
         final String after = afterArgument.orElse(new OffsetBasedCursor(0L).toConnectionCursor()
-                                                                .toString());
+                                                                           .toString());
 
         final OffsetBasedCursor cursor = OffsetBasedCursor.fromCursor(after);
 
@@ -60,9 +60,9 @@ public class GraphQLJpaRelayDataFetcher implements DataFetcher<Page<Object>> {
                 .withOffset(firstResult)
                 .withLimit(maxResults);
 
+        Optional<List<Object>> restrictedKeys = queryFactory.getRestrictedKeys(environment);
+        
         if (edgesSelection.isPresent()) {
-            Optional<List<Object>> restrictedKeys = queryFactory.getRestrictedKeys(environment);
-
             if (restrictedKeys.isPresent()) {
                 final List<Object> queryKeys = new ArrayList<>();
     
@@ -84,7 +84,8 @@ public class GraphQLJpaRelayDataFetcher implements DataFetcher<Page<Object>> {
         }
 
         if (pageInfoSelection.isPresent()) {
-            final Long total = queryFactory.queryTotalCount(environment);
+            final Long total = queryFactory.queryTotalCount(environment,
+                                                            restrictedKeys);
 
             pagedResult.withTotal(total);
         }

--- a/graphql-jpa-query-schema/src/main/java/com/introproventures/graphql/jpa/query/schema/relay/GraphQLJpaRelayDataFetcher.java
+++ b/graphql-jpa-query-schema/src/main/java/com/introproventures/graphql/jpa/query/schema/relay/GraphQLJpaRelayDataFetcher.java
@@ -72,6 +72,9 @@ public class GraphQLJpaRelayDataFetcher implements DataFetcher<Page<Object>> {
                                                             maxResults,
                                                             restrictedKeys.get()));
                 }
+                else {
+                    queryKeys.addAll(restrictedKeys.get());
+                }
     
                 final List<Object> resultList = queryFactory.queryResultList(environment,
                                                                              maxResults,

--- a/graphql-jpa-query-schema/src/test/java/com/introproventures/graphql/jpa/query/restricted/RestrictedKeysProviderRelayTests.java
+++ b/graphql-jpa-query-schema/src/test/java/com/introproventures/graphql/jpa/query/restricted/RestrictedKeysProviderRelayTests.java
@@ -56,8 +56,9 @@ public class RestrictedKeysProviderRelayTests extends AbstractSpringBootTestSupp
     @WithMockUser(value = "spring", authorities = "Thing:read:2d1ebc5b-7d27-4197-9cf0-e84451c5bbb1")
     public void testRestrictedThingQuery() {
         //given
-        String query = "query RestrictedThingQuery { things { edges { node {id type } } } }";
-        String expected = "{things={edges=[{node={id=2d1ebc5b-7d27-4197-9cf0-e84451c5bbb1, type=Thing1}}]}}";
+        String query = "query RestrictedThingQuery { things { pageInfo { hasNextPage, startCursor, endCursor } edges { node { id type } } } }";
+        String expected = "{things={pageInfo={hasNextPage=false, startCursor=b2Zmc2V0PTE=, endCursor=b2Zmc2V0PTE=}, "
+                + "edges=[{node={id=2d1ebc5b-7d27-4197-9cf0-e84451c5bbb1, type=Thing1}}]}}";
 
         //when
         Object result = executor.execute(query).getData();
@@ -70,8 +71,9 @@ public class RestrictedKeysProviderRelayTests extends AbstractSpringBootTestSupp
     @WithMockUser(value = "spring", authorities = "Thing:read:*")
     public void testNonRestrictedThingQuery() {
         //given
-        String query = "query RestrictedThingQuery { things { edges { node {id type } } } }";
-        String expected = "{things={edges=["
+        String query = "query RestrictedThingQuery { things { pageInfo { hasNextPage, startCursor, endCursor } edges { node {id type } } } }";
+        String expected = "{things={pageInfo={hasNextPage=false, startCursor=b2Zmc2V0PTE=, endCursor=b2Zmc2V0PTM=}, "
+                + "edges=["
                 + "{node={id=2d1ebc5b-7d27-4197-9cf0-e84451c5bbb1, type=Thing1}}, "
                 + "{node={id=2d1ebc5b-7d27-4197-9cf0-e84451c5bbc1, type=Thing2}}, "
                 + "{node={id=2d1ebc5b-7d27-4197-9cf0-e84451c5bbd1, type=Thing3}}"

--- a/graphql-jpa-query-schema/src/test/java/com/introproventures/graphql/jpa/query/restricted/RestrictedKeysProviderRelayTests.java
+++ b/graphql-jpa-query-schema/src/test/java/com/introproventures/graphql/jpa/query/restricted/RestrictedKeysProviderRelayTests.java
@@ -22,7 +22,7 @@ import com.introproventures.graphql.jpa.query.schema.impl.GraphQLJpaSchemaBuilde
 import com.introproventures.graphql.jpa.query.schema.model.uuid.Thing;
 
 @SpringBootTest(properties = "spring.datasource.data=RestrictedKeysProviderTests.sql")
-public class RestrictedKeysProviderTests extends AbstractSpringBootTestSupport {
+public class RestrictedKeysProviderRelayTests extends AbstractSpringBootTestSupport {
 
     @SpringBootApplication
     @EntityScan(basePackageClasses = Thing.class)
@@ -39,6 +39,7 @@ public class RestrictedKeysProviderTests extends AbstractSpringBootTestSupport {
             return new GraphQLJpaSchemaBuilder(entityManager)
                 .name("GraphQLBooks")
                 .description("Books JPA test schema")
+                .enableRelay(true)
                 .restrictedKeysProvider(new SpringSecurityRestrictedKeysProvider(entityManager.getMetamodel()));
         }
     }
@@ -55,8 +56,8 @@ public class RestrictedKeysProviderTests extends AbstractSpringBootTestSupport {
     @WithMockUser(value = "spring", authorities = "Thing:read:2d1ebc5b-7d27-4197-9cf0-e84451c5bbb1")
     public void testRestrictedThingQuery() {
         //given
-        String query = "query RestrictedThingQuery { Things { select {id type } } }";
-        String expected = "{Things={select=[{id=2d1ebc5b-7d27-4197-9cf0-e84451c5bbb1, type=Thing1}]}}";
+        String query = "query RestrictedThingQuery { things { edges { node {id type } } } }";
+        String expected = "{things={edges=[{node={id=2d1ebc5b-7d27-4197-9cf0-e84451c5bbb1, type=Thing1}}]}}";
 
         //when
         Object result = executor.execute(query).getData();
@@ -69,11 +70,11 @@ public class RestrictedKeysProviderTests extends AbstractSpringBootTestSupport {
     @WithMockUser(value = "spring", authorities = "Thing:read:*")
     public void testNonRestrictedThingQuery() {
         //given
-        String query = "query RestrictedThingQuery { Things { select {id type } } }";
-        String expected = "{Things={select=["
-                + "{id=2d1ebc5b-7d27-4197-9cf0-e84451c5bbb1, type=Thing1}, "
-                + "{id=2d1ebc5b-7d27-4197-9cf0-e84451c5bbc1, type=Thing2}, "
-                + "{id=2d1ebc5b-7d27-4197-9cf0-e84451c5bbd1, type=Thing3}"
+        String query = "query RestrictedThingQuery { things { edges { node {id type } } } }";
+        String expected = "{things={edges=["
+                + "{node={id=2d1ebc5b-7d27-4197-9cf0-e84451c5bbb1, type=Thing1}}, "
+                + "{node={id=2d1ebc5b-7d27-4197-9cf0-e84451c5bbc1, type=Thing2}}, "
+                + "{node={id=2d1ebc5b-7d27-4197-9cf0-e84451c5bbd1, type=Thing3}}"
                 + "]}}";
 
         //when
@@ -87,8 +88,8 @@ public class RestrictedKeysProviderTests extends AbstractSpringBootTestSupport {
     @WithMockUser(value = "spring", authorities = "OtherThing:*")
     public void testRestrictAllOtherThingQuery() {
         //given
-        String query = "query RestrictedThingQuery { Things { select {id type } } }";
-        String expected = "{Things={select=[]}}";
+        String query = "query RestrictedThingQuery { things { edges { node {id type } } } }";
+        String expected = "{things={edges=[]}}";
 
         //when
         Object result = executor.execute(query).getData();
@@ -101,9 +102,9 @@ public class RestrictedKeysProviderTests extends AbstractSpringBootTestSupport {
     @WithAnonymousUser
     public void testRestrictAllThingQueryForAnonymous() {
         //given
-        String query = "query RestrictedThingQuery { Things { select {id type } } }";
-        String expected = "{Things={select=[]}}";
-
+        String query = "query RestrictedThingQuery { things { edges { node {id type } } } }";
+        String expected = "{things={edges=[]}}";
+        
         //when
         Object result = executor.execute(query).getData();
 
@@ -114,9 +115,9 @@ public class RestrictedKeysProviderTests extends AbstractSpringBootTestSupport {
     @Test
     public void testRestrictAllThingQueryWithNullAuthentication() {
         //given
-        String query = "query RestrictedThingQuery { Things { select {id type } } }";
-        String expected = "{Things={select=[]}}";
-
+        String query = "query RestrictedThingQuery { things { edges { node {id type } } } }";
+        String expected = "{things={edges=[]}}";
+        
         //when
         Object result = executor.execute(query).getData();
 

--- a/graphql-jpa-query-schema/src/test/java/com/introproventures/graphql/jpa/query/restricted/RestrictedKeysProviderSelectTests.java
+++ b/graphql-jpa-query-schema/src/test/java/com/introproventures/graphql/jpa/query/restricted/RestrictedKeysProviderSelectTests.java
@@ -56,8 +56,8 @@ public class RestrictedKeysProviderSelectTests extends AbstractSpringBootTestSup
     @WithMockUser(value = "spring", authorities = "Thing:read:2d1ebc5b-7d27-4197-9cf0-e84451c5bbb1")
     public void testRestrictedThingQuery() {
         //given
-        String query = "query RestrictedThingQuery { Things { select {id type } } }";
-        String expected = "{Things={select=[{id=2d1ebc5b-7d27-4197-9cf0-e84451c5bbb1, type=Thing1}]}}";
+        String query = "query RestrictedThingQuery { Things { total select {id type } } }";
+        String expected = "{Things={total=1, select=[{id=2d1ebc5b-7d27-4197-9cf0-e84451c5bbb1, type=Thing1}]}}";
 
         //when
         Object result = executor.execute(query).getData();
@@ -67,11 +67,30 @@ public class RestrictedKeysProviderSelectTests extends AbstractSpringBootTestSup
     }
     
     @Test
+    @WithMockUser(value = "spring", authorities = {"Thing:read:2d1ebc5b-7d27-4197-9cf0-e84451c5bbb1", 
+                                                   "Thing:read:2d1ebc5b-7d27-4197-9cf0-e84451c5bbc1"})
+    public void testRestrictedThingQueryMultiple() {
+        //given
+        String query = "query RestrictedThingQuery { Things { total select {id type } } }";
+        String expected = "{Things={total=2, select=["
+                + "{id=2d1ebc5b-7d27-4197-9cf0-e84451c5bbb1, type=Thing1}, "
+                + "{id=2d1ebc5b-7d27-4197-9cf0-e84451c5bbc1, type=Thing2}"
+                + "]}}";
+
+        //when
+        Object result = executor.execute(query).getData();
+
+        //then
+        assertThat(result.toString()).isEqualTo(expected);
+    }
+    
+    
+    @Test
     @WithMockUser(value = "spring", authorities = "Thing:read:*")
     public void testNonRestrictedThingQuery() {
         //given
-        String query = "query RestrictedThingQuery { Things { select {id type } } }";
-        String expected = "{Things={select=["
+        String query = "query RestrictedThingQuery { Things { total select {id type } } }";
+        String expected = "{Things={total=3, select=["
                 + "{id=2d1ebc5b-7d27-4197-9cf0-e84451c5bbb1, type=Thing1}, "
                 + "{id=2d1ebc5b-7d27-4197-9cf0-e84451c5bbc1, type=Thing2}, "
                 + "{id=2d1ebc5b-7d27-4197-9cf0-e84451c5bbd1, type=Thing3}"
@@ -88,8 +107,8 @@ public class RestrictedKeysProviderSelectTests extends AbstractSpringBootTestSup
     @WithMockUser(value = "spring", authorities = "OtherThing:*")
     public void testRestrictAllOtherThingQuery() {
         //given
-        String query = "query RestrictedThingQuery { Things { select {id type } } }";
-        String expected = "{Things={select=[]}}";
+        String query = "query RestrictedThingQuery { Things { total select {id type } } }";
+        String expected = "{Things={total=0, select=[]}}";
 
         //when
         Object result = executor.execute(query).getData();
@@ -102,8 +121,8 @@ public class RestrictedKeysProviderSelectTests extends AbstractSpringBootTestSup
     @WithAnonymousUser
     public void testRestrictAllThingQueryForAnonymous() {
         //given
-        String query = "query RestrictedThingQuery { Things { select {id type } } }";
-        String expected = "{Things={select=[]}}";
+        String query = "query RestrictedThingQuery { Things { total select {id type } } }";
+        String expected = "{Things={total=0, select=[]}}";
 
         //when
         Object result = executor.execute(query).getData();
@@ -115,8 +134,8 @@ public class RestrictedKeysProviderSelectTests extends AbstractSpringBootTestSup
     @Test
     public void testRestrictAllThingQueryWithNullAuthentication() {
         //given
-        String query = "query RestrictedThingQuery { Things { select {id type } } }";
-        String expected = "{Things={select=[]}}";
+        String query = "query RestrictedThingQuery { Things { total select {id type } } }";
+        String expected = "{Things={total=0, select=[]}}";
 
         //when
         Object result = executor.execute(query).getData();

--- a/graphql-jpa-query-schema/src/test/java/com/introproventures/graphql/jpa/query/restricted/RestrictedKeysProviderSelectTests.java
+++ b/graphql-jpa-query-schema/src/test/java/com/introproventures/graphql/jpa/query/restricted/RestrictedKeysProviderSelectTests.java
@@ -22,7 +22,7 @@ import com.introproventures.graphql.jpa.query.schema.impl.GraphQLJpaSchemaBuilde
 import com.introproventures.graphql.jpa.query.schema.model.uuid.Thing;
 
 @SpringBootTest(properties = "spring.datasource.data=RestrictedKeysProviderTests.sql")
-public class RestrictedKeysProviderTests extends AbstractSpringBootTestSupport {
+public class RestrictedKeysProviderSelectTests extends AbstractSpringBootTestSupport {
 
     @SpringBootApplication
     @EntityScan(basePackageClasses = Thing.class)
@@ -39,6 +39,7 @@ public class RestrictedKeysProviderTests extends AbstractSpringBootTestSupport {
             return new GraphQLJpaSchemaBuilder(entityManager)
                 .name("GraphQLBooks")
                 .description("Books JPA test schema")
+                .enableDefaultMaxResults(false)
                 .restrictedKeysProvider(new SpringSecurityRestrictedKeysProvider(entityManager.getMetamodel()));
         }
     }

--- a/graphql-jpa-query-schema/src/test/java/com/introproventures/graphql/jpa/query/restricted/RestrictedKeysProviderSelectTests.java
+++ b/graphql-jpa-query-schema/src/test/java/com/introproventures/graphql/jpa/query/restricted/RestrictedKeysProviderSelectTests.java
@@ -142,6 +142,75 @@ public class RestrictedKeysProviderSelectTests extends AbstractSpringBootTestSup
 
         //then
         assertThat(result.toString()).isEqualTo(expected);
-    }        
+    }
+
+    @Test
+    public void testRestrictThingQueryWithNullAuthentication() {
+        //given
+        String query = "query { Thing(id: \"2d1ebc5b-7d27-4197-9cf0-e84451c5bbb1\") { id type } }";
+        String expected = "{Thing=null}";
+
+        //when
+        Object result = executor.execute(query).getData();
+
+        //then
+        assertThat(result.toString()).isEqualTo(expected);
+    }    
+    
+    @Test
+    @WithAnonymousUser
+    public void testRestrictThingQueryWithAnonymouseAuthentication() {
+        //given
+        String query = "query { Thing(id: \"2d1ebc5b-7d27-4197-9cf0-e84451c5bbb1\") { id type } }";
+        String expected = "{Thing=null}";
+
+        //when
+        Object result = executor.execute(query).getData();
+
+        //then
+        assertThat(result.toString()).isEqualTo(expected);
+    }
+    
+    @Test
+    @WithMockUser(value = "spring", authorities = "Thing:read:2d1ebc5b-7d27-4197-9cf0-e84451c5bbb2")
+    public void testRestrictThingQueryWithoutPermission() {
+        //given
+        String query = "query { Thing(id: \"2d1ebc5b-7d27-4197-9cf0-e84451c5bbb1\") { id type } }";
+        String expected = "{Thing=null}";
+
+        //when
+        Object result = executor.execute(query).getData();
+
+        //then
+        assertThat(result.toString()).isEqualTo(expected);
+    }           
+
+    @Test
+    @WithMockUser(value = "spring", authorities = "Thing:read:2d1ebc5b-7d27-4197-9cf0-e84451c5bbb1")
+    public void testRestrictThingQueryWithPermission() {
+        //given
+        String query = "query { Thing(id: \"2d1ebc5b-7d27-4197-9cf0-e84451c5bbb1\") { id type } }";
+        String expected = "{Thing={id=2d1ebc5b-7d27-4197-9cf0-e84451c5bbb1, type=Thing1}}";
+
+        //when
+        Object result = executor.execute(query).getData();
+
+        //then
+        assertThat(result.toString()).isEqualTo(expected);
+    }
+    
+    @Test
+    @WithMockUser(value = "spring", authorities = "Thing:read:*")
+    public void testRestrictThingQueryWithWildcardPermission() {
+        //given
+        String query = "query { Thing(id: \"2d1ebc5b-7d27-4197-9cf0-e84451c5bbb1\") { id type } }";
+        String expected = "{Thing={id=2d1ebc5b-7d27-4197-9cf0-e84451c5bbb1, type=Thing1}}";
+
+        //when
+        Object result = executor.execute(query).getData();
+
+        //then
+        assertThat(result.toString()).isEqualTo(expected);
+    }         
     
 }

--- a/graphql-jpa-query-schema/src/test/java/com/introproventures/graphql/jpa/query/restricted/RestrictedKeysProviderTests.java
+++ b/graphql-jpa-query-schema/src/test/java/com/introproventures/graphql/jpa/query/restricted/RestrictedKeysProviderTests.java
@@ -1,0 +1,161 @@
+package com.introproventures.graphql.jpa.query.restricted;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.List;
+import java.util.Optional;
+import java.util.stream.Collectors;
+
+import javax.persistence.EntityManager;
+import javax.persistence.metamodel.Metamodel;
+
+import org.junit.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.boot.autoconfigure.domain.EntityScan;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.context.annotation.Bean;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.test.context.support.WithAnonymousUser;
+import org.springframework.security.test.context.support.WithMockUser;
+import org.springframework.util.Assert;
+
+import com.introproventures.graphql.jpa.query.AbstractSpringBootTestSupport;
+import com.introproventures.graphql.jpa.query.schema.GraphQLExecutor;
+import com.introproventures.graphql.jpa.query.schema.GraphQLSchemaBuilder;
+import com.introproventures.graphql.jpa.query.schema.RestrictedKeysProvider;
+import com.introproventures.graphql.jpa.query.schema.impl.GraphQLJpaExecutor;
+import com.introproventures.graphql.jpa.query.schema.impl.GraphQLJpaSchemaBuilder;
+import com.introproventures.graphql.jpa.query.schema.model.uuid.Thing;
+
+@SpringBootTest(properties = "spring.datasource.data=RestrictedKeysProviderTests.sql")
+public class RestrictedKeysProviderTests extends AbstractSpringBootTestSupport {
+
+    @SpringBootApplication
+    @EntityScan(basePackageClasses = Thing.class)
+    static class Application {
+        
+        @Bean
+        public GraphQLExecutor graphQLExecutor(final GraphQLSchemaBuilder graphQLSchemaBuilder) {
+            return new GraphQLJpaExecutor(graphQLSchemaBuilder.build());
+        }
+
+        @Bean
+        public GraphQLSchemaBuilder graphQLSchemaBuilder(final EntityManager entityManager) {
+
+            return new GraphQLJpaSchemaBuilder(entityManager)
+                .name("GraphQLBooks")
+                .description("Books JPA test schema")
+                .restrictedKeysProvider(restrictedKeysProvider(entityManager.getMetamodel()));
+        }
+        
+        public RestrictedKeysProvider restrictedKeysProvider(Metamodel metamodel) {
+            return (entityDescriptor) -> {
+                Authentication token = SecurityContextHolder.getContext()
+                                                            .getAuthentication();
+                if (token == null) {
+                    return Optional.empty();
+                }
+                
+                String entityName = metamodel.entity(entityDescriptor.getEntity())
+                                             .getName();
+                
+                List<Object> ids = token.getAuthorities()
+                                        .stream()
+                                        .map(GrantedAuthority::getAuthority)
+                                        .map(authority -> authority.split(":"))
+                                        .filter(permission -> entityName.equals(permission[0]))
+                                        .filter(permission -> "read".equals(permission[1]))
+                                        .map(permission -> permission[2])
+                                        .collect(Collectors.toList());
+                
+                return ids.isEmpty() ? Optional.empty()  // restrict query if no permissions exists 
+                                     : Optional.of(ids); // execute query with restricted keys
+            };
+        }
+    }
+    
+    @Autowired
+    private GraphQLExecutor executor;
+
+    @Test
+    public void contextLoads() {
+        Assert.isAssignable(GraphQLExecutor.class, executor.getClass());
+    }
+
+    @Test
+    @WithMockUser(value = "spring", authorities = "Thing:read:2d1ebc5b-7d27-4197-9cf0-e84451c5bbb1")
+    public void testRestrictedThingQuery() {
+        //given
+        String query = "query RestrictedThingQuery { Things { select {id type } } }";
+        String expected = "{Things={select=[{id=2d1ebc5b-7d27-4197-9cf0-e84451c5bbb1, type=Thing1}]}}";
+
+        //when
+        Object result = executor.execute(query).getData();
+
+        //then
+        assertThat(result.toString()).isEqualTo(expected);
+    }
+    
+    @Test
+    @WithMockUser(value = "spring", authorities = "Thing:read:*")
+    public void testNonRestrictedThingQuery() {
+        //given
+        String query = "query RestrictedThingQuery { Things { select {id type } } }";
+        String expected = "{Things={select=["
+                + "{id=2d1ebc5b-7d27-4197-9cf0-e84451c5bbb1, type=Thing1}, "
+                + "{id=2d1ebc5b-7d27-4197-9cf0-e84451c5bbc1, type=Thing2}, "
+                + "{id=2d1ebc5b-7d27-4197-9cf0-e84451c5bbd1, type=Thing3}"
+                + "]}}";
+
+        //when
+        Object result = executor.execute(query).getData();
+
+        //then
+        assertThat(result.toString()).isEqualTo(expected);
+    }    
+
+    @Test
+    @WithMockUser(value = "spring", authorities = "NotThing:*")
+    public void testRestrictAllThingQuery() {
+        //given
+        String query = "query RestrictedThingQuery { Things { select {id type } } }";
+        String expected = "{Things={select=[]}}";
+
+        //when
+        Object result = executor.execute(query).getData();
+
+        //then
+        assertThat(result.toString()).isEqualTo(expected);
+    }        
+
+    @Test
+    @WithAnonymousUser
+    public void testRestrictAllThingQueryForAnonymous() {
+        //given
+        String query = "query RestrictedThingQuery { Things { select {id type } } }";
+        String expected = "{Things={select=[]}}";
+
+        //when
+        Object result = executor.execute(query).getData();
+
+        //then
+        assertThat(result.toString()).isEqualTo(expected);
+    }        
+
+    @Test
+    public void testRestrictAllThingQueryWithNullAuthentication() {
+        //given
+        String query = "query RestrictedThingQuery { Things { select {id type } } }";
+        String expected = "{Things={select=[]}}";
+
+        //when
+        Object result = executor.execute(query).getData();
+
+        //then
+        assertThat(result.toString()).isEqualTo(expected);
+    }        
+    
+}

--- a/graphql-jpa-query-schema/src/test/java/com/introproventures/graphql/jpa/query/restricted/SpringSecurityRestrictedKeysProvider.java
+++ b/graphql-jpa-query-schema/src/test/java/com/introproventures/graphql/jpa/query/restricted/SpringSecurityRestrictedKeysProvider.java
@@ -1,0 +1,55 @@
+package com.introproventures.graphql.jpa.query.restricted;
+
+import java.util.Collection;
+import java.util.List;
+import java.util.Optional;
+import java.util.stream.Collectors;
+
+import javax.persistence.metamodel.Metamodel;
+
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.context.SecurityContextHolder;
+
+import com.introproventures.graphql.jpa.query.schema.RestrictedKeysProvider;
+import com.introproventures.graphql.jpa.query.schema.impl.EntityIntrospector.EntityIntrospectionResult;
+
+public class SpringSecurityRestrictedKeysProvider implements RestrictedKeysProvider {
+    
+    private final Metamodel metamodel;
+    
+    public SpringSecurityRestrictedKeysProvider(Metamodel metamodel) {
+        this.metamodel = metamodel;
+    }
+
+    @Override
+    public Optional<List<Object>> apply(EntityIntrospectionResult entityDescriptor) {
+        Authentication token = SecurityContextHolder.getContext()
+                                                    .getAuthentication();
+        if (token == null) {
+            return Optional.empty();
+        }
+
+        String entityName = metamodel.entity(entityDescriptor.getEntity())
+                                     .getName();
+
+        List<Object> keys = resolveKeys(entityName, token.getAuthorities());
+
+        return keys.isEmpty() ? Optional.empty() // restrict query if no permissions exists 
+                              : Optional.of(keys); // execute query with restricted keys
+    }
+    
+    private List<Object> resolveKeys(String entityName, Collection<? extends GrantedAuthority> grantedAuthorities) {
+        return grantedAuthorities.stream()
+                                 .filter(GrantedAuthority.class::isInstance)
+                                 .map(GrantedAuthority.class::cast)
+                                 .map(GrantedAuthority::getAuthority)
+                                 .map(authority -> authority.split(":"))
+                                 .filter(permission -> entityName.equals(permission[0]))
+                                 .filter(permission -> "read".equals(permission[1]))
+                                 .map(permission -> permission[2])
+                                 .collect(Collectors.toList());
+
+    }
+    
+}

--- a/graphql-jpa-query-schema/src/test/resources/RestrictedKeysProviderTests.sql
+++ b/graphql-jpa-query-schema/src/test/resources/RestrictedKeysProviderTests.sql
@@ -1,0 +1,6 @@
+-- Things
+insert into thing (id, type) values
+    ('2D1EBC5B7D2741979CF0E84451C5BBB1', 'Thing1'),
+    ('2D1EBC5B7D2741979CF0E84451C5BBC1', 'Thing2'),
+    ('2D1EBC5B7D2741979CF0E84451C5BBD1', 'Thing3');
+   


### PR DESCRIPTION
This PR adds support for row filtering via restricting query search criteria using pluggable RestrictedKeysProvider implementation.

The RestrictedKeysProvider functional interface should provide a list of restricted keys in order to filter records  at runtime based on user security context and supplied EntityIntrospection descriptor arugment.  

The return argument uses Optional<List<Object>> return type.  
 * The non-empty list will restrict the query results to provided keys 
 * The empty list will execute the query without any restrictions.  
 * The empty Optional will block running the query and return empty result list or null value.  

```java
@FunctionalInterface
public interface RestrictedKeysProvider extends Function<EntityIntrospectionResult, Optional<List<Object>>> {

    /**
     * Applies this restricted keys provider function to the given argument of entityDescriptor.
     *
     * @param entityDescriptor the function argument
     * @return the function result with optional list of keys
     */
    @Override
    Optional<List<Object>> apply(EntityIntrospectionResult entityDescriptor);
    
}
```

You can configure the implementation of the provider via `GraphqJpaSchemaBuilder.restrictedKeysProvider` builder method Java Api, i.e., 

```
graphQLSchemaBuilder = GraphQLJpaSchemaBuilder(entityManager)
                .name("GraphQLBooks")
                .description("Books JPA test schema")
                .restrictedKeysProvider(new SpringSecurityRestrictedKeysProvider(entityManager.getMetamode()));
```

```java
public class SpringSecurityRestrictedKeysProvider implements RestrictedKeysProvider {
    
    private final Metamodel metamodel;
    
    public SpringSecurityRestrictedKeysProvider(Metamodel metamodel) {
        this.metamodel = metamodel;
    }

    @Override
    public Optional<List<Object>> apply(EntityIntrospectionResult entityDescriptor) {
        Authentication token = SecurityContextHolder.getContext()
                                                    .getAuthentication();
        if (token == null) {
            return Optional.empty();
        }
        
        // resolve entity name from descriptor
        String entityName = metamodel.entity(entityDescriptor.getEntity())
                                     .getName();

        // resolve keys from entityName and user token in permission store
        List<Object> keys = resolveKeys(entityName, token);

        return keys.isEmpty() ? Optional.empty() // restrict query if no permissions exists 
                              : Optional.of(keys); // execute query with restricted keys
    }
    
```

The provided `graphql-jpa-query-boot-starter` will detect and automatically inject RestrictedKeysProvider bean instance from application context. 

Fixes https://github.com/introproventures/graphql-jpa-query/issues/219
