### PR TITLE
fix: support EQ/NE nullable criteria values  for Java scalars

### DIFF
--- a/graphql-jpa-query-schema/src/test/java/com/introproventures/graphql/jpa/query/converter/GraphQLJpaConverterTests.java
+++ b/graphql-jpa-query-schema/src/test/java/com/introproventures/graphql/jpa/query/converter/GraphQLJpaConverterTests.java
@@ -226,7 +226,7 @@ public class GraphQLJpaConverterTests extends AbstractSpringBootTestSupport {
 
         // then:
         assertThat(result).isNotEmpty();
-        assertThat(result).hasSize(4);
+        assertThat(result).hasSize(5);
     }    
     
     @Test
@@ -258,7 +258,7 @@ public class GraphQLJpaConverterTests extends AbstractSpringBootTestSupport {
 
         // then:
         assertThat(result).isNotEmpty();
-        assertThat(result).hasSize(4);
+        assertThat(result).hasSize(5);
     }       
     
     @Test // Problem with generating cast() in the where expression
@@ -823,7 +823,72 @@ public class GraphQLJpaConverterTests extends AbstractSpringBootTestSupport {
 
         // then
         assertThat(result.toString()).isEqualTo(expected);
-    }       
+    }
 
+    @Test
+    public void testGraphqlTasksQueryWithEQNullValues() {
+        // @formatter:off
+        String query =
+                "query {" +
+                        "  Tasks(" +
+                        "    page: { start: 1, limit: 100 }" +
+                        "    where: { status: { IN: [CREATED, ASSIGNED] }, dueDate: { EQ: null } }" +
+                        "  ) {" +
+                        "    select {" +
+                        "      id" +
+                        "      businessKey" +
+                        "      name" +
+                        "      status" +
+                        "      priority(orderBy: DESC)" +
+                        "      dueDate(orderBy: ASC)" +
+                        "      assignee" +
+                        "    }" +
+                        "  }" +
+                        "}";
+        // @formatter:on
+
+        Object result = executor.execute(query).getData();
+
+        String expected = "{Tasks={select=[" +
+                "{id=2, businessKey=null, name=task2, status=CREATED, priority=10, dueDate=null, assignee=assignee}, " +
+                "{id=4, businessKey=null, name=task4, status=CREATED, priority=10, dueDate=null, assignee=assignee}, " +
+                "{id=6, businessKey=bk6, name=task6, status=ASSIGNED, priority=10, dueDate=null, assignee=assignee}, " +
+                "{id=3, businessKey=null, name=task3, status=CREATED, priority=5, dueDate=null, assignee=assignee}" +
+                "]}}";
+
+        assertThat(result.toString()).isEqualTo(expected);
+    }
+
+    @Test
+    public void testGraphqlTasksQueryWithNENullValues() {
+        // @formatter:off
+        String query =
+                "query {" +
+                        "  Tasks(" +
+                        "    page: { start: 1, limit: 100 }" +
+                        "    where: { status: { IN: [ASSIGNED, COMPLETED] }, businessKey: { NE: null } }" +
+                        "  ) {" +
+                        "    select {" +
+                        "      id" +
+                        "      businessKey" +
+                        "      name" +
+                        "      status" +
+                        "      priority(orderBy: DESC)" +
+                        "      dueDate(orderBy: ASC)" +
+                        "      assignee" +
+                        "    }" +
+                        "  }" +
+                        "}";
+        // @formatter:on
+
+        Object result = executor.execute(query).getData();
+
+        String expected = "{Tasks={select=[" +
+                "{id=6, businessKey=bk6, name=task6, status=ASSIGNED, priority=10, dueDate=null, assignee=assignee}, " +
+                "{id=1, businessKey=bk1, name=task1, status=COMPLETED, priority=5, dueDate=null, assignee=assignee}" +
+                "]}}";
+
+        assertThat(result.toString()).isEqualTo(expected);
+    }
 
 }

--- a/graphql-jpa-query-schema/src/test/java/com/introproventures/graphql/jpa/query/converter/model/TaskEntity.java
+++ b/graphql-jpa-query-schema/src/test/java/com/introproventures/graphql/jpa/query/converter/model/TaskEntity.java
@@ -37,6 +37,7 @@ public class TaskEntity extends ActivitiEntityMetadata {
     private String assignee;
     private String name;
     private String description;
+    private String businessKey;
     @DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME)
     private Date createdDate;
     @DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME)
