### PR TITLE
Support for Nested @Embedded

### DIFF
--- a/schema/src/main/java/com/introproventures/graphql/jpa/query/schema/impl/GraphQLJpaSchemaBuilder.java
+++ b/schema/src/main/java/com/introproventures/graphql/jpa/query/schema/impl/GraphQLJpaSchemaBuilder.java
@@ -990,7 +990,7 @@ public class GraphQLJpaSchemaBuilder implements GraphQLSchemaBuilder {
                                         return GraphQLInputObjectField
                                             .newInputObjectField()
                                             .name(attribute.getName())
-                                            .description(getSchemaDescription(nestedEmbeddableType))
+                                            .description(getSchemaDescription(attribute))
                                             .type(
                                                 (GraphQLInputType) getEmbeddableType(
                                                     nestedEmbeddableType,
@@ -1039,7 +1039,7 @@ public class GraphQLJpaSchemaBuilder implements GraphQLSchemaBuilder {
                                     return GraphQLFieldDefinition
                                         .newFieldDefinition()
                                         .name(attribute.getName())
-                                        .description(getSchemaDescription(nestedEmbeddableType))
+                                        .description(getSchemaDescription(attribute))
                                         .type(
                                             (GraphQLOutputType) getEmbeddableType(
                                                 nestedEmbeddableType,


### PR DESCRIPTION
Fixed bug when generating the GraphQL schema for an Embeddable as the system was not taking into consideration having nested representations annotated with `Embedded`. By enhancing `getEmbeddableType` under `GraphQLJpaSchemaBuilder` so that generation is done in a recursive manner the system now supports an infinite amount of nestable classes annotated with `Embedded`.

Resolved https://github.com/introproventures/graphql-jpa-query/issues/336