### PR TITLE
fix: add support for java.sql.Timestamp GraphQLScalar coercing

### DIFF
--- a/graphql-jpa-query-schema/src/main/java/com/introproventures/graphql/jpa/query/schema/JavaScalars.java
+++ b/graphql-jpa-query-schema/src/main/java/com/introproventures/graphql/jpa/query/schema/JavaScalars.java
@@ -64,6 +64,7 @@ import graphql.language.StringValue;
 import graphql.language.Value;
 import graphql.language.VariableReference;
 import graphql.schema.Coercing;
+import graphql.schema.CoercingParseLiteralException;
 import graphql.schema.CoercingParseValueException;
 import graphql.schema.CoercingSerializeException;
 import graphql.schema.GraphQLScalarType;
@@ -628,7 +629,7 @@ public class JavaScalars {
             else if (StringValue.class.isInstance(input)) {
                 value = StringValue.class.cast(input).getValue();
             } else {
-                throw new CoercingParseValueException("Invalid value '" + input + "' for Timestamp");
+                throw new CoercingParseLiteralException("Invalid value '" + input + "' for Timestamp");
             }
             
             return doConvert(value);
@@ -791,8 +792,8 @@ public class JavaScalars {
 
             @Override
             public Instant apply(String date) {
-                return OffsetDateTime.parse(date, FORMATTER)
-                                     .toInstant();
+                return ZonedDateTime.parse(date, FORMATTER)
+                                    .toInstant();
             }
         }
         
@@ -803,8 +804,8 @@ public class JavaScalars {
 
             @Override
             public Instant apply(String date) {
-                return OffsetDateTime.parse(date, FORMATTER)
-                                     .toInstant();
+                return LocalDateTime.parse(date, FORMATTER)
+                                    .toInstant(ZoneOffset.UTC);
             }
         }    
 

--- a/graphql-jpa-query-schema/src/main/java/com/introproventures/graphql/jpa/query/schema/JavaScalars.java
+++ b/graphql-jpa-query-schema/src/main/java/com/introproventures/graphql/jpa/query/schema/JavaScalars.java
@@ -748,6 +748,7 @@ public class JavaScalars {
         static {
             CONVERTERS.add(new InstantConverter());
             CONVERTERS.add(new OffsetDateTimeConverter());
+            CONVERTERS.add(new ZonedDateTimeConverter());
             CONVERTERS.add(new LocalDateTimeConverter());
             CONVERTERS.add(new LocalDateConverter());
         }
@@ -775,33 +776,45 @@ public class JavaScalars {
 
         static class OffsetDateTimeConverter implements Function<String, Instant> {
 
-            static final DateTimeFormatter ISO_OFFSET_DATE_TIME = DateTimeFormatter.ISO_OFFSET_DATE_TIME.withZone(ZoneOffset.UTC);
+            static final DateTimeFormatter FORMATTER = DateTimeFormatter.ISO_OFFSET_DATE_TIME.withZone(ZoneOffset.UTC);
 
             @Override
             public Instant apply(String date) {
-                return OffsetDateTime.parse(date, ISO_OFFSET_DATE_TIME)
+                return OffsetDateTime.parse(date, FORMATTER)
                                      .toInstant();
             }
         }
         
-        static class LocalDateTimeConverter implements Function<String, Instant> {
+        static class ZonedDateTimeConverter implements Function<String, Instant> {
 
-            static final DateTimeFormatter ISO_LOCAL_DATE_TIME = DateTimeFormatter.ISO_LOCAL_DATE_TIME.withZone(ZoneOffset.UTC);
+            static final DateTimeFormatter FORMATTER = DateTimeFormatter.ISO_ZONED_DATE_TIME.withZone(ZoneOffset.UTC);
 
             @Override
             public Instant apply(String date) {
-                return OffsetDateTime.parse(date, ISO_LOCAL_DATE_TIME)
+                return OffsetDateTime.parse(date, FORMATTER)
+                                     .toInstant();
+            }
+        }
+        
+        
+        static class LocalDateTimeConverter implements Function<String, Instant> {
+
+            static final DateTimeFormatter FORMATTER = DateTimeFormatter.ISO_LOCAL_DATE_TIME.withZone(ZoneOffset.UTC);
+
+            @Override
+            public Instant apply(String date) {
+                return OffsetDateTime.parse(date, FORMATTER)
                                      .toInstant();
             }
         }    
 
         static class LocalDateConverter implements Function<String, Instant> {
 
-            static final DateTimeFormatter ISO_LOCAL_DATE = DateTimeFormatter.ISO_LOCAL_DATE.withZone(ZoneOffset.UTC);
+            static final DateTimeFormatter FORMATTER = DateTimeFormatter.ISO_LOCAL_DATE.withZone(ZoneOffset.UTC);
 
             @Override
             public Instant apply(String date) {
-                LocalDate localDate = LocalDate.parse(date, ISO_LOCAL_DATE);
+                LocalDate localDate = LocalDate.parse(date, FORMATTER);
 
                 return localDate.atStartOfDay()
                                 .toInstant(ZoneOffset.UTC);

--- a/graphql-jpa-query-schema/src/main/java/com/introproventures/graphql/jpa/query/schema/JavaScalars.java
+++ b/graphql-jpa-query-schema/src/main/java/com/introproventures/graphql/jpa/query/schema/JavaScalars.java
@@ -583,7 +583,7 @@ public class JavaScalars {
 
     public static class GraphQLSqlTimestampCoercing implements Coercing<Timestamp, Object> {
 
-        private Timestamp convert(Object input) {
+        private Timestamp doConvert(Object input) {
             if (input instanceof Long) {
                 return new Timestamp(Long.class.cast(input));
             } else if (input instanceof String) {
@@ -597,20 +597,18 @@ public class JavaScalars {
         
         @Override
         public Object serialize(Object input) {
-            if (input instanceof Timestamp) {
-                return DateTimeFormatter.ISO_INSTANT.format(Timestamp.class.cast(input).toInstant());
-            } else {
-                Timestamp result = convert(input);
-                if (result == null) {
-                    throw new CoercingSerializeException("Invalid value '" + input + "' for Timestamp");
-                }
-                return DateTimeFormatter.ISO_INSTANT.format(result.toInstant());
+            Timestamp result = doConvert(input);
+            
+            if (result == null) {
+                throw new CoercingSerializeException("Invalid value '" + input + "' for Timestamp");
             }
+            
+            return DateTimeFormatter.ISO_INSTANT.format(result.toInstant());
         }
 
         @Override
         public Timestamp parseValue(Object input) {
-            Timestamp result = convert(input);
+            Timestamp result = doConvert(input);
             
             if (result == null) {
                 throw new CoercingParseValueException("Invalid value '" + input + "' for Timestamp");
@@ -631,7 +629,7 @@ public class JavaScalars {
                 throw new CoercingParseValueException("Invalid value '" + input + "' for Timestamp");
             }
             
-            return convert(value);
+            return doConvert(value);
         }
     }
 

--- a/graphql-jpa-query-schema/src/test/java/com/introproventures/graphql/jpa/query/schema/JavaScalarsTest.java
+++ b/graphql-jpa-query-schema/src/test/java/com/introproventures/graphql/jpa/query/schema/JavaScalarsTest.java
@@ -367,14 +367,6 @@ public class JavaScalarsTest {
         //then
         assertThat(result).asInstanceOf(new InstanceOfAssertFactory<>(Timestamp.class, Assertions::assertThat))
                           .isEqualTo(expected);
-
-//        //when
-//        String localDateTime = LocalDateTime.ofInstant(instant, ZoneOffset.systemDefault()).toString();
-//        result = coercing.parseLiteral(StringValue.newStringValue(localDateTime).build());
-//
-//        //then
-//        assertThat(result).asInstanceOf(new InstanceOfAssertFactory<>(Timestamp.class, Assertions::assertThat))
-//                          .isEqualTo(expected);
     }    
 
     @Test

--- a/graphql-jpa-query-schema/src/test/java/com/introproventures/graphql/jpa/query/schema/JavaScalarsTest.java
+++ b/graphql-jpa-query-schema/src/test/java/com/introproventures/graphql/jpa/query/schema/JavaScalarsTest.java
@@ -30,6 +30,7 @@ import java.time.OffsetDateTime;
 import java.time.ZoneId;
 import java.time.ZoneOffset;
 import java.time.ZonedDateTime;
+import java.time.format.DateTimeFormatter;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
@@ -300,38 +301,38 @@ public class JavaScalarsTest {
     }
     
     @Test
-    public void serializeTimestamp() {
+    public void testTimestampSerialize() {
         //given
-        Coercing<?, ?> coercing = JavaScalars.of(Timestamp.class).getCoercing();
-        Instant instant = Instant.parse("2019-08-05T07:15:07Z");
+        Coercing<?, ?> subject = JavaScalars.of(Timestamp.class).getCoercing();
+        Instant expected = Instant.parse("2019-08-05T07:15:07Z");
 
-        final Timestamp timestamp = new Timestamp(instant.toEpochMilli());
+        final Timestamp input = new Timestamp(expected.toEpochMilli());
 
         //when
-        Object result = coercing.serialize(timestamp);
+        Object result = subject.serialize(input);
 
         //then
         assertThat(result).asString()
-                          .isEqualTo(instant.toString());
+                          .isEqualTo(expected.toString());
         
         //when
-        result = coercing.serialize(instant.toString());
+        result = subject.serialize(expected.toString());
 
         //then
         assertThat(result).asString()
-                          .isEqualTo(instant.toString());
+                          .isEqualTo(expected.toString());
 
         //when
-        result = coercing.serialize(instant.toEpochMilli());
+        result = subject.serialize(expected.toEpochMilli());
 
         //then
         assertThat(result).asString()
-                          .isEqualTo(instant.toString());
+                          .isEqualTo(expected.toString());
         
     }
     
     @Test
-    public void parseValueTimestamp() {
+    public void testTimestampParseValue() {
         //given
         Coercing<?, ?> coercing = JavaScalars.of(Timestamp.class).getCoercing();
         Instant instant = Instant.parse("2019-08-05T07:15:07Z");
@@ -346,7 +347,7 @@ public class JavaScalarsTest {
     }    
     
     @Test
-    public void parseLiteralStringValueTimestamp() {
+    public void testTimestampParseLiteralStringValue() {
         //given
         Coercing<?, ?> coercing = JavaScalars.of(Timestamp.class).getCoercing();
         Instant instant = Instant.parse("2019-08-05T07:15:07Z");
@@ -359,18 +360,10 @@ public class JavaScalarsTest {
         //then
         assertThat(result).asInstanceOf(new InstanceOfAssertFactory<>(Timestamp.class, Assertions::assertThat))
                           .isEqualTo(expected);
-        
-        //when
-        String offsetTimeZone = OffsetDateTime.ofInstant(instant, ZoneOffset.systemDefault()).toString();
-        result = coercing.parseLiteral(StringValue.newStringValue(offsetTimeZone).build());
-
-        //then
-        assertThat(result).asInstanceOf(new InstanceOfAssertFactory<>(Timestamp.class, Assertions::assertThat))
-                          .isEqualTo(expected);
     }    
 
     @Test
-    public void parseLiteralIntValueTimestamp() {
+    public void testTimestampParseLiteralIntValue() {
         //given
         Coercing<?, ?> coercing = JavaScalars.of(Timestamp.class).getCoercing();
         Instant instant = Instant.parse("2019-08-05T07:15:07Z");
@@ -385,6 +378,60 @@ public class JavaScalarsTest {
                           .isEqualTo(expected);
     }    
     
+    @Test
+    public void testTimestampParseLiteralStringValueOffsetDateTime() {
+        //given
+        Coercing<?, ?> coercing = JavaScalars.of(Timestamp.class).getCoercing();
+        OffsetDateTime offsetDateTime = OffsetDateTime.parse("2020-09-06T11:45:27-07:00");
+        Instant instant = offsetDateTime.toInstant();
+        
+        Timestamp expected = new Timestamp(instant.toEpochMilli());
+        StringValue input = StringValue.newStringValue(offsetDateTime.toString()).build();
+        
+        //when
+        Object result = coercing.parseLiteral(input);
+
+        //then
+        assertThat(result).asInstanceOf(new InstanceOfAssertFactory<>(Timestamp.class, Assertions::assertThat))
+                          .isEqualTo(expected);
+    }  
+
+    @Test
+    public void testTimestampParseLiteralStringValueLocalDateTime() {
+        //given
+        Coercing<?, ?> coercing = new JavaScalars.GraphQLSqlTimestampCoercing();
+        LocalDateTime localDateTime = LocalDateTime.parse("2019-08-05T07:15:07", DateTimeFormatter.ISO_LOCAL_DATE_TIME.withZone(ZoneId.of("UTC")));
+        Instant instant = localDateTime.toInstant(ZoneOffset.UTC);
+        
+        Timestamp expected = new Timestamp(instant.toEpochMilli());
+        StringValue input = StringValue.newStringValue(localDateTime.toString()).build();
+        
+        //when
+        Object result = coercing.parseLiteral(input);
+
+        //then
+        assertThat(result).asInstanceOf(new InstanceOfAssertFactory<>(Timestamp.class, Assertions::assertThat))
+                          .isEqualTo(expected);
+    }  
+    
+    
+    @Test
+    public void testTimestampParseLiteralStringValueLocalDate() {
+        //given
+        Coercing<?, ?> coercing = new JavaScalars.GraphQLSqlTimestampCoercing();
+        Instant instant = Instant.parse("2019-08-05T00:00:00Z");
+        String localDate = LocalDate.ofInstant(instant, ZoneOffset.UTC).toString();
+        
+        Timestamp expected = new Timestamp(instant.toEpochMilli());
+        StringValue input = StringValue.newStringValue(localDate).build();
+        
+        //when
+        Object result = coercing.parseLiteral(input);
+
+        //then
+        assertThat(result).asInstanceOf(new InstanceOfAssertFactory<>(Timestamp.class, Assertions::assertThat))
+                          .isEqualTo(expected);
+    }
     
     @Test
     public void dateCoercionThreadSafe() throws InterruptedException, ExecutionException {

--- a/graphql-jpa-query-schema/src/test/java/com/introproventures/graphql/jpa/query/schema/JavaScalarsTest.java
+++ b/graphql-jpa-query-schema/src/test/java/com/introproventures/graphql/jpa/query/schema/JavaScalarsTest.java
@@ -397,6 +397,23 @@ public class JavaScalarsTest {
     }  
 
     @Test
+    public void testTimestampParseLiteralStringValueZonedDateTime() {
+        //given
+        Coercing<?, ?> coercing = JavaScalars.of(Timestamp.class).getCoercing();
+        ZonedDateTime zonedDateTime = ZonedDateTime.parse("2020-09-06T11:45:27-07:00[America/Los_Angeles]");
+        Instant instant = zonedDateTime.toInstant();
+        
+        Timestamp expected = new Timestamp(instant.toEpochMilli());
+        StringValue input = StringValue.newStringValue(zonedDateTime.toString()).build();
+        
+        //when
+        Object result = coercing.parseLiteral(input);
+
+        //then
+        assertThat(result).asInstanceOf(new InstanceOfAssertFactory<>(Timestamp.class, Assertions::assertThat))
+                          .isEqualTo(expected);
+    }      
+    @Test
     public void testTimestampParseLiteralStringValueLocalDateTime() {
         //given
         Coercing<?, ?> coercing = new JavaScalars.GraphQLSqlTimestampCoercing();

--- a/graphql-jpa-query-schema/src/test/java/com/introproventures/graphql/jpa/query/schema/JavaScalarsTest.java
+++ b/graphql-jpa-query-schema/src/test/java/com/introproventures/graphql/jpa/query/schema/JavaScalarsTest.java
@@ -45,9 +45,11 @@ import org.junit.Test;
 import com.introproventures.graphql.jpa.query.converter.model.VariableValue;
 import com.introproventures.graphql.jpa.query.schema.JavaScalars.GraphQLObjectCoercing;
 
+import graphql.language.BooleanValue;
 import graphql.language.IntValue;
 import graphql.language.StringValue;
 import graphql.schema.Coercing;
+import graphql.schema.CoercingParseLiteralException;
 import graphql.schema.CoercingParseValueException;
 import graphql.schema.CoercingSerializeException;
 import graphql.schema.GraphQLScalarType;
@@ -362,6 +364,36 @@ public class JavaScalarsTest {
                           .isEqualTo(expected);
     }    
 
+    @Test(expected = CoercingParseLiteralException.class)
+    public void testTimestampParseLiteralWrongValue() {
+        //given
+        Coercing<?, ?> coercing = new JavaScalars.GraphQLSqlTimestampCoercing();
+        Object input = Boolean.valueOf("true");
+        
+        //when
+        coercing.parseLiteral(input);
+    }    
+
+    @Test(expected = CoercingParseValueException.class)
+    public void testTimestampParseValueWrongValue() {
+        //given
+        Coercing<?, ?> coercing = new JavaScalars.GraphQLSqlTimestampCoercing();
+        Object input = Boolean.valueOf("true");
+        
+        //when
+        coercing.parseValue(input);
+    }       
+    @Test(expected = CoercingSerializeException.class)
+    public void testTimestampSerializeWrongValue() {
+        //given
+        Coercing<?, ?> coercing = new JavaScalars.GraphQLSqlTimestampCoercing();
+        Object input = BooleanValue.newBooleanValue(true).build();
+        
+        //when
+        coercing.serialize(input);
+    }    
+        
+    
     @Test
     public void testTimestampParseLiteralIntValue() {
         //given
@@ -431,16 +463,15 @@ public class JavaScalarsTest {
                           .isEqualTo(expected);
     }  
     
-    
     @Test
     public void testTimestampParseLiteralStringValueLocalDate() {
         //given
         Coercing<?, ?> coercing = new JavaScalars.GraphQLSqlTimestampCoercing();
-        Instant instant = Instant.parse("2019-08-05T00:00:00Z");
-        String localDate = LocalDate.ofInstant(instant, ZoneOffset.UTC).toString();
+        LocalDate localDate = LocalDate.parse("2019-08-05", DateTimeFormatter.ISO_LOCAL_DATE.withZone(ZoneId.of("UTC")));
+        Instant instant = localDate.atStartOfDay(ZoneId.of("UTC")).toInstant();
         
         Timestamp expected = new Timestamp(instant.toEpochMilli());
-        StringValue input = StringValue.newStringValue(localDate).build();
+        StringValue input = StringValue.newStringValue(localDate.toString()).build();
         
         //when
         Object result = coercing.parseLiteral(input);


### PR DESCRIPTION
This PR adds support for parsing and serializing Timestamp scalar value, i.e.

- [x] Epoch time in milliseconds 
- [x] ISO Instant
- [x] ISO Offset Date/Time 
- [x] ISO Zoned Date/Time
- [x] ISO Local Date/Time 
- [x] ISO Local Date 

The output of serialize is a string in ISO 8086 Date/Time in UTC time zone, i.e. "2019-08-05T07:15:07Z"

The output of parseValue and parseLiteral is java.sql Timestamp value in UTC time zone. 