@@ -156,6 +157,10 @@ public class TaskEntity extends ActivitiEntityMetadata {
     public String getDescription() {
         return description;
     }
+
+    public String getBusinessKey() { return businessKey; }
+
+    public void setBusinessKey(String businessKey) { this.businessKey = businessKey; }
 
     public Date getCreatedDate() {
         return createdDate;

--- a/graphql-jpa-query-schema/src/test/resources/GraphQLJpaConverterTests.sql
+++ b/graphql-jpa-query-schema/src/test/resources/GraphQLJpaConverterTests.sql
@@ -3,12 +3,13 @@ insert into json_entity (id, first_name, last_name, attributes) values
 	(1, 'john', 'doe', '{"attr":{"key":["1","2","3","4","5"]}}'),
 	(2, 'joe', 'smith', '{"attr":["1","2","3","4","5"]}');
 
-insert into TASK (id, assignee, created_date, description, due_date, last_modified, last_modified_from, last_modified_to, name, priority, process_definition_id, process_instance_id, status, owner, claimed_date) values
-  ('1', 'assignee', CURRENT_TIMESTAMP, 'description', null, null, null, null, 'task1', 5, 'process_definition_id', 0, 'COMPLETED'  , 'owner', null),
-  ('2', 'assignee', CURRENT_TIMESTAMP, 'description', null, null, null, null, 'task2', 10, 'process_definition_id', 0, 'CREATED'  , 'owner', null),
-  ('3', 'assignee', CURRENT_TIMESTAMP, 'description', null, null, null, null, 'task3', 5, 'process_definition_id', 0, 'CREATED'  , 'owner', null),
-  ('4', 'assignee', CURRENT_TIMESTAMP, 'description', null, null, null, null, 'task4', 10, 'process_definition_id', 1, 'CREATED'  , 'owner', null),
-  ('5', 'assignee', CURRENT_TIMESTAMP, 'description', null, null, null, null, 'task5', 5, 'process_definition_id', 1, 'COMPLETED'  , 'owner', null);
+insert into task (id, assignee, business_key, created_date, description, due_date, last_modified, last_modified_from, last_modified_to, name, priority, process_definition_id, process_instance_id, status, owner, claimed_date) values
+('1', 'assignee', 'bk1', CURRENT_TIMESTAMP, 'description', null, null, null, null, 'task1', 5, 'process_definition_id', 0, 'COMPLETED'  , 'owner', null),
+('2', 'assignee', null, CURRENT_TIMESTAMP, 'description', null, null, null, null, 'task2', 10, 'process_definition_id', 0, 'CREATED'  , 'owner', null),
+('3', 'assignee', null, CURRENT_TIMESTAMP, 'description', null, null, null, null, 'task3', 5, 'process_definition_id', 0, 'CREATED'  , 'owner', null),
+('4', 'assignee', null, CURRENT_TIMESTAMP, 'description', null, null, null, null, 'task4', 10, 'process_definition_id', 1, 'CREATED'  , 'owner', null),
+('5', 'assignee', null, CURRENT_TIMESTAMP, 'description', null, null, null, null, 'task5', 10, 'process_definition_id', 1, 'COMPLETED'  , 'owner', null),
+('6', 'assignee', 'bk6', CURRENT_TIMESTAMP, 'description', null, null, null, null, 'task6', 10, 'process_definition_id', 0, 'ASSIGNED'  , 'owner', null);
 
 insert into PROCESS_VARIABLE (create_time, execution_id, last_updated_time, name, process_instance_id, type, value) values
   (CURRENT_TIMESTAMP, 'execution_id', CURRENT_TIMESTAMP, 'document', 1, 'json', '{"value":{"key":["1","2","3","4","5"]}}');


### PR DESCRIPTION
Add support for types to build EQ/NE predicates for Java scalars with `null` values

- Boolean.class
- Byte.class
- Character.class
- Double.class
- Float.class
- Integer.class
- Long.class
- Short.class
- BigInteger.class
- BigDecimal.class
- String.class
- Date.class
- LocalDate.class
- LocalDateTime.class
- ZonedDateTime.class
- Instant.class
- LocalTime.class
- Calendar.class
- OffsetDateTime.class
- java.sql.Date.class
- java.sql.Time.class
- java.sql.Timestamp.class
- UUID.class

See tests for details..