### PR TITLE
fix: add spring-graphql  to graphq-jpa-query autoconfigure module

### DIFF
--- a/graphql-jpa-query-autoconfigure/pom.xml
+++ b/graphql-jpa-query-autoconfigure/pom.xml
@@ -62,6 +62,11 @@
       <artifactId>reactor-test</artifactId>
       <scope>test</scope>
     </dependency>
+    <dependency>
+      <groupId>org.springframework.boot</groupId>
+      <artifactId>spring-boot-starter-data-jpa</artifactId>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
   
 </project>

--- a/graphql-jpa-query-autoconfigure/pom.xml
+++ b/graphql-jpa-query-autoconfigure/pom.xml
@@ -54,7 +54,7 @@
     <dependency>
       <groupId>org.reflections</groupId>
       <artifactId>reflections</artifactId>
-      <version>0.9.11</version>
+      <version>0.10.2</version>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/graphql-jpa-query-autoconfigure/pom.xml
+++ b/graphql-jpa-query-autoconfigure/pom.xml
@@ -25,6 +25,11 @@
     </dependency>
     <dependency>
       <groupId>org.springframework.boot</groupId>
+      <artifactId>spring-boot-starter-graphql</artifactId>
+      <optional>true</optional>
+    </dependency>
+    <dependency>
+      <groupId>org.springframework.boot</groupId>
       <artifactId>spring-boot-autoconfigure</artifactId>
     </dependency>
     <dependency>

--- a/graphql-jpa-query-autoconfigure/src/main/java/com/introproventures/graphql/jpa/query/autoconfigure/EnableGraphQLJpaQuerySchema.java
+++ b/graphql-jpa-query-autoconfigure/src/main/java/com/introproventures/graphql/jpa/query/autoconfigure/EnableGraphQLJpaQuerySchema.java
@@ -1,0 +1,26 @@
+package com.introproventures.graphql.jpa.query.autoconfigure;
+
+import org.springframework.boot.autoconfigure.ImportAutoConfiguration;
+import org.springframework.boot.autoconfigure.domain.EntityScan;
+import org.springframework.context.annotation.Import;
+import org.springframework.core.annotation.AliasFor;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Target({ ElementType.TYPE })
+@Retention(RetentionPolicy.RUNTIME)
+@Documented
+@EntityScan
+@Import(EnableGraphQLJpaQuerySchemaImportSelector.class)
+@ImportAutoConfiguration(GraphQLSchemaBuilderAutoConfiguration.class)
+public @interface EnableGraphQLJpaQuerySchema {
+    @AliasFor(annotation = EntityScan.class, attribute = "basePackageClasses")
+    Class<?>[] value() default {};
+
+    @AliasFor(annotation = EntityScan.class, attribute = "basePackageClasses")
+    Class<?>[] basePackageClasses() default {};
+}

--- a/graphql-jpa-query-autoconfigure/src/main/java/com/introproventures/graphql/jpa/query/autoconfigure/EnableGraphQLJpaQuerySchemaImportSelector.java
+++ b/graphql-jpa-query-autoconfigure/src/main/java/com/introproventures/graphql/jpa/query/autoconfigure/EnableGraphQLJpaQuerySchemaImportSelector.java
@@ -1,0 +1,35 @@
+package com.introproventures.graphql.jpa.query.autoconfigure;
+
+import org.springframework.context.annotation.ImportSelector;
+import org.springframework.core.annotation.AnnotationAttributes;
+import org.springframework.core.type.AnnotationMetadata;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.stream.Stream;
+
+class EnableGraphQLJpaQuerySchemaImportSelector implements ImportSelector {
+
+    private static List<String> packageNames = new ArrayList<>();
+
+    @Override
+    public String[] selectImports(AnnotationMetadata importingClassMetadata) {
+        AnnotationAttributes attributes = AnnotationAttributes.fromMap(
+                importingClassMetadata.getAnnotationAttributes(
+                        EnableGraphQLJpaQuerySchema.class.getName(), false));
+
+        if (attributes != null) {
+            Stream.of(attributes.getClassArray("basePackageClasses"))
+                  .map(Class::getPackage)
+                  .map(Package::getName)
+                  .forEach(packageNames::add);
+        }
+
+        return new String[0];
+    }
+
+    static List<String> getPackageNames() {
+        return packageNames;
+    }
+
+}

--- a/graphql-jpa-query-autoconfigure/src/main/java/com/introproventures/graphql/jpa/query/autoconfigure/GraphQLJPASchemaBuilderCustomizer.java
+++ b/graphql-jpa-query-autoconfigure/src/main/java/com/introproventures/graphql/jpa/query/autoconfigure/GraphQLJPASchemaBuilderCustomizer.java
@@ -1,0 +1,8 @@
+package com.introproventures.graphql.jpa.query.autoconfigure;
+
+import com.introproventures.graphql.jpa.query.schema.impl.GraphQLJpaSchemaBuilder;
+
+@FunctionalInterface
+public interface GraphQLJPASchemaBuilderCustomizer {
+    void customize(GraphQLJpaSchemaBuilder builder);
+}

--- a/graphql-jpa-query-autoconfigure/src/main/java/com/introproventures/graphql/jpa/query/autoconfigure/GraphQLJpaQueryGraphQlExecutionAutoConfiguration.java
+++ b/graphql-jpa-query-autoconfigure/src/main/java/com/introproventures/graphql/jpa/query/autoconfigure/GraphQLJpaQueryGraphQlExecutionAutoConfiguration.java
@@ -5,12 +5,11 @@ import org.dataloader.DataLoaderOptions;
 import org.dataloader.MappedBatchLoaderWithContext;
 import org.springframework.beans.factory.InitializingBean;
 import org.springframework.beans.factory.ListableBeanFactory;
-import org.springframework.boot.autoconfigure.AutoConfigureAfter;
+import org.springframework.boot.autoconfigure.AutoConfiguration;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
 import org.springframework.boot.autoconfigure.graphql.GraphQlAutoConfiguration;
 import org.springframework.context.annotation.Bean;
-import org.springframework.context.annotation.Configuration;
 import org.springframework.graphql.ExecutionGraphQlService;
 import org.springframework.graphql.execution.BatchLoaderRegistry;
 import org.springframework.graphql.execution.GraphQlSource;
@@ -18,9 +17,8 @@ import reactor.core.publisher.Mono;
 
 import static com.introproventures.graphql.jpa.query.schema.impl.BatchLoaderRegistry.newDataLoaderRegistry;
 
-@Configuration
+@AutoConfiguration(after = GraphQlAutoConfiguration.class)
 @ConditionalOnClass({GraphQL.class, GraphQlSource.class})
-@AutoConfigureAfter(GraphQlAutoConfiguration.class)
 public class GraphQLJpaQueryGraphQlExecutionAutoConfiguration {
 
     @Bean

--- a/graphql-jpa-query-autoconfigure/src/main/java/com/introproventures/graphql/jpa/query/autoconfigure/GraphQLJpaQueryGraphQlExecutionAutoConfiguration.java
+++ b/graphql-jpa-query-autoconfigure/src/main/java/com/introproventures/graphql/jpa/query/autoconfigure/GraphQLJpaQueryGraphQlExecutionAutoConfiguration.java
@@ -1,10 +1,12 @@
-package com.introproventures.graphql.jpa.query.boot.autoconfigure;
+package com.introproventures.graphql.jpa.query.autoconfigure;
 
+import graphql.GraphQL;
 import org.dataloader.DataLoaderOptions;
 import org.dataloader.MappedBatchLoaderWithContext;
 import org.springframework.beans.factory.InitializingBean;
 import org.springframework.beans.factory.ListableBeanFactory;
 import org.springframework.boot.autoconfigure.AutoConfigureAfter;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
 import org.springframework.boot.autoconfigure.graphql.GraphQlAutoConfiguration;
 import org.springframework.context.annotation.Bean;
@@ -17,6 +19,7 @@ import reactor.core.publisher.Mono;
 import static com.introproventures.graphql.jpa.query.schema.impl.BatchLoaderRegistry.newDataLoaderRegistry;
 
 @Configuration
+@ConditionalOnClass({GraphQL.class, GraphQlSource.class})
 @AutoConfigureAfter(GraphQlAutoConfiguration.class)
 public class GraphQLJpaQueryGraphQlExecutionAutoConfiguration {
 

--- a/graphql-jpa-query-autoconfigure/src/main/java/com/introproventures/graphql/jpa/query/autoconfigure/GraphQLJpaQueryGraphQlSourceAutoConfiguration.java
+++ b/graphql-jpa-query-autoconfigure/src/main/java/com/introproventures/graphql/jpa/query/autoconfigure/GraphQLJpaQueryGraphQlSourceAutoConfiguration.java
@@ -13,9 +13,8 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package com.introproventures.graphql.jpa.query.boot.autoconfigure;
+package com.introproventures.graphql.jpa.query.autoconfigure;
 
-import com.introproventures.graphql.jpa.query.autoconfigure.GraphQLSchemaConfigurer;
 import graphql.GraphQL;
 import graphql.execution.instrumentation.Instrumentation;
 import graphql.schema.GraphQLSchema;
@@ -45,7 +44,7 @@ import java.util.stream.Collectors;
 @ConditionalOnClass({GraphQL.class, GraphQlSource.class, GraphQLSchemaConfigurer.class})
 @ConditionalOnProperty(name="spring.graphql.jpa.query.enabled", havingValue="true", matchIfMissing=true)
 @EnableConfigurationProperties(GraphQlProperties.class)
-@AutoConfigureBefore(GraphQlAutoConfiguration.class)
+@AutoConfigureBefore({GraphQlAutoConfiguration.class, GraphQLSchemaAutoConfiguration.class})
 public class GraphQLJpaQueryGraphQlSourceAutoConfiguration {
 
     @Bean

--- a/graphql-jpa-query-autoconfigure/src/main/java/com/introproventures/graphql/jpa/query/autoconfigure/GraphQLJpaQueryGraphQlSourceAutoConfiguration.java
+++ b/graphql-jpa-query-autoconfigure/src/main/java/com/introproventures/graphql/jpa/query/autoconfigure/GraphQLJpaQueryGraphQlSourceAutoConfiguration.java
@@ -15,12 +15,14 @@
  */
 package com.introproventures.graphql.jpa.query.autoconfigure;
 
+import java.util.function.Consumer;
+import java.util.stream.Collectors;
 import graphql.GraphQL;
 import graphql.execution.instrumentation.Instrumentation;
 import graphql.schema.GraphQLSchema;
 import org.springframework.beans.factory.ListableBeanFactory;
 import org.springframework.beans.factory.ObjectProvider;
-import org.springframework.boot.autoconfigure.AutoConfigureBefore;
+import org.springframework.boot.autoconfigure.AutoConfiguration;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
@@ -30,21 +32,16 @@ import org.springframework.boot.autoconfigure.graphql.GraphQlProperties;
 import org.springframework.boot.autoconfigure.graphql.GraphQlSourceBuilderCustomizer;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.context.annotation.Bean;
-import org.springframework.context.annotation.Configuration;
 import org.springframework.core.io.support.ResourcePatternResolver;
 import org.springframework.graphql.execution.DataFetcherExceptionResolver;
 import org.springframework.graphql.execution.GraphQlSource;
 import org.springframework.graphql.execution.RuntimeWiringConfigurer;
 import org.springframework.graphql.execution.SubscriptionExceptionResolver;
 
-import java.util.function.Consumer;
-import java.util.stream.Collectors;
-
-@Configuration
+@AutoConfiguration(before = {GraphQlAutoConfiguration.class, GraphQLSchemaAutoConfiguration.class})
 @ConditionalOnClass({GraphQL.class, GraphQlSource.class, GraphQLSchemaConfigurer.class})
 @ConditionalOnProperty(name="spring.graphql.jpa.query.enabled", havingValue="true", matchIfMissing=true)
 @EnableConfigurationProperties(GraphQlProperties.class)
-@AutoConfigureBefore({GraphQlAutoConfiguration.class, GraphQLSchemaAutoConfiguration.class})
 public class GraphQLJpaQueryGraphQlSourceAutoConfiguration {
 
     @Bean

--- a/graphql-jpa-query-autoconfigure/src/main/java/com/introproventures/graphql/jpa/query/autoconfigure/GraphQLJpaQueryProperties.java
+++ b/graphql-jpa-query-autoconfigure/src/main/java/com/introproventures/graphql/jpa/query/autoconfigure/GraphQLJpaQueryProperties.java
@@ -15,10 +15,9 @@
  */
 package com.introproventures.graphql.jpa.query.autoconfigure;
 
+import javax.validation.constraints.NotEmpty;
 import org.springframework.boot.context.properties.ConfigurationProperties;
 import org.springframework.validation.annotation.Validated;
-
-import javax.validation.constraints.NotEmpty;
 
 @ConfigurationProperties(prefix="spring.graphql.jpa.query")
 @Validated
@@ -28,13 +27,13 @@ public class GraphQLJpaQueryProperties {
      * Provides the name of GraphQL schema. This is required attribute.
      */
     @NotEmpty
-    private String name;
+    private String name = "Query";
     
     /**
      * Provides the description of GraphQL schema. Cannot be null.
      */
     @NotEmpty
-    private String description;
+    private String description = "Query description";
 
     /**
      * Enable or disable distinct parameter.

--- a/graphql-jpa-query-autoconfigure/src/main/java/com/introproventures/graphql/jpa/query/autoconfigure/GraphQLSchemaAutoConfiguration.java
+++ b/graphql-jpa-query-autoconfigure/src/main/java/com/introproventures/graphql/jpa/query/autoconfigure/GraphQLSchemaAutoConfiguration.java
@@ -3,19 +3,17 @@ package com.introproventures.graphql.jpa.query.autoconfigure;
 import graphql.GraphQL;
 import graphql.schema.GraphQLSchema;
 import org.springframework.beans.factory.ObjectProvider;
-import org.springframework.boot.autoconfigure.AutoConfigureAfter;
+import org.springframework.boot.autoconfigure.AutoConfiguration;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.context.annotation.Bean;
-import org.springframework.context.annotation.Configuration;
 
-@Configuration
+@AutoConfiguration(after = GraphQLSchemaBuilderAutoConfiguration.class)
 @EnableConfigurationProperties(GraphQLJpaQueryProperties.class)
 @ConditionalOnClass(GraphQL.class)
 @ConditionalOnProperty(name="spring.graphql.jpa.query.enabled", havingValue="true", matchIfMissing=true)
-@AutoConfigureAfter(GraphQLSchemaBuilderAutoConfiguration.class)
 public class GraphQLSchemaAutoConfiguration {
 
     @Bean

--- a/graphql-jpa-query-autoconfigure/src/main/java/com/introproventures/graphql/jpa/query/autoconfigure/GraphQLSchemaAutoConfiguration.java
+++ b/graphql-jpa-query-autoconfigure/src/main/java/com/introproventures/graphql/jpa/query/autoconfigure/GraphQLSchemaAutoConfiguration.java
@@ -2,6 +2,7 @@ package com.introproventures.graphql.jpa.query.autoconfigure;
 
 import graphql.GraphQL;
 import graphql.schema.GraphQLSchema;
+import org.springframework.beans.factory.ObjectProvider;
 import org.springframework.boot.autoconfigure.AutoConfigureAfter;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
@@ -10,8 +11,6 @@ import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.PropertySource;
 import org.springframework.context.annotation.PropertySources;
-
-import java.util.List;
 
 @Configuration
 @ConditionalOnClass(GraphQL.class)
@@ -33,7 +32,7 @@ public class GraphQLSchemaAutoConfiguration {
     @ConditionalOnMissingBean(GraphQLSchema.class)
     public GraphQLSchemaFactoryBean graphQLSchemaFactoryBean(GraphQLJpaQueryProperties properties,
                                                              GraphQLShemaRegistration graphQLShemaRegistration,
-                                                             List<GraphQLSchemaConfigurer> graphQLSchemaConfigurers) {
+                                                             ObjectProvider<GraphQLSchemaConfigurer> graphQLSchemaConfigurers) {
         for (GraphQLSchemaConfigurer configurer : graphQLSchemaConfigurers) {
             configurer.configure(graphQLShemaRegistration);
         }

--- a/graphql-jpa-query-autoconfigure/src/main/java/com/introproventures/graphql/jpa/query/autoconfigure/GraphQLSchemaAutoConfiguration.java
+++ b/graphql-jpa-query-autoconfigure/src/main/java/com/introproventures/graphql/jpa/query/autoconfigure/GraphQLSchemaAutoConfiguration.java
@@ -6,19 +6,15 @@ import org.springframework.beans.factory.ObjectProvider;
 import org.springframework.boot.autoconfigure.AutoConfigureAfter;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
-import org.springframework.context.annotation.PropertySource;
-import org.springframework.context.annotation.PropertySources;
 
 @Configuration
-@ConditionalOnClass(GraphQL.class)
 @EnableConfigurationProperties(GraphQLJpaQueryProperties.class)
-@PropertySources(value= {
-    @PropertySource("classpath:com/introproventures/graphql/jpa/query/boot/autoconfigure/default.properties"),
-    @PropertySource(value = "classpath:graphql-jpa-autoconfigure.properties", ignoreResourceNotFound = true)
-})
+@ConditionalOnClass(GraphQL.class)
+@ConditionalOnProperty(name="spring.graphql.jpa.query.enabled", havingValue="true", matchIfMissing=true)
 @AutoConfigureAfter(GraphQLSchemaBuilderAutoConfiguration.class)
 public class GraphQLSchemaAutoConfiguration {
 
@@ -40,8 +36,6 @@ public class GraphQLSchemaAutoConfiguration {
         return new GraphQLSchemaFactoryBean(graphQLShemaRegistration.getManagedGraphQLSchemas())
 	        		.setQueryName(properties.getName())
 	    			.setQueryDescription(properties.getDescription());
-
-
     };
 
 }

--- a/graphql-jpa-query-autoconfigure/src/main/java/com/introproventures/graphql/jpa/query/autoconfigure/GraphQLSchemaBuilderAutoConfiguration.java
+++ b/graphql-jpa-query-autoconfigure/src/main/java/com/introproventures/graphql/jpa/query/autoconfigure/GraphQLSchemaBuilderAutoConfiguration.java
@@ -27,12 +27,16 @@ public class GraphQLSchemaBuilderAutoConfiguration {
     @ConditionalOnMissingBean
     @ConditionalOnSingleCandidate(EntityManagerFactory.class)
     GraphQLJpaSchemaBuilder defaultGraphQLJpaSchemaBuilder(EntityManagerFactory entityManagerFactory,
-                                                        GraphQLJpaQueryProperties properties,
-                                                        ObjectProvider<RestrictedKeysProvider> restrictedKeysProvider) {
+                                                           GraphQLJpaQueryProperties properties,
+                                                           ObjectProvider<RestrictedKeysProvider> restrictedKeysProvider) {
         GraphQLJpaSchemaBuilder builder = new GraphQLJpaSchemaBuilder(entityManagerFactory.createEntityManager());
 
         builder.name(properties.getName())
-               .description(properties.getDescription());
+               .description(properties.getDescription())
+               .defaultDistinct(properties.isDefaultDistinct())
+               .useDistinctParameter(properties.isUseDistinctParameter())
+               .toManyDefaultOptional(properties.isToManyDefaultOptional())
+               .enableRelay(properties.isEnableRelay());
 
         EnableGraphQLJpaQuerySchemaImportSelector.getPackageNames()
                                                  .stream()

--- a/graphql-jpa-query-autoconfigure/src/main/java/com/introproventures/graphql/jpa/query/autoconfigure/GraphQLSchemaBuilderAutoConfiguration.java
+++ b/graphql-jpa-query-autoconfigure/src/main/java/com/introproventures/graphql/jpa/query/autoconfigure/GraphQLSchemaBuilderAutoConfiguration.java
@@ -6,21 +6,20 @@ import com.introproventures.graphql.jpa.query.schema.RestrictedKeysProvider;
 import com.introproventures.graphql.jpa.query.schema.impl.GraphQLJpaSchemaBuilder;
 import graphql.GraphQL;
 import org.springframework.beans.factory.ObjectProvider;
-import org.springframework.boot.autoconfigure.AutoConfigureAfter;
-import org.springframework.boot.autoconfigure.AutoConfigureBefore;
+import org.springframework.boot.autoconfigure.AutoConfiguration;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnSingleCandidate;
 import org.springframework.boot.autoconfigure.orm.jpa.HibernateJpaAutoConfiguration;
 import org.springframework.context.annotation.Bean;
-import org.springframework.context.annotation.Configuration;
 
-@Configuration
+@AutoConfiguration(
+        before = {GraphQLSchemaAutoConfiguration.class, GraphQLJpaQueryGraphQlSourceAutoConfiguration.class},
+        after = HibernateJpaAutoConfiguration.class
+)
 @ConditionalOnClass({EntityManagerFactory.class, GraphQL.class, GraphQLSchemaBuilder.class})
 @ConditionalOnProperty(name="spring.graphql.jpa.query.enabled", havingValue="true", matchIfMissing=true)
-@AutoConfigureBefore({GraphQLSchemaAutoConfiguration.class, GraphQLJpaQueryGraphQlSourceAutoConfiguration.class})
-@AutoConfigureAfter(HibernateJpaAutoConfiguration.class)
 public class GraphQLSchemaBuilderAutoConfiguration {
 
     @Bean

--- a/graphql-jpa-query-autoconfigure/src/main/java/com/introproventures/graphql/jpa/query/autoconfigure/GraphQLSchemaBuilderAutoConfiguration.java
+++ b/graphql-jpa-query-autoconfigure/src/main/java/com/introproventures/graphql/jpa/query/autoconfigure/GraphQLSchemaBuilderAutoConfiguration.java
@@ -4,11 +4,9 @@ import com.introproventures.graphql.jpa.query.schema.GraphQLSchemaBuilder;
 import com.introproventures.graphql.jpa.query.schema.RestrictedKeysProvider;
 import com.introproventures.graphql.jpa.query.schema.impl.GraphQLJpaSchemaBuilder;
 import graphql.GraphQL;
-import org.springframework.beans.factory.InitializingBean;
 import org.springframework.beans.factory.ObjectProvider;
 import org.springframework.boot.autoconfigure.AutoConfigureAfter;
 import org.springframework.boot.autoconfigure.AutoConfigureBefore;
-import org.springframework.boot.autoconfigure.condition.ConditionalOnBean;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
@@ -18,43 +16,39 @@ import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
 import javax.persistence.EntityManagerFactory;
-import java.util.List;
 
 @Configuration
 @ConditionalOnClass({EntityManagerFactory.class, GraphQL.class, GraphQLSchemaBuilder.class})
 @ConditionalOnProperty(name="spring.graphql.jpa.query.enabled", havingValue="true", matchIfMissing=true)
-@AutoConfigureBefore(GraphQLSchemaAutoConfiguration.class)
+@AutoConfigureBefore({GraphQLSchemaAutoConfiguration.class, GraphQLJpaQueryGraphQlSourceAutoConfiguration.class})
 @AutoConfigureAfter(HibernateJpaAutoConfiguration.class)
 public class GraphQLSchemaBuilderAutoConfiguration {
+
     @Bean
     @ConditionalOnMissingBean
     @ConditionalOnSingleCandidate(EntityManagerFactory.class)
-    public GraphQLSchemaBuilder defaultGraphQLJpaSchemaBuilder(final EntityManagerFactory entityManagerFactory,
-                                                        ObjectProvider<RestrictedKeysProvider> restrictedKeysProvider) {
-        GraphQLJpaSchemaBuilder bean = new GraphQLJpaSchemaBuilder(entityManagerFactory.createEntityManager());
+    GraphQLSchemaBuilder defaultGraphQLJpaSchemaBuilder(EntityManagerFactory entityManagerFactory,
+                                                        GraphQLJpaQueryProperties properties,
+                                                        ObjectProvider<RestrictedKeysProvider> restrictedKeysProvider,
+                                                        ObjectProvider<GraphQLSchemaBuilderCustomizer> graphQLSchemaBuilderCustomizer) {
+        GraphQLJpaSchemaBuilder builder = new GraphQLJpaSchemaBuilder(entityManagerFactory.createEntityManager());
 
-        restrictedKeysProvider.ifAvailable(bean::restrictedKeysProvider);
+        EnableGraphQLJpaQuerySchemaImportSelector.getPackageNames()
+                                                 .stream()
+                                                 .forEach(builder::entityPath);
 
-        return bean;
+        graphQLSchemaBuilderCustomizer.ifAvailable(it -> it.customize(builder));
+
+        restrictedKeysProvider.ifAvailable(builder::restrictedKeysProvider);
+
+        return builder;
     }
 
     @Bean
-    @ConditionalOnBean(name = "defaultGraphQLJpaSchemaBuilder")
+    @ConditionalOnMissingBean
     @ConditionalOnSingleCandidate(GraphQLSchemaBuilder.class)
     GraphQLSchemaConfigurer defaultGraphQLJpaSchemaBuilderConfigurer(GraphQLSchemaBuilder graphQLJpaSchemaBuilder) {
         return registry -> registry.register(graphQLJpaSchemaBuilder.build());
-    }
-
-    @Bean
-    @ConditionalOnMissingBean(GraphQLSchemaConfigurer.class)
-    InitializingBean defaultGraphQLSchemaBuilderConfigurer(GraphQLShemaRegistration graphQLShemaRegistration,
-                                                           GraphQLSchemaBuilder graphQLSchemaBuilder,
-                                                           List<GraphQLSchemaConfigurer> configurers) {
-        return () -> {
-            if (configurers.isEmpty()) {
-                graphQLShemaRegistration.register(graphQLSchemaBuilder.build());
-            }
-        };
     }
 
 }

--- a/graphql-jpa-query-autoconfigure/src/main/java/com/introproventures/graphql/jpa/query/autoconfigure/GraphQLSchemaBuilderCustomizer.java
+++ b/graphql-jpa-query-autoconfigure/src/main/java/com/introproventures/graphql/jpa/query/autoconfigure/GraphQLSchemaBuilderCustomizer.java
@@ -1,0 +1,8 @@
+package com.introproventures.graphql.jpa.query.autoconfigure;
+
+import com.introproventures.graphql.jpa.query.schema.GraphQLSchemaBuilder;
+
+@FunctionalInterface
+public interface GraphQLSchemaBuilderCustomizer {
+    void customize(GraphQLSchemaBuilder builder);
+}

--- a/graphql-jpa-query-autoconfigure/src/main/java/com/introproventures/graphql/jpa/query/autoconfigure/GraphQLSchemaBuilderCustomizer.java
+++ b/graphql-jpa-query-autoconfigure/src/main/java/com/introproventures/graphql/jpa/query/autoconfigure/GraphQLSchemaBuilderCustomizer.java
@@ -1,8 +1,0 @@
-package com.introproventures.graphql.jpa.query.autoconfigure;
-
-import com.introproventures.graphql.jpa.query.schema.GraphQLSchemaBuilder;
-
-@FunctionalInterface
-public interface GraphQLSchemaBuilderCustomizer {
-    void customize(GraphQLSchemaBuilder builder);
-}

--- a/graphql-jpa-query-autoconfigure/src/main/java/com/introproventures/graphql/jpa/query/autoconfigure/JavaScalarsRuntimeWiringConfigurer.java
+++ b/graphql-jpa-query-autoconfigure/src/main/java/com/introproventures/graphql/jpa/query/autoconfigure/JavaScalarsRuntimeWiringConfigurer.java
@@ -1,4 +1,4 @@
-package com.introproventures.graphql.jpa.query.boot.autoconfigure;
+package com.introproventures.graphql.jpa.query.autoconfigure;
 
 import com.introproventures.graphql.jpa.query.schema.JavaScalars;
 import com.introproventures.graphql.jpa.query.schema.JavaScalarsWiringPostProcessor;

--- a/graphql-jpa-query-autoconfigure/src/main/java/com/introproventures/graphql/jpa/query/autoconfigure/TypeTraverser.java
+++ b/graphql-jpa-query-autoconfigure/src/main/java/com/introproventures/graphql/jpa/query/autoconfigure/TypeTraverser.java
@@ -1,20 +1,17 @@
 package com.introproventures.graphql.jpa.query.autoconfigure;
 
-import graphql.PublicApi;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.function.Function;
 import graphql.schema.GraphQLSchemaElement;
-import graphql.schema.GraphQLType;
 import graphql.schema.GraphQLTypeVisitor;
 import graphql.util.TraversalControl;
 import graphql.util.Traverser;
 import graphql.util.TraverserContext;
 import graphql.util.TraverserResult;
 import graphql.util.TraverserVisitor;
-
-import java.util.Collection;
-import java.util.Collections;
-import java.util.List;
-import java.util.Map;
-import java.util.function.Function;
 
 import static graphql.util.TraversalControl.CONTINUE;
 

--- a/graphql-jpa-query-autoconfigure/src/main/resources/META-INF/spring.factories
+++ b/graphql-jpa-query-autoconfigure/src/main/resources/META-INF/spring.factories
@@ -1,3 +1,5 @@
 org.springframework.boot.autoconfigure.EnableAutoConfiguration=\
 	com.introproventures.graphql.jpa.query.autoconfigure.GraphQLSchemaAutoConfiguration,\
-    com.introproventures.graphql.jpa.query.autoconfigure.GraphQLSchemaBuilderAutoConfiguration
+    com.introproventures.graphql.jpa.query.autoconfigure.GraphQLSchemaBuilderAutoConfiguration,\
+    com.introproventures.graphql.jpa.query.autoconfigure.GraphQLJpaQueryGraphQlSourceAutoConfiguration,\
+    com.introproventures.graphql.jpa.query.autoconfigure.GraphQLJpaQueryGraphQlExecutionAutoConfiguration

--- a/graphql-jpa-query-autoconfigure/src/main/resources/META-INF/spring.factories
+++ b/graphql-jpa-query-autoconfigure/src/main/resources/META-INF/spring.factories
@@ -1,5 +1,4 @@
 org.springframework.boot.autoconfigure.EnableAutoConfiguration=\
 	com.introproventures.graphql.jpa.query.autoconfigure.GraphQLSchemaAutoConfiguration,\
-    com.introproventures.graphql.jpa.query.autoconfigure.GraphQLSchemaBuilderAutoConfiguration,\
     com.introproventures.graphql.jpa.query.autoconfigure.GraphQLJpaQueryGraphQlSourceAutoConfiguration,\
     com.introproventures.graphql.jpa.query.autoconfigure.GraphQLJpaQueryGraphQlExecutionAutoConfiguration

--- a/graphql-jpa-query-autoconfigure/src/main/resources/com/introproventures/graphql/jpa/query/boot/autoconfigure/default.properties
+++ b/graphql-jpa-query-autoconfigure/src/main/resources/com/introproventures/graphql/jpa/query/boot/autoconfigure/default.properties
@@ -1,5 +1,0 @@
-spring.graphql.jpa.query.name=Query
-spring.graphql.jpa.query.description=Query root
-spring.graphql.jpa.query.useDistinctParameter=false
-spring.graphql.jpa.query.defaultDistinct=true
-spring.graphql.jpa.query.enabled=true

--- a/graphql-jpa-query-autoconfigure/src/test/java/com/introproventures/graphql/jpa/query/autoconfigure/GraphQLSchemaAutoConfigurationTest.java
+++ b/graphql-jpa-query-autoconfigure/src/test/java/com/introproventures/graphql/jpa/query/autoconfigure/GraphQLSchemaAutoConfigurationTest.java
@@ -16,6 +16,7 @@ import com.introproventures.graphql.jpa.query.autoconfigure.support.AdditionalGr
 import com.introproventures.graphql.jpa.query.autoconfigure.support.MutationRoot;
 import com.introproventures.graphql.jpa.query.autoconfigure.support.QueryRoot;
 import com.introproventures.graphql.jpa.query.autoconfigure.support.SubscriptionRoot;
+import com.introproventures.graphql.jpa.query.autoconfigure.support.TestEntity;
 import com.introproventures.graphql.jpa.query.schema.JavaScalars;
 import com.introproventures.graphql.jpa.query.schema.JavaScalarsWiringPostProcessor;
 import graphql.ExecutionResult;
@@ -77,7 +78,7 @@ public class GraphQLSchemaAutoConfigurationTest {
     private GraphQLJpaQueryProperties graphQLJpaQueryProperties;
     
     @SpringBootApplication
-    @EnableGraphQLJpaQuerySchema
+    @EnableGraphQLJpaQuerySchema(basePackageClasses = TestEntity.class)
     static class Application {
         
         @Configuration

--- a/graphql-jpa-query-autoconfigure/src/test/java/com/introproventures/graphql/jpa/query/autoconfigure/GraphQLSchemaAutoConfigurationTest.java
+++ b/graphql-jpa-query-autoconfigure/src/test/java/com/introproventures/graphql/jpa/query/autoconfigure/GraphQLSchemaAutoConfigurationTest.java
@@ -1,5 +1,17 @@
 package com.introproventures.graphql.jpa.query.autoconfigure;
 
+import java.io.File;
+import java.io.IOException;
+import java.time.Duration;
+import java.time.Instant;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.UUID;
+import java.util.function.Supplier;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
 import com.introproventures.graphql.jpa.query.autoconfigure.support.AdditionalGraphQLType;
 import com.introproventures.graphql.jpa.query.autoconfigure.support.MutationRoot;
 import com.introproventures.graphql.jpa.query.autoconfigure.support.QueryRoot;
@@ -44,19 +56,6 @@ import org.springframework.util.StringUtils;
 import reactor.core.publisher.Flux;
 import reactor.test.StepVerifier;
 
-import java.io.File;
-import java.io.IOException;
-import java.time.Duration;
-import java.time.Instant;
-import java.util.LinkedHashMap;
-import java.util.List;
-import java.util.Map;
-import java.util.Set;
-import java.util.UUID;
-import java.util.function.Supplier;
-import java.util.stream.Collectors;
-import java.util.stream.Stream;
-
 import static graphql.annotations.AnnotationsSchemaCreator.newAnnotationsSchema;
 import static graphql.schema.FieldCoordinates.coordinates;
 import static graphql.schema.GraphQLCodeRegistry.newCodeRegistry;
@@ -78,6 +77,7 @@ public class GraphQLSchemaAutoConfigurationTest {
     private GraphQLJpaQueryProperties graphQLJpaQueryProperties;
     
     @SpringBootApplication
+    @EnableGraphQLJpaQuerySchema
     static class Application {
         
         @Configuration

--- a/graphql-jpa-query-autoconfigure/src/test/java/com/introproventures/graphql/jpa/query/autoconfigure/GraphQLSchemaAutoConfigurationTest.java
+++ b/graphql-jpa-query-autoconfigure/src/test/java/com/introproventures/graphql/jpa/query/autoconfigure/GraphQLSchemaAutoConfigurationTest.java
@@ -32,6 +32,7 @@ import graphql.schema.DataFetcher;
 import graphql.schema.GraphQLCodeRegistry;
 import graphql.schema.GraphQLDirective;
 import graphql.schema.GraphQLFieldDefinition;
+import graphql.schema.GraphQLNamedType;
 import graphql.schema.GraphQLObjectType;
 import graphql.schema.GraphQLScalarType;
 import graphql.schema.GraphQLSchema;
@@ -297,7 +298,15 @@ public class GraphQLSchemaAutoConfigurationTest {
                 .containsExactly("GraphQLBooks", "GraphQL Books Schema Description");
         	
     }
-    
+
+    @Test
+    public void enableGraphQLJpaQuerySchema() {
+        assertThat(graphQLSchema.getAllTypesAsList())
+                .extracting(GraphQLNamedType::getName)
+                .contains("TestEntity");
+
+    }
+
     @Test
     public void directivesSupport() {
         assertThat(graphQLSchema.getDirectives())

--- a/graphql-jpa-query-autoconfigure/src/test/java/com/introproventures/graphql/jpa/query/autoconfigure/support/TestEntity.java
+++ b/graphql-jpa-query-autoconfigure/src/test/java/com/introproventures/graphql/jpa/query/autoconfigure/support/TestEntity.java
@@ -1,0 +1,12 @@
+package com.introproventures.graphql.jpa.query.autoconfigure.support;
+
+import javax.persistence.Entity;
+import javax.persistence.Id;
+import lombok.Data;
+
+@Entity
+@Data
+public class TestEntity {
+    @Id
+    private Long id;
+}

--- a/graphql-jpa-query-boot-starter-graphql/pom.xml
+++ b/graphql-jpa-query-boot-starter-graphql/pom.xml
@@ -31,7 +31,6 @@
     <dependency>
       <groupId>org.springframework.boot</groupId>
       <artifactId>spring-boot-starter-graphql</artifactId>
-      <optional>true</optional>
     </dependency>
     
     <dependency>

--- a/graphql-jpa-query-boot-starter-graphql/src/main/resources/META-INF/spring.factories
+++ b/graphql-jpa-query-boot-starter-graphql/src/main/resources/META-INF/spring.factories
@@ -1,3 +1,0 @@
-org.springframework.boot.autoconfigure.EnableAutoConfiguration=\
-com.introproventures.graphql.jpa.query.boot.autoconfigure.GraphQLJpaQueryGraphQlSourceAutoConfiguration,\
-com.introproventures.graphql.jpa.query.boot.autoconfigure.GraphQLJpaQueryGraphQlExecutionAutoConfiguration

--- a/graphql-jpa-query-boot-starter-graphql/src/main/resources/com/introproventures/graphql/jpa/query/boot/autoconfigure/default.properties
+++ b/graphql-jpa-query-boot-starter-graphql/src/main/resources/com/introproventures/graphql/jpa/query/boot/autoconfigure/default.properties
@@ -1,2 +1,0 @@
-spring.graphql.jpa.query.name=GraphQLJpaQueryBootStarterGraphQl
-spring.graphql.jpa.query.description=GraphQL Jpa Query Schema Boot Starter GraphQl Specification

--- a/graphql-jpa-query-boot-starter-graphql/src/test/java/com/introproventures/graphql/jpa/query/boot/test/boot/autoconfigure/GraphQLJpaQueryGraphQlSourceAutoConfigurationTest.java
+++ b/graphql-jpa-query-boot-starter-graphql/src/test/java/com/introproventures/graphql/jpa/query/boot/test/boot/autoconfigure/GraphQLJpaQueryGraphQlSourceAutoConfigurationTest.java
@@ -15,37 +15,41 @@
  */
 package com.introproventures.graphql.jpa.query.boot.test.boot.autoconfigure;
 
+import com.introproventures.graphql.jpa.query.autoconfigure.EnableGraphQLJpaQuerySchema;
 import com.introproventures.graphql.jpa.query.autoconfigure.JavaScalarsRuntimeWiringConfigurer;
 import com.introproventures.graphql.jpa.query.boot.test.starter.model.Author;
 import com.introproventures.graphql.jpa.query.schema.GraphQLSchemaBuilder;
 import com.introproventures.graphql.jpa.query.schema.impl.GraphQLJpaSchemaBuilder;
 import graphql.schema.GraphQLObjectType;
 import graphql.schema.GraphQLSchema;
+import org.dataloader.DataLoaderRegistry;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
-import org.springframework.boot.autoconfigure.domain.EntityScan;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.context.SpringBootTest.WebEnvironment;
 import org.springframework.graphql.ExecutionGraphQlService;
 import org.springframework.graphql.execution.BatchLoaderRegistry;
 import org.springframework.graphql.execution.GraphQlSource;
+import org.springframework.graphql.execution.RuntimeWiringConfigurer;
 import org.springframework.test.context.junit4.SpringRunner;
 
+import static graphql.GraphQLContext.newContext;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.dataloader.DataLoaderRegistry.newRegistry;
 
 @RunWith(SpringRunner.class)
 @SpringBootTest(webEnvironment = WebEnvironment.RANDOM_PORT)
 public class GraphQLJpaQueryGraphQlSourceAutoConfigurationTest {
 
     @SpringBootApplication
-    @EntityScan(basePackageClasses=Author.class)
+    @EnableGraphQLJpaQuerySchema(basePackageClasses=Author.class)
     static class Application {
     }
     
     @Autowired
-    private JavaScalarsRuntimeWiringConfigurer javaScalarsRuntimeWiringConfigurer;
+    private RuntimeWiringConfigurer javaScalarsRuntimeWiringConfigurer;
 
     @Autowired
     private GraphQLSchemaBuilder graphQLSchemaBuilder;
@@ -53,7 +57,7 @@ public class GraphQLJpaQueryGraphQlSourceAutoConfigurationTest {
     @Autowired
     private GraphQLSchema graphQLSchema;
 
-    @Autowired(required = false)
+    @Autowired
     private GraphQlSource graphQlSource;
 
     @Autowired
@@ -64,16 +68,24 @@ public class GraphQLJpaQueryGraphQlSourceAutoConfigurationTest {
 
     @Test
     public void contextIsAutoConfigured() {
-        assertThat(javaScalarsRuntimeWiringConfigurer).isNotNull();
+        assertThat(javaScalarsRuntimeWiringConfigurer).isInstanceOf(JavaScalarsRuntimeWiringConfigurer.class);
         
-        assertThat(graphQLSchemaBuilder).isNotNull()
-                                        .isInstanceOf(GraphQLJpaSchemaBuilder.class);
+        assertThat(graphQLSchemaBuilder).isInstanceOf(GraphQLJpaSchemaBuilder.class);
 
         assertThat(graphQLSchema.getQueryType())
                                 .extracting(GraphQLObjectType::getName, GraphQLObjectType::getDescription)
                                 .containsExactly("GraphQLBooks", "GraphQL Books Schema Description");
 
-        assertThat(graphQlSource).isNotNull();
+        assertThat(graphQlSource.schema()
+                                .getQueryType())
+                                .extracting(GraphQLObjectType::getName, GraphQLObjectType::getDescription)
+                                .containsExactly("GraphQLBooks", "GraphQL Books Schema Description");
 
+        DataLoaderRegistry dataLoaderRegistry = newRegistry().build();
+        batchLoaderRegistry.registerDataLoaders(dataLoaderRegistry, newContext().build());
+
+        assertThat(dataLoaderRegistry.getDataLoadersMap())
+                                     .isNotEmpty()
+                                     .containsOnlyKeys("Author.books", "Book.author");
     }
 }

--- a/graphql-jpa-query-boot-starter-graphql/src/test/java/com/introproventures/graphql/jpa/query/boot/test/boot/autoconfigure/GraphQLJpaQueryGraphQlSourceAutoConfigurationTest.java
+++ b/graphql-jpa-query-boot-starter-graphql/src/test/java/com/introproventures/graphql/jpa/query/boot/test/boot/autoconfigure/GraphQLJpaQueryGraphQlSourceAutoConfigurationTest.java
@@ -15,7 +15,7 @@
  */
 package com.introproventures.graphql.jpa.query.boot.test.boot.autoconfigure;
 
-import com.introproventures.graphql.jpa.query.boot.autoconfigure.JavaScalarsRuntimeWiringConfigurer;
+import com.introproventures.graphql.jpa.query.autoconfigure.JavaScalarsRuntimeWiringConfigurer;
 import com.introproventures.graphql.jpa.query.boot.test.starter.model.Author;
 import com.introproventures.graphql.jpa.query.schema.GraphQLSchemaBuilder;
 import com.introproventures.graphql.jpa.query.schema.impl.GraphQLJpaSchemaBuilder;

--- a/graphql-jpa-query-boot-starter-graphql/src/test/java/com/introproventures/graphql/jpa/query/boot/test/starter/controllers/MutationController.java
+++ b/graphql-jpa-query-boot-starter-graphql/src/test/java/com/introproventures/graphql/jpa/query/boot/test/starter/controllers/MutationController.java
@@ -1,0 +1,18 @@
+package com.introproventures.graphql.jpa.query.boot.test.starter.controllers;
+
+import org.springframework.graphql.data.method.annotation.Argument;
+import org.springframework.graphql.data.method.annotation.MutationMapping;
+import org.springframework.stereotype.Controller;
+import reactor.core.publisher.Mono;
+
+@Controller
+public class MutationController {
+
+    @MutationMapping
+    Mono<String> reverse(@Argument String string) {
+        return Mono.just(new StringBuilder(string))
+                   .map(StringBuilder::reverse)
+                   .map(StringBuilder::toString);
+    }
+
+}

--- a/graphql-jpa-query-boot-starter-graphql/src/test/java/com/introproventures/graphql/jpa/query/boot/test/starter/controllers/QueryController.java
+++ b/graphql-jpa-query-boot-starter-graphql/src/test/java/com/introproventures/graphql/jpa/query/boot/test/starter/controllers/QueryController.java
@@ -1,0 +1,23 @@
+package com.introproventures.graphql.jpa.query.boot.test.starter.controllers;
+
+import org.springframework.graphql.data.method.annotation.Argument;
+import org.springframework.graphql.data.method.annotation.QueryMapping;
+import org.springframework.stereotype.Controller;
+import reactor.core.publisher.Mono;
+
+import java.util.Date;
+
+@Controller
+public class QueryController {
+
+    @QueryMapping
+    Mono<Long> count(@Argument String string) {
+       return Mono.just(string.length())
+                  .map(Long::valueOf);
+    }
+
+    @QueryMapping
+    Mono<Date> today() {
+        return Mono.just(new Date());
+    }
+}

--- a/graphql-jpa-query-boot-starter-graphql/src/test/resources/graphql/schema.graphqls
+++ b/graphql-jpa-query-boot-starter-graphql/src/test/resources/graphql/schema.graphqls
@@ -1,0 +1,16 @@
+scalar Long
+scalar Date
+
+schema {
+    query: Query
+    mutation: Mutation
+}
+
+type Query {
+    count(string: String): Long
+    today: Date
+}
+
+type Mutation {
+    reverse(string: String): String
+}

--- a/graphql-jpa-query-boot-starter/src/main/java/com/introproventures/graphql/jpa/query/boot/autoconfigure/GraphQLJpaQueryAutoConfiguration.java
+++ b/graphql-jpa-query-boot-starter/src/main/java/com/introproventures/graphql/jpa/query/boot/autoconfigure/GraphQLJpaQueryAutoConfiguration.java
@@ -15,6 +15,7 @@
  */
 package com.introproventures.graphql.jpa.query.boot.autoconfigure;
 
+import java.util.function.Supplier;
 import com.introproventures.graphql.jpa.query.autoconfigure.EnableGraphQLJpaQuerySchema;
 import com.introproventures.graphql.jpa.query.schema.GraphQLExecutionInputFactory;
 import com.introproventures.graphql.jpa.query.schema.GraphQLExecutor;
@@ -28,20 +29,16 @@ import graphql.execution.instrumentation.Instrumentation;
 import graphql.schema.GraphQLSchema;
 import graphql.schema.visibility.GraphqlFieldVisibility;
 import org.springframework.beans.factory.ObjectProvider;
-import org.springframework.boot.autoconfigure.AutoConfigureAfter;
+import org.springframework.boot.autoconfigure.AutoConfiguration;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.boot.autoconfigure.orm.jpa.HibernateJpaAutoConfiguration;
 import org.springframework.context.annotation.Bean;
-import org.springframework.context.annotation.Configuration;
 
-import java.util.function.Supplier;
-
-@Configuration
+@AutoConfiguration(after = HibernateJpaAutoConfiguration.class)
 @ConditionalOnClass(GraphQL.class)
 @ConditionalOnProperty(name="spring.graphql.jpa.query.enabled", havingValue="true", matchIfMissing=true)
-@AutoConfigureAfter({HibernateJpaAutoConfiguration.class})
 @EnableGraphQLJpaQuerySchema
 public class GraphQLJpaQueryAutoConfiguration {
 

--- a/graphql-jpa-query-boot-starter/src/main/resources/com/introproventures/graphql/jpa/query/boot/autoconfigure/default.properties
+++ b/graphql-jpa-query-boot-starter/src/main/resources/com/introproventures/graphql/jpa/query/boot/autoconfigure/default.properties
@@ -1,5 +1,0 @@
-spring.graphql.jpa.query.name=GraphQLJpaQuery
-spring.graphql.jpa.query.description=GraphQL Jpa Query Schema Specification
-spring.graphql.jpa.query.useDistinctParameter=false
-spring.graphql.jpa.query.distinctFetcher=false
-spring.graphql.jpa.query.enabled=true

--- a/graphql-jpa-query-boot-starter/src/test/java/com/introproventures/graphql/jpa/query/boot/test/boot/autoconfigure/GraphQLJpaQueryAutoConfigurationTest.java
+++ b/graphql-jpa-query-boot-starter/src/test/java/com/introproventures/graphql/jpa/query/boot/test/boot/autoconfigure/GraphQLJpaQueryAutoConfigurationTest.java
@@ -16,6 +16,7 @@
 package com.introproventures.graphql.jpa.query.boot.test.boot.autoconfigure;
 
 import java.util.function.Supplier;
+import com.introproventures.graphql.jpa.query.autoconfigure.EnableGraphQLJpaQuerySchema;
 import com.introproventures.graphql.jpa.query.autoconfigure.GraphQLJPASchemaBuilderCustomizer;
 import com.introproventures.graphql.jpa.query.boot.test.starter.model.Author;
 import com.introproventures.graphql.jpa.query.schema.GraphQLExecutionInputFactory;
@@ -34,7 +35,6 @@ import org.junit.runner.RunWith;
 import org.springframework.beans.factory.ObjectProvider;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
-import org.springframework.boot.autoconfigure.domain.EntityScan;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.context.SpringBootTest.WebEnvironment;
 import org.springframework.boot.test.mock.mockito.MockBean;
@@ -49,7 +49,7 @@ import static org.mockito.Mockito.verify;
 public class GraphQLJpaQueryAutoConfigurationTest {
 
     @SpringBootApplication
-    @EntityScan(basePackageClasses=Author.class)
+    @EnableGraphQLJpaQuerySchema(basePackageClasses=Author.class)
     static class Application {
         @MockBean
         private GraphQLExecutionInputFactory mockExecutionInputFactory;

--- a/graphql-jpa-query-boot-starter/src/test/java/com/introproventures/graphql/jpa/query/boot/test/boot/autoconfigure/GraphQLJpaQueryAutoConfigurationTest.java
+++ b/graphql-jpa-query-boot-starter/src/test/java/com/introproventures/graphql/jpa/query/boot/test/boot/autoconfigure/GraphQLJpaQueryAutoConfigurationTest.java
@@ -15,10 +15,20 @@
  */
 package com.introproventures.graphql.jpa.query.boot.test.boot.autoconfigure;
 
-import static org.assertj.core.api.Assertions.assertThat;
-
 import java.util.function.Supplier;
-
+import com.introproventures.graphql.jpa.query.autoconfigure.GraphQLJPASchemaBuilderCustomizer;
+import com.introproventures.graphql.jpa.query.boot.test.starter.model.Author;
+import com.introproventures.graphql.jpa.query.schema.GraphQLExecutionInputFactory;
+import com.introproventures.graphql.jpa.query.schema.GraphQLExecutor;
+import com.introproventures.graphql.jpa.query.schema.RestrictedKeysProvider;
+import com.introproventures.graphql.jpa.query.schema.impl.GraphQLJpaExecutor;
+import com.introproventures.graphql.jpa.query.schema.impl.GraphQLJpaExecutorContextFactory;
+import com.introproventures.graphql.jpa.query.schema.impl.GraphQLJpaSchemaBuilder;
+import graphql.GraphQLContext;
+import graphql.execution.instrumentation.Instrumentation;
+import graphql.schema.GraphQLObjectType;
+import graphql.schema.GraphQLSchema;
+import graphql.schema.visibility.GraphqlFieldVisibility;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.springframework.beans.factory.ObjectProvider;
@@ -30,20 +40,9 @@ import org.springframework.boot.test.context.SpringBootTest.WebEnvironment;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.test.context.junit4.SpringRunner;
 
-import com.introproventures.graphql.jpa.query.boot.test.starter.model.Author;
-import com.introproventures.graphql.jpa.query.schema.GraphQLExecutionInputFactory;
-import com.introproventures.graphql.jpa.query.schema.GraphQLExecutor;
-import com.introproventures.graphql.jpa.query.schema.GraphQLSchemaBuilder;
-import com.introproventures.graphql.jpa.query.schema.RestrictedKeysProvider;
-import com.introproventures.graphql.jpa.query.schema.impl.GraphQLJpaExecutor;
-import com.introproventures.graphql.jpa.query.schema.impl.GraphQLJpaExecutorContextFactory;
-import com.introproventures.graphql.jpa.query.schema.impl.GraphQLJpaSchemaBuilder;
-
-import graphql.GraphQLContext;
-import graphql.execution.instrumentation.Instrumentation;
-import graphql.schema.GraphQLObjectType;
-import graphql.schema.GraphQLSchema;
-import graphql.schema.visibility.GraphqlFieldVisibility;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.verify;
 
 @RunWith(SpringRunner.class)
 @SpringBootTest(webEnvironment = WebEnvironment.RANDOM_PORT)
@@ -66,13 +65,16 @@ public class GraphQLJpaQueryAutoConfigurationTest {
         
         @MockBean
         private RestrictedKeysProvider restrictedKeysProvider;
+
+        @MockBean
+        private GraphQLJPASchemaBuilderCustomizer graphQLJPASchemaBuilderCustomizer;
     }
     
     @Autowired(required=false)
     private GraphQLExecutor graphQLExecutor;
 
     @Autowired(required=false)
-    private GraphQLSchemaBuilder graphQLSchemaBuilder;
+    private GraphQLJpaSchemaBuilder graphQLSchemaBuilder;
     
     @Autowired(required=false)
     private GraphQLJpaExecutorContextFactory executorContextFactory;   
@@ -94,6 +96,9 @@ public class GraphQLJpaQueryAutoConfigurationTest {
     
     @Autowired
     private GraphQLSchema graphQLSchema;
+
+    @Autowired
+    private GraphQLJPASchemaBuilderCustomizer graphQLJPASchemaBuilderCustomizer;
     
     @Test
     public void contextIsAutoConfigured() {
@@ -118,9 +123,11 @@ public class GraphQLJpaQueryAutoConfigurationTest {
         assertThat(executorContextFactory.getInstrumentation()).isEqualTo(instrumentation.getObject());
         assertThat(executorContextFactory.getGraphqlFieldVisibility()).isEqualTo(graphqlFieldVisibility.getObject());
         assertThat(executorContextFactory.getGraphqlContext()).isEqualTo(graphqlContext.getObject());
-        
+
         assertThat(graphQLSchema.getQueryType())
                                 .extracting(GraphQLObjectType::getName, GraphQLObjectType::getDescription)
                                 .containsExactly("GraphQLBooks", "GraphQL Books Schema Description");
+
+        verify(graphQLJPASchemaBuilderCustomizer).customize(eq(graphQLSchemaBuilder));
     }
 }

--- a/graphql-jpa-query-boot-starter/src/test/java/com/introproventures/graphql/jpa/query/boot/test/starter/GraphQLJpaQueryStarterIT.java
+++ b/graphql-jpa-query-boot-starter/src/test/java/com/introproventures/graphql/jpa/query/boot/test/starter/GraphQLJpaQueryStarterIT.java
@@ -15,13 +15,12 @@
  */
 package com.introproventures.graphql.jpa.query.boot.test.starter;
 
-import static org.assertj.core.api.Assertions.assertThat;
-
-import java.io.IOException;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
-
+import com.fasterxml.jackson.core.JsonParseException;
+import com.fasterxml.jackson.databind.JsonMappingException;
+import com.introproventures.graphql.jpa.query.autoconfigure.EnableGraphQLJpaQuerySchema;
+import com.introproventures.graphql.jpa.query.boot.test.starter.Result.GraphQLError;
+import com.introproventures.graphql.jpa.query.boot.test.starter.model.Author;
+import com.introproventures.graphql.jpa.query.web.GraphQLController.GraphQLQueryRequest;
 import org.junit.Assert;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -35,10 +34,12 @@ import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.test.context.junit4.SpringRunner;
 
-import com.fasterxml.jackson.core.JsonParseException;
-import com.fasterxml.jackson.databind.JsonMappingException;
-import com.introproventures.graphql.jpa.query.boot.test.starter.Result.GraphQLError;
-import com.introproventures.graphql.jpa.query.web.GraphQLController.GraphQLQueryRequest;
+import java.io.IOException;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
 
 @RunWith(SpringRunner.class)
 @SpringBootTest(webEnvironment = WebEnvironment.RANDOM_PORT)
@@ -46,6 +47,7 @@ public class GraphQLJpaQueryStarterIT {
 	private static final String	WAR_AND_PEACE	= "War and Peace";
 
     @SpringBootApplication
+    @EnableGraphQLJpaQuerySchema(basePackageClasses = Author.class)
     static class Application {
     }
    	

--- a/graphql-jpa-query-example-relay/src/main/java/com/introproventures/graphql/jpa/query/example/relay/Application.java
+++ b/graphql-jpa-query-example-relay/src/main/java/com/introproventures/graphql/jpa/query/example/relay/Application.java
@@ -15,18 +15,14 @@
  */
 package com.introproventures.graphql.jpa.query.example.relay;
 
+import com.introproventures.graphql.jpa.query.autoconfigure.EnableGraphQLJpaQuerySchema;
+import com.introproventures.graphql.jpa.query.autoconfigure.GraphQLJPASchemaBuilderCustomizer;
 import com.introproventures.graphql.jpa.query.autoconfigure.GraphQLJpaQueryProperties;
-import com.introproventures.graphql.jpa.query.autoconfigure.GraphQLSchemaConfigurer;
-import com.introproventures.graphql.jpa.query.autoconfigure.GraphQLShemaRegistration;
-import com.introproventures.graphql.jpa.query.schema.impl.GraphQLJpaSchemaBuilder;
 import com.introproventures.graphql.jpa.query.schema.model.book.Book;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
-import org.springframework.boot.autoconfigure.domain.EntityScan;
+import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
-
-import javax.persistence.EntityManager;
 
 /**
  * GraphQL JPA Query Example Relay with Spring Boot Autoconfiguration
@@ -37,7 +33,7 @@ import javax.persistence.EntityManager;
  *
  */
 @SpringBootApplication
-@EntityScan(basePackageClasses=Book.class)
+@EnableGraphQLJpaQuerySchema(basePackageClasses=Book.class)
 public class Application {
 
     public static void main(String[] args) {
@@ -45,28 +41,11 @@ public class Application {
     }
     
     @Configuration
-    public static class GraphQLJpaQuerySchemaConfigurer implements GraphQLSchemaConfigurer {
+    public static class GraphQLJpaQuerySchemaConfigurer {
 
-        private final EntityManager entityManager;
-
-        @Autowired
-        private GraphQLJpaQueryProperties properties;
-
-        public GraphQLJpaQuerySchemaConfigurer(EntityManager entityManager) {
-            this.entityManager = entityManager;
-        }
-
-        @Override
-        public void configure(GraphQLShemaRegistration registry) {
-            registry.register(
-                    new GraphQLJpaSchemaBuilder(entityManager)
-                        .name(properties.getName())
-                        .description(properties.getDescription())
-                        .useDistinctParameter(properties.isUseDistinctParameter())
-                        .defaultDistinct(properties.isDefaultDistinct())
-                        .enableRelay(properties.isEnableRelay())
-                        .build()
-            );
+        @Bean
+        GraphQLJPASchemaBuilderCustomizer graphQLSchemaBuilderCustomizer(GraphQLJpaQueryProperties properties) {
+            return builder -> builder.enableRelay(properties.isEnableRelay());
         }
     }    
     

--- a/graphql-jpa-query-example-relay/src/main/java/com/introproventures/graphql/jpa/query/example/relay/Application.java
+++ b/graphql-jpa-query-example-relay/src/main/java/com/introproventures/graphql/jpa/query/example/relay/Application.java
@@ -15,19 +15,18 @@
  */
 package com.introproventures.graphql.jpa.query.example.relay;
 
-import javax.persistence.EntityManager;
-
+import com.introproventures.graphql.jpa.query.autoconfigure.GraphQLJpaQueryProperties;
+import com.introproventures.graphql.jpa.query.autoconfigure.GraphQLSchemaConfigurer;
+import com.introproventures.graphql.jpa.query.autoconfigure.GraphQLShemaRegistration;
+import com.introproventures.graphql.jpa.query.schema.impl.GraphQLJpaSchemaBuilder;
+import com.introproventures.graphql.jpa.query.schema.model.book.Book;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.boot.autoconfigure.domain.EntityScan;
 import org.springframework.context.annotation.Configuration;
 
-import com.introproventures.graphql.jpa.query.autoconfigure.GraphQLJpaQueryProperties;
-import com.introproventures.graphql.jpa.query.autoconfigure.GraphQLSchemaConfigurer;
-import com.introproventures.graphql.jpa.query.autoconfigure.GraphQLShemaRegistration;
-import com.introproventures.graphql.jpa.query.schema.impl.GraphQLJpaSchemaBuilder;
-import com.introproventures.graphql.jpa.query.schema.model.book.Book;
+import javax.persistence.EntityManager;
 
 /**
  * GraphQL JPA Query Example Relay with Spring Boot Autoconfiguration

--- a/graphql-jpa-query-example-simple/src/main/java/com/introproventures/graphql/jpa/query/example/Application.java
+++ b/graphql-jpa-query-example-simple/src/main/java/com/introproventures/graphql/jpa/query/example/Application.java
@@ -15,10 +15,10 @@
  */
 package com.introproventures.graphql.jpa.query.example;
 
+import com.introproventures.graphql.jpa.query.autoconfigure.EnableGraphQLJpaQuerySchema;
 import com.introproventures.graphql.jpa.query.schema.model.starwars.Character;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
-import org.springframework.boot.autoconfigure.domain.EntityScan;
 
 /**
  * GraphQL JPA Query Example with Spring Boot Autoconfiguration
@@ -29,7 +29,7 @@ import org.springframework.boot.autoconfigure.domain.EntityScan;
  *
  */
 @SpringBootApplication
-@EntityScan(basePackageClasses=Character.class)
+@EnableGraphQLJpaQuerySchema(basePackageClasses=Character.class)
 public class Application {
 
     public static void main(String[] args) {

--- a/graphql-jpa-query-example-spring-graphql/src/main/java/com/introproventures/graphql/jpa/query/example/Application.java
+++ b/graphql-jpa-query-example-spring-graphql/src/main/java/com/introproventures/graphql/jpa/query/example/Application.java
@@ -15,10 +15,10 @@
  */
 package com.introproventures.graphql.jpa.query.example;
 
+import com.introproventures.graphql.jpa.query.autoconfigure.EnableGraphQLJpaQuerySchema;
 import com.introproventures.graphql.jpa.query.schema.model.starwars.Character;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
-import org.springframework.boot.autoconfigure.domain.EntityScan;
 import org.springframework.context.annotation.Configuration;
 
 /**
@@ -37,7 +37,7 @@ public class Application {
     }
 
     @Configuration
-    @EntityScan(basePackageClasses=Character.class)
+    @EnableGraphQLJpaQuerySchema(basePackageClasses=Character.class)
     static class StarwarsJpaModelConfiguration {
     }
 }


### PR DESCRIPTION
- [x] Added `@EnableGraphQLJpaQuerySchema` annotation to trigger `GraphQLSchemaBuilderAutoConfiguration`, i.e. 

```java
@SpringBootApplication
@EnableGraphQLJpaQuerySchema(basePackageClasses=Character.class)
public class Application {

    public static void main(String[] args) {
        SpringApplication.run(Application.class, args);
    }
    
}
```

- [x] Added `GraphQLJPASchemaBuilderCustomizer` to customize `GraphQLJpaSchemaBuilder` features at runtime, i.e.

```java
@SpringBootApplication
@EnableGraphQLJpaQuerySchema(basePackageClasses=Book.class)
public class Application {

    public static void main(String[] args) {
        SpringApplication.run(Application.class, args);
    }
    
    @Configuration
    public static class GraphQLJpaQuerySchemaConfigurer {

        @Bean
        GraphQLJPASchemaBuilderCustomizer graphQLSchemaBuilderCustomizer() {
            return builder -> builder.enableRelay(true);
        }
    }
}
```

- [x] Added auto configuration support for `GraphQLSchema` factory bean integration with Spring `GraphQlSource` and `ExecutionGraphQlService`, i.e. `graphql-jpa-query-example-spring-graphql` example

