### PR TITLE
fix: resolve default GraphQLSchemaConfigurer bean race condition in autoconfigure

### DIFF
--- a/graphql-jpa-query-autoconfigure/src/main/java/com/introproventures/graphql/jpa/query/autoconfigure/GraphQLSchemaAutoConfiguration.java
+++ b/graphql-jpa-query-autoconfigure/src/main/java/com/introproventures/graphql/jpa/query/autoconfigure/GraphQLSchemaAutoConfiguration.java
@@ -2,7 +2,7 @@ package com.introproventures.graphql.jpa.query.autoconfigure;
 
 import graphql.GraphQL;
 import graphql.schema.GraphQLSchema;
-import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.autoconfigure.AutoConfigureAfter;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
@@ -10,9 +10,7 @@ import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.PropertySource;
 import org.springframework.context.annotation.PropertySources;
-import org.springframework.util.CollectionUtils;
 
-import java.util.ArrayList;
 import java.util.List;
 
 @Configuration
@@ -22,32 +20,29 @@ import java.util.List;
     @PropertySource("classpath:com/introproventures/graphql/jpa/query/boot/autoconfigure/default.properties"),
     @PropertySource(value = "classpath:graphql-jpa-autoconfigure.properties", ignoreResourceNotFound = true)
 })
+@AutoConfigureAfter(GraphQLSchemaBuilderAutoConfiguration.class)
 public class GraphQLSchemaAutoConfiguration {
 
-    private final List<GraphQLSchemaConfigurer> graphQLSchemaConfigurers = new ArrayList<>();
-    
-    @Autowired(required = true)
-    public void setGraphQLSchemaConfigurers(List<GraphQLSchemaConfigurer> configurers) {
-        if (!CollectionUtils.isEmpty(configurers)) {
-        	graphQLSchemaConfigurers.addAll(configurers);
-        }
+    @Bean
+    @ConditionalOnMissingBean
+    public GraphQLShemaRegistration graphQLShemaRegistration() {
+        return new GraphQLShemaRegistrationImpl();
     }
-    
+
     @Bean
     @ConditionalOnMissingBean(GraphQLSchema.class)
-    public GraphQLSchemaFactoryBean graphQLSchemaFactoryBean(GraphQLJpaQueryProperties properties) {
-    	GraphQLShemaRegistrationImpl graphQLShemaRegistration = new GraphQLShemaRegistrationImpl();
-
+    public GraphQLSchemaFactoryBean graphQLSchemaFactoryBean(GraphQLJpaQueryProperties properties,
+                                                             GraphQLShemaRegistration graphQLShemaRegistration,
+                                                             List<GraphQLSchemaConfigurer> graphQLSchemaConfigurers) {
         for (GraphQLSchemaConfigurer configurer : graphQLSchemaConfigurers) {
             configurer.configure(graphQLShemaRegistration);
         }
-        
+
         return new GraphQLSchemaFactoryBean(graphQLShemaRegistration.getManagedGraphQLSchemas())
 	        		.setQueryName(properties.getName())
 	    			.setQueryDescription(properties.getDescription());
-        
-        
+
+
     };
-    
-    
+
 }

--- a/graphql-jpa-query-autoconfigure/src/main/java/com/introproventures/graphql/jpa/query/autoconfigure/GraphQLSchemaBuilderAutoConfiguration.java
+++ b/graphql-jpa-query-autoconfigure/src/main/java/com/introproventures/graphql/jpa/query/autoconfigure/GraphQLSchemaBuilderAutoConfiguration.java
@@ -4,9 +4,9 @@ import com.introproventures.graphql.jpa.query.schema.GraphQLSchemaBuilder;
 import com.introproventures.graphql.jpa.query.schema.RestrictedKeysProvider;
 import com.introproventures.graphql.jpa.query.schema.impl.GraphQLJpaSchemaBuilder;
 import graphql.GraphQL;
+import org.springframework.beans.factory.InitializingBean;
 import org.springframework.beans.factory.ObjectProvider;
 import org.springframework.boot.autoconfigure.AutoConfigureAfter;
-import org.springframework.boot.autoconfigure.AutoConfigureBefore;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
@@ -16,11 +16,11 @@ import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
 import javax.persistence.EntityManagerFactory;
+import java.util.List;
 
 @Configuration
 @ConditionalOnClass({GraphQL.class, GraphQLSchemaBuilder.class})
 @ConditionalOnProperty(name="spring.graphql.jpa.query.enabled", havingValue="true", matchIfMissing=true)
-@AutoConfigureBefore(GraphQLSchemaAutoConfiguration.class)
 @AutoConfigureAfter(HibernateJpaAutoConfiguration.class)
 public class GraphQLSchemaBuilderAutoConfiguration {
     @Bean
@@ -36,11 +36,15 @@ public class GraphQLSchemaBuilderAutoConfiguration {
     }
 
     @Bean
-    @ConditionalOnMissingBean
-    public GraphQLSchemaConfigurer graphQLJpaQuerySchemaConfigurer(GraphQLSchemaBuilder graphQLSchemaBuilder) {
-
-        return (registry) -> {
-            registry.register(graphQLSchemaBuilder.build());
+    @ConditionalOnMissingBean(GraphQLSchemaConfigurer.class)
+    InitializingBean defaultGraphQLSchemaBuilderConfigurer(GraphQLShemaRegistration graphQLShemaRegistration,
+                                                           GraphQLSchemaBuilder graphQLSchemaBuilder,
+                                                           List<GraphQLSchemaConfigurer> configurers) {
+        return () -> {
+            if (configurers.isEmpty()) {
+                graphQLShemaRegistration.register(graphQLSchemaBuilder.build());
+            }
         };
     }
+
 }

--- a/graphql-jpa-query-autoconfigure/src/main/java/com/introproventures/graphql/jpa/query/autoconfigure/GraphQLShemaRegistration.java
+++ b/graphql-jpa-query-autoconfigure/src/main/java/com/introproventures/graphql/jpa/query/autoconfigure/GraphQLShemaRegistration.java
@@ -4,7 +4,7 @@ import graphql.schema.GraphQLSchema;
 
 public interface GraphQLShemaRegistration {
 
-	public void register(GraphQLSchema graphQLSchema);
+	void register(GraphQLSchema graphQLSchema);
 
-
+	GraphQLSchema[] getManagedGraphQLSchemas();
 }


### PR DESCRIPTION
This PR fixes default GraphQLSchemaConfigurer bean race condition in autoconfigure where Spring Boot ConditionalOnMissingBean missed existing GraphQLSchemaConfigurer beans in the application context.