### PR TITLE
bugfix: query with embedded entity producing an exception

### DIFF
--- a/graphql-jpa-query-schema/src/test/java/com/introproventures/graphql/jpa/query/embeddedid/EntityWithEmbeddedIdTest.java
+++ b/graphql-jpa-query-schema/src/test/java/com/introproventures/graphql/jpa/query/embeddedid/EntityWithEmbeddedIdTest.java
@@ -94,16 +94,14 @@ public class EntityWithEmbeddedIdTest  extends AbstractSpringBootTestSupport {
     }
     
     @Test
-    public void queryBooksWithyWithEmbeddedIdWhereCriteriaExpression() {
+    public void queryBooksWithWithEmbeddedIdWhereCriteriaExpression() {
         //given
         String query = "query {" +
                 "  Books( " +
                 "    where: {" +
                 "      bookId: {" +
-                "        EQ: {" +
-                "          title: \"War and Piece\"" +
-                "          language: \"Russian\"" +
-                "        }" +
+                "        title: {LIKE: \"War % Piece\"}" +
+                "        language: {EQ: \"Russian\"}" +
                 "      }" +
                 "    }" +
                 "  ){" +

--- a/graphql-jpa-query-schema/src/test/java/com/introproventures/graphql/jpa/query/schema/GraphQLExecutorTests.java
+++ b/graphql-jpa-query-schema/src/test/java/com/introproventures/graphql/jpa/query/schema/GraphQLExecutorTests.java
@@ -770,6 +770,20 @@ public class GraphQLExecutorTests extends AbstractSpringBootTestSupport {
         assertThat(result.toString()).isEqualTo(expected);
     }
 
+    @Test
+    public void whereQueryWithSeparateEmbeddedEntityFieldsCriterias() {
+        //given
+        String query = "query { Cars(where: { engine: {identification:{LIKE:\"%\"}, hp:{GE:200}} }) { select {id brand} } }";
+
+        String expected = "{Cars={select=[{id=2, brand=Cadillac}]}}";
+
+        //when
+        Object result = executor.execute(query).getData();
+
+        // then
+        assertThat(result.toString()).isEqualTo(expected);
+    }
+
     // https://github.com/introproventures/graphql-jpa-query/issues/30
     @Test
     public void queryForEntityWithEmbeddedIdAndEmbeddedField() {

--- a/graphql-jpa-query-schema/src/test/java/com/introproventures/graphql/jpa/query/schema/model/embedded/Engine.java
+++ b/graphql-jpa-query-schema/src/test/java/com/introproventures/graphql/jpa/query/schema/model/embedded/Engine.java
@@ -6,5 +6,6 @@ import javax.persistence.Embeddable;
 public class Engine {
 
     String identification;
+    Long hp;
 
 }

--- a/graphql-jpa-query-schema/src/test/resources/data.sql
+++ b/graphql-jpa-query-schema/src/test/resources/data.sql
@@ -143,10 +143,10 @@ insert into book_publishers(book_id, name, country) values
 	(2, 'Willey', 'US'), (2, 'Simon', 'EU');
 	
 -- Car
-insert into Car (id, brand, identification) values
-	(1, 'Ford', 'xxxxx'),
-	(2, 'Cadillac', 'yyyyy'),
-	(3, 'Toyota', 'zzzzz');
+insert into Car (id, brand, identification, hp) values
+	(1, 'Ford', 'xxxxx', 160),
+	(2, 'Cadillac', 'yyyyy', 250),
+	(3, 'Toyota', 'zzzzz', 180);
 
 	
 -- Boat


### PR DESCRIPTION
lets consider an example:
we have an entity with `@Embedded` field
embedded field contains a long value

we want to make query where embedded.longVal > 7
but unfortunately there was no way to do so, because if we do where query with:
`embedded: {GT: {longVal: 7}}`
we will get an exception.
`Unsupported field type class <className> for field <embeddedField>`

this PR changes schema generation for embedded and allows for such queries to be performed.
(query will look like: `embedded: {longVal: {GT: 7}}`)