### PR TITLE
Fix auto-configuration to apply a shared container entity manager instance for GraphQLJPASchemaBuilder 

### DIFF
--- a/autoconfigure/pom.xml
+++ b/autoconfigure/pom.xml
@@ -14,6 +14,10 @@
 
   <dependencies>
     <dependency>
+      <groupId>org.springframework</groupId>
+      <artifactId>spring-orm</artifactId>
+    </dependency>
+    <dependency>
       <groupId>com.introproventures</groupId>
       <artifactId>graphql-jpa-query-scalars</artifactId>
     </dependency>

--- a/autoconfigure/src/main/java/com/introproventures/graphql/jpa/query/autoconfigure/GraphQLJpaQueryAutoConfiguration.java
+++ b/autoconfigure/src/main/java/com/introproventures/graphql/jpa/query/autoconfigure/GraphQLJpaQueryAutoConfiguration.java
@@ -22,7 +22,6 @@ import com.introproventures.graphql.jpa.query.schema.impl.GraphQLJpaExecutor;
 import com.introproventures.graphql.jpa.query.schema.impl.GraphQLJpaExecutorContextFactory;
 import graphql.GraphQL;
 import graphql.GraphQLContext;
-import graphql.execution.ExecutionStrategy;
 import graphql.execution.instrumentation.Instrumentation;
 import graphql.schema.GraphQLSchema;
 import graphql.schema.visibility.GraphqlFieldVisibility;
@@ -60,9 +59,9 @@ public class GraphQLJpaQueryAutoConfiguration {
         ObjectProvider<Supplier<GraphqlFieldVisibility>> graphqlFieldVisibility,
         ObjectProvider<Supplier<Instrumentation>> instrumentation,
         ObjectProvider<Supplier<GraphQLContext>> graphqlContext,
-        ObjectProvider<Supplier<ExecutionStrategy>> queryExecutionStrategy,
-        ObjectProvider<Supplier<ExecutionStrategy>> mutationExecutionStrategy,
-        ObjectProvider<Supplier<ExecutionStrategy>> subscriptionExecutionStrategy
+        ObjectProvider<QueryExecutionStrategyProvider> queryExecutionStrategy,
+        ObjectProvider<MutationExecutionStrategyProvider> mutationExecutionStrategy,
+        ObjectProvider<SubscriptionExecutionStrategyProvider> subscriptionExecutionStrategy
     ) {
         GraphQLJpaExecutorContextFactory bean = new GraphQLJpaExecutorContextFactory();
 

--- a/autoconfigure/src/main/java/com/introproventures/graphql/jpa/query/autoconfigure/GraphQLJpaQueryGraphQlSourceAutoConfiguration.java
+++ b/autoconfigure/src/main/java/com/introproventures/graphql/jpa/query/autoconfigure/GraphQLJpaQueryGraphQlSourceAutoConfiguration.java
@@ -47,15 +47,15 @@ public class GraphQLJpaQueryGraphQlSourceAutoConfiguration {
     @Bean
     @ConditionalOnBean(GraphQLSchema.class)
     Consumer<GraphQL.Builder> graphQlExecutionStrategyConfigurer(
-        QueryExecutionStrategyProvider queryExecutionStrategy,
-        MutationExecutionStrategyProvider mutationExecutionStrategy,
-        SubscriptionExecutionStrategyProvider subscriptionExecutionStrategy
+        ObjectProvider<QueryExecutionStrategyProvider> queryExecutionStrategy,
+        ObjectProvider<MutationExecutionStrategyProvider> mutationExecutionStrategy,
+        ObjectProvider<SubscriptionExecutionStrategyProvider> subscriptionExecutionStrategy
     ) {
-        return builder ->
-            builder
-                .queryExecutionStrategy(queryExecutionStrategy.get())
-                .mutationExecutionStrategy(mutationExecutionStrategy.get())
-                .subscriptionExecutionStrategy(subscriptionExecutionStrategy.get());
+        return builder -> {
+            queryExecutionStrategy.ifAvailable(it -> builder.queryExecutionStrategy(it.get()));
+            mutationExecutionStrategy.ifAvailable(it -> builder.mutationExecutionStrategy(it.get()));
+            subscriptionExecutionStrategy.ifAvailable(it -> builder.subscriptionExecutionStrategy(it.get()));
+        };
     }
 
     @Bean

--- a/autoconfigure/src/main/java/com/introproventures/graphql/jpa/query/autoconfigure/GraphQLJpaQueryGraphQlSourceAutoConfiguration.java
+++ b/autoconfigure/src/main/java/com/introproventures/graphql/jpa/query/autoconfigure/GraphQLJpaQueryGraphQlSourceAutoConfiguration.java
@@ -19,7 +19,6 @@ import graphql.GraphQL;
 import graphql.execution.instrumentation.Instrumentation;
 import graphql.schema.GraphQLSchema;
 import java.util.function.Consumer;
-import java.util.stream.Collectors;
 import org.springframework.beans.factory.ListableBeanFactory;
 import org.springframework.beans.factory.ObjectProvider;
 import org.springframework.boot.autoconfigure.AutoConfiguration;
@@ -44,6 +43,28 @@ import org.springframework.graphql.execution.SubscriptionExceptionResolver;
 @ConditionalOnProperty(name = "spring.graphql.jpa.query.enabled", havingValue = "true", matchIfMissing = true)
 @EnableConfigurationProperties(GraphQlProperties.class)
 public class GraphQLJpaQueryGraphQlSourceAutoConfiguration {
+
+    @Bean
+    @ConditionalOnBean(GraphQLSchema.class)
+    Consumer<GraphQL.Builder> graphQlExecutionStrategyConfigurer(
+        QueryExecutionStrategyProvider queryExecutionStrategy,
+        MutationExecutionStrategyProvider mutationExecutionStrategy,
+        SubscriptionExecutionStrategyProvider subscriptionExecutionStrategy
+    ) {
+        return builder ->
+            builder
+                .queryExecutionStrategy(queryExecutionStrategy.get())
+                .mutationExecutionStrategy(mutationExecutionStrategy.get())
+                .subscriptionExecutionStrategy(subscriptionExecutionStrategy.get());
+    }
+
+    @Bean
+    @ConditionalOnGraphQlSchema
+    GraphQlSourceBuilderCustomizer graphQlSourceBuilderExecutionStrategyCustomizer(
+        Consumer<GraphQL.Builder> graphQlExecutionStrategyConfigurer
+    ) {
+        return builder -> builder.configureGraphQl(graphQlExecutionStrategyConfigurer);
+    }
 
     @Bean
     @ConditionalOnGraphQlSchema
@@ -86,9 +107,9 @@ public class GraphQLJpaQueryGraphQlSourceAutoConfiguration {
         GraphQlSource.Builder<?> builder = GraphQlSource.builder(graphQLSchema);
 
         builder
-            .exceptionResolvers(exceptionResolvers.orderedStream().collect(Collectors.toList()))
-            .subscriptionExceptionResolvers(subscriptionExceptionResolvers.orderedStream().collect(Collectors.toList()))
-            .instrumentation(instrumentations.orderedStream().collect(Collectors.toList()));
+            .exceptionResolvers(exceptionResolvers.orderedStream().toList())
+            .subscriptionExceptionResolvers(subscriptionExceptionResolvers.orderedStream().toList())
+            .instrumentation(instrumentations.orderedStream().toList());
 
         configurers.orderedStream().forEach(builder::configureGraphQl);
 

--- a/autoconfigure/src/main/java/com/introproventures/graphql/jpa/query/autoconfigure/GraphQLSchemaBuilderAutoConfiguration.java
+++ b/autoconfigure/src/main/java/com/introproventures/graphql/jpa/query/autoconfigure/GraphQLSchemaBuilderAutoConfiguration.java
@@ -1,10 +1,16 @@
 package com.introproventures.graphql.jpa.query.autoconfigure;
 
+import static com.introproventures.graphql.jpa.query.autoconfigure.TransactionalDelegateExecutionStrategy.Builder.newTransactionalExecutionStrategy;
+
 import com.introproventures.graphql.jpa.query.schema.GraphQLSchemaBuilder;
 import com.introproventures.graphql.jpa.query.schema.RestrictedKeysProvider;
 import com.introproventures.graphql.jpa.query.schema.impl.GraphQLJpaSchemaBuilder;
 import graphql.GraphQL;
+import jakarta.persistence.EntityManager;
 import jakarta.persistence.EntityManagerFactory;
+import java.util.function.Supplier;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.ObjectProvider;
 import org.springframework.boot.autoconfigure.AutoConfiguration;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
@@ -14,6 +20,10 @@ import org.springframework.boot.autoconfigure.condition.ConditionalOnSingleCandi
 import org.springframework.boot.autoconfigure.orm.jpa.HibernateJpaAutoConfiguration;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.context.annotation.Bean;
+import org.springframework.orm.jpa.SharedEntityManagerCreator;
+import org.springframework.transaction.PlatformTransactionManager;
+import org.springframework.transaction.TransactionDefinition;
+import org.springframework.transaction.support.TransactionTemplate;
 
 @AutoConfiguration(
     before = { GraphQLSchemaAutoConfiguration.class, GraphQLJpaQueryGraphQlSourceAutoConfiguration.class },
@@ -23,6 +33,45 @@ import org.springframework.context.annotation.Bean;
 @ConditionalOnClass({ EntityManagerFactory.class, GraphQL.class, GraphQLSchemaBuilder.class })
 @ConditionalOnProperty(name = "spring.graphql.jpa.query.enabled", havingValue = "true", matchIfMissing = true)
 public class GraphQLSchemaBuilderAutoConfiguration {
+
+    private static final Logger log = LoggerFactory.getLogger(GraphQLSchemaBuilderAutoConfiguration.class);
+
+    @Bean
+    @ConditionalOnMissingBean(value = TransactionTemplate.class, parameterizedContainer = Supplier.class)
+    Supplier<TransactionTemplate> transactionTemplateSupplier(PlatformTransactionManager transactionManager) {
+        return () -> new TransactionTemplate(transactionManager);
+    }
+
+    @Bean
+    @ConditionalOnMissingBean(QueryExecutionStrategyProvider.class)
+    QueryExecutionStrategyProvider queryExecutionStrategy(Supplier<TransactionTemplate> transactionTemplateSupplier) {
+        var transactionTemplate = transactionTemplateSupplier.get();
+        transactionTemplate.setReadOnly(true);
+
+        return () -> newTransactionalExecutionStrategy(transactionTemplate).build();
+    }
+
+    @Bean
+    @ConditionalOnMissingBean(MutationExecutionStrategyProvider.class)
+    MutationExecutionStrategyProvider mutationExecutionStrategy(
+        Supplier<TransactionTemplate> transactionTemplateSupplier
+    ) {
+        var transactionTemplate = transactionTemplateSupplier.get();
+        transactionTemplate.setPropagationBehavior(TransactionDefinition.PROPAGATION_REQUIRES_NEW);
+
+        return () -> newTransactionalExecutionStrategy(transactionTemplate).build();
+    }
+
+    @Bean
+    @ConditionalOnMissingBean(SubscriptionExecutionStrategyProvider.class)
+    SubscriptionExecutionStrategyProvider subscriptionExecutionStrategy(
+        Supplier<TransactionTemplate> transactionTemplateSupplier
+    ) {
+        var transactionTemplate = transactionTemplateSupplier.get();
+        transactionTemplate.setPropagationBehavior(TransactionDefinition.PROPAGATION_SUPPORTS);
+
+        return () -> newTransactionalExecutionStrategy(transactionTemplate).build();
+    }
 
     @Bean
     @GraphQLSchemaEntityManager

--- a/autoconfigure/src/main/java/com/introproventures/graphql/jpa/query/autoconfigure/GraphQLSchemaEntityManager.java
+++ b/autoconfigure/src/main/java/com/introproventures/graphql/jpa/query/autoconfigure/GraphQLSchemaEntityManager.java
@@ -1,20 +1,6 @@
 package com.introproventures.graphql.jpa.query.autoconfigure;
 
-import java.lang.annotation.Documented;
-import java.lang.annotation.ElementType;
-import java.lang.annotation.Inherited;
-import java.lang.annotation.Retention;
-import java.lang.annotation.RetentionPolicy;
-import java.lang.annotation.Target;
-import org.springframework.beans.factory.annotation.Qualifier;
-import org.springframework.core.annotation.AliasFor;
+import jakarta.persistence.EntityManager;
+import java.util.function.Supplier;
 
-@Target({ ElementType.FIELD, ElementType.METHOD, ElementType.PARAMETER, ElementType.TYPE, ElementType.ANNOTATION_TYPE })
-@Retention(RetentionPolicy.RUNTIME)
-@Inherited
-@Documented
-@Qualifier
-public @interface GraphQLSchemaEntityManager {
-    @AliasFor(annotation = Qualifier.class, attribute = "value")
-    String value() default "graphQLSchemaEntityManager";
-}
+public interface GraphQLSchemaEntityManager extends Supplier<EntityManager> {}

--- a/autoconfigure/src/main/java/com/introproventures/graphql/jpa/query/autoconfigure/GraphQLSchemaEntityManager.java
+++ b/autoconfigure/src/main/java/com/introproventures/graphql/jpa/query/autoconfigure/GraphQLSchemaEntityManager.java
@@ -1,0 +1,20 @@
+package com.introproventures.graphql.jpa.query.autoconfigure;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Inherited;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.core.annotation.AliasFor;
+
+@Target({ ElementType.FIELD, ElementType.METHOD, ElementType.PARAMETER, ElementType.TYPE, ElementType.ANNOTATION_TYPE })
+@Retention(RetentionPolicy.RUNTIME)
+@Inherited
+@Documented
+@Qualifier
+public @interface GraphQLSchemaEntityManager {
+    @AliasFor(annotation = Qualifier.class, attribute = "value")
+    String value() default "graphQLSchemaEntityManager";
+}

--- a/autoconfigure/src/main/java/com/introproventures/graphql/jpa/query/autoconfigure/GraphQLSchemaTransactionTemplate.java
+++ b/autoconfigure/src/main/java/com/introproventures/graphql/jpa/query/autoconfigure/GraphQLSchemaTransactionTemplate.java
@@ -1,0 +1,6 @@
+package com.introproventures.graphql.jpa.query.autoconfigure;
+
+import java.util.function.Supplier;
+import org.springframework.transaction.support.TransactionTemplate;
+
+public interface GraphQLSchemaTransactionTemplate extends Supplier<TransactionTemplate> {}

--- a/autoconfigure/src/main/java/com/introproventures/graphql/jpa/query/autoconfigure/MutationExecutionStrategyProvider.java
+++ b/autoconfigure/src/main/java/com/introproventures/graphql/jpa/query/autoconfigure/MutationExecutionStrategyProvider.java
@@ -1,0 +1,6 @@
+package com.introproventures.graphql.jpa.query.autoconfigure;
+
+import graphql.execution.ExecutionStrategy;
+import java.util.function.Supplier;
+
+public interface MutationExecutionStrategyProvider extends Supplier<ExecutionStrategy> {}

--- a/autoconfigure/src/main/java/com/introproventures/graphql/jpa/query/autoconfigure/QueryExecutionStrategyProvider.java
+++ b/autoconfigure/src/main/java/com/introproventures/graphql/jpa/query/autoconfigure/QueryExecutionStrategyProvider.java
@@ -1,0 +1,6 @@
+package com.introproventures.graphql.jpa.query.autoconfigure;
+
+import graphql.execution.ExecutionStrategy;
+import java.util.function.Supplier;
+
+public interface QueryExecutionStrategyProvider extends Supplier<ExecutionStrategy> {}

--- a/autoconfigure/src/main/java/com/introproventures/graphql/jpa/query/autoconfigure/SubscriptionExecutionStrategyProvider.java
+++ b/autoconfigure/src/main/java/com/introproventures/graphql/jpa/query/autoconfigure/SubscriptionExecutionStrategyProvider.java
@@ -1,0 +1,6 @@
+package com.introproventures.graphql.jpa.query.autoconfigure;
+
+import graphql.execution.ExecutionStrategy;
+import java.util.function.Supplier;
+
+public interface SubscriptionExecutionStrategyProvider extends Supplier<ExecutionStrategy> {}

--- a/autoconfigure/src/main/java/com/introproventures/graphql/jpa/query/autoconfigure/TransactionalDelegateExecutionStrategy.java
+++ b/autoconfigure/src/main/java/com/introproventures/graphql/jpa/query/autoconfigure/TransactionalDelegateExecutionStrategy.java
@@ -1,0 +1,128 @@
+package com.introproventures.graphql.jpa.query.autoconfigure;
+
+import graphql.ExecutionResult;
+import graphql.execution.AsyncExecutionStrategy;
+import graphql.execution.ExecutionContext;
+import graphql.execution.ExecutionStrategy;
+import graphql.execution.ExecutionStrategyParameters;
+import graphql.execution.NonNullableFieldWasNullException;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.Executor;
+import java.util.concurrent.Executors;
+import java.util.function.Supplier;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.transaction.support.TransactionSynchronizationManager;
+import org.springframework.transaction.support.TransactionTemplate;
+
+public class TransactionalDelegateExecutionStrategy extends ExecutionStrategy {
+
+    private static final Logger log = LoggerFactory.getLogger(TransactionalDelegateExecutionStrategy.class);
+
+    private final TransactionTemplate transactionTemplate;
+
+    private final ExecutionStrategy delegate;
+
+    private final Supplier<Executor> executor;
+
+    public TransactionalDelegateExecutionStrategy(
+        TransactionTemplate transactionTemplate,
+        ExecutionStrategy delegate,
+        Supplier<Executor> executor
+    ) {
+        this.transactionTemplate = transactionTemplate;
+        this.delegate = delegate;
+        this.executor = executor;
+    }
+
+    @Override
+    public CompletableFuture<ExecutionResult> execute(
+        ExecutionContext executionContext,
+        ExecutionStrategyParameters parameters
+    ) throws NonNullableFieldWasNullException {
+        if (!TransactionSynchronizationManager.isActualTransactionActive()) {
+            if (log.isTraceEnabled()) {
+                log.trace(
+                    "Start root execution request {} running on {}",
+                    executionContext.getExecutionId(),
+                    Thread.currentThread()
+                );
+            }
+            return CompletableFuture.supplyAsync(
+                () -> {
+                    return transactionTemplate.execute(status -> {
+                        if (log.isTraceEnabled()) {
+                            log.trace(
+                                "Begin transaction for {} on {}",
+                                executionContext.getExecutionId(),
+                                Thread.currentThread()
+                            );
+                        }
+                        try {
+                            if (log.isTraceEnabled()) {
+                                log.trace(
+                                    "Execute request for {} on {}",
+                                    executionContext.getExecutionId(),
+                                    Thread.currentThread()
+                                );
+                            }
+
+                            return delegate.execute(executionContext, parameters).join();
+                        } finally {
+                            if (log.isTraceEnabled()) {
+                                log.trace(
+                                    "End transaction for {} on {}",
+                                    executionContext.getExecutionId(),
+                                    Thread.currentThread()
+                                );
+                            }
+                        }
+                    });
+                },
+                executor.get()
+            );
+        } else {
+            if (log.isTraceEnabled()) {
+                log.trace(
+                    "Execute request {} for {} on {}",
+                    executionContext.getExecutionId(),
+                    parameters.getField().getName(),
+                    Thread.currentThread()
+                );
+            }
+            return delegate.execute(executionContext, parameters);
+        }
+    }
+
+    public static final class Builder {
+
+        private TransactionTemplate transactionTemplate;
+        private Supplier<Executor> executor = Executors::newCachedThreadPool;
+        private ExecutionStrategy delegate = new AsyncExecutionStrategy();
+
+        private Builder() {}
+
+        public static Builder newTransactionalExecutionStrategy(TransactionTemplate transactionTemplate) {
+            return new Builder().transactionTemplate(transactionTemplate);
+        }
+
+        public Builder transactionTemplate(TransactionTemplate transactionTemplate) {
+            this.transactionTemplate = transactionTemplate;
+            return this;
+        }
+
+        public Builder delegate(ExecutionStrategy delegate) {
+            this.delegate = delegate;
+            return this;
+        }
+
+        public Builder executor(Supplier<Executor> executor) {
+            this.executor = executor;
+            return this;
+        }
+
+        public TransactionalDelegateExecutionStrategy build() {
+            return new TransactionalDelegateExecutionStrategy(transactionTemplate, delegate, executor);
+        }
+    }
+}

--- a/autoconfigure/src/test/java/com/introproventures/graphql/jpa/query/autoconfigure/GraphQLSchemaAutoConfigurationTest.java
+++ b/autoconfigure/src/test/java/com/introproventures/graphql/jpa/query/autoconfigure/GraphQLSchemaAutoConfigurationTest.java
@@ -17,6 +17,7 @@ import com.introproventures.graphql.jpa.query.autoconfigure.support.Subscription
 import com.introproventures.graphql.jpa.query.autoconfigure.support.TestEntity;
 import com.introproventures.graphql.jpa.query.schema.JavaScalars;
 import com.introproventures.graphql.jpa.query.schema.JavaScalarsWiringPostProcessor;
+import com.introproventures.graphql.jpa.query.schema.impl.GraphQLJpaSchemaBuilder;
 import graphql.ExecutionResult;
 import graphql.GraphQL;
 import graphql.Scalars;
@@ -39,6 +40,8 @@ import graphql.schema.idl.RuntimeWiring;
 import graphql.schema.idl.SchemaGenerator;
 import graphql.schema.idl.SchemaParser;
 import graphql.schema.idl.TypeDefinitionRegistry;
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.PersistenceContext;
 import java.io.File;
 import java.io.IOException;
 import java.time.Duration;
@@ -59,6 +62,7 @@ import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.context.SpringBootTest.WebEnvironment;
+import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.core.io.Resource;
 import org.springframework.stereotype.Component;
@@ -73,11 +77,26 @@ public class GraphQLSchemaAutoConfigurationTest {
     private GraphQLSchema graphQLSchema;
 
     @Autowired
+    private GraphQLJpaSchemaBuilder graphQLJpaSchemaBuilder;
+
+    @Autowired
+    private Supplier<EntityManager> entityManagerSupplier;
+
+    @Autowired
     private GraphQLJpaQueryProperties graphQLJpaQueryProperties;
 
     @SpringBootApplication
     @EnableGraphQLJpaQuerySchema(basePackageClasses = TestEntity.class)
     static class Application {
+
+        @PersistenceContext
+        EntityManager entityManager;
+
+        @Bean
+        @GraphQLSchemaEntityManager
+        Supplier<EntityManager> persistentContextEntityManager() {
+            return () -> entityManager;
+        }
 
         @Configuration
         static class GraphQLAnnotationsSchemaConfigurer implements GraphQLSchemaConfigurer {
@@ -376,10 +395,16 @@ public class GraphQLSchemaAutoConfigurationTest {
     }
 
     @Test
-    public void defaultConfigurationProperties() {
+    void defaultConfigurationProperties() {
         // given
         assertThat(graphQLJpaQueryProperties.isDefaultDistinct()).isTrue();
         assertThat(graphQLJpaQueryProperties.isUseDistinctParameter()).isFalse();
         assertThat(graphQLJpaQueryProperties.isToManyDefaultOptional()).isTrue();
+    }
+
+    @Test
+    void configuresSharedEntityManager() {
+        // given
+        assertThat(graphQLJpaSchemaBuilder.getEntityManager()).isEqualTo(entityManagerSupplier.get());
     }
 }

--- a/autoconfigure/src/test/java/com/introproventures/graphql/jpa/query/autoconfigure/GraphQLSchemaAutoConfigurationTest.java
+++ b/autoconfigure/src/test/java/com/introproventures/graphql/jpa/query/autoconfigure/GraphQLSchemaAutoConfigurationTest.java
@@ -80,7 +80,7 @@ public class GraphQLSchemaAutoConfigurationTest {
     private GraphQLJpaSchemaBuilder graphQLJpaSchemaBuilder;
 
     @Autowired
-    private Supplier<EntityManager> entityManagerSupplier;
+    private GraphQLSchemaEntityManager entityManagerSupplier;
 
     @Autowired
     private QueryExecutionStrategyProvider queryExecutionStrategy;
@@ -102,8 +102,7 @@ public class GraphQLSchemaAutoConfigurationTest {
         EntityManager entityManager;
 
         @Bean
-        @GraphQLSchemaEntityManager
-        Supplier<EntityManager> persistentContextEntityManager() {
+        GraphQLSchemaEntityManager persistentContextEntityManager() {
             return () -> entityManager;
         }
 

--- a/autoconfigure/src/test/java/com/introproventures/graphql/jpa/query/autoconfigure/GraphQLSchemaAutoConfigurationTest.java
+++ b/autoconfigure/src/test/java/com/introproventures/graphql/jpa/query/autoconfigure/GraphQLSchemaAutoConfigurationTest.java
@@ -83,6 +83,15 @@ public class GraphQLSchemaAutoConfigurationTest {
     private Supplier<EntityManager> entityManagerSupplier;
 
     @Autowired
+    private QueryExecutionStrategyProvider queryExecutionStrategy;
+
+    @Autowired
+    private MutationExecutionStrategyProvider mutationExecutionStrategy;
+
+    @Autowired
+    private SubscriptionExecutionStrategyProvider subscriptionExecutionStrategy;
+
+    @Autowired
     private GraphQLJpaQueryProperties graphQLJpaQueryProperties;
 
     @SpringBootApplication

--- a/schema/src/main/java/com/introproventures/graphql/jpa/query/schema/impl/GraphQLJpaExecutor.java
+++ b/schema/src/main/java/com/introproventures/graphql/jpa/query/schema/impl/GraphQLJpaExecutor.java
@@ -36,6 +36,7 @@ import java.util.Optional;
  * @author Igor Dianov
  *
  */
+@Transactional(TxType.SUPPORTS)
 public class GraphQLJpaExecutor implements GraphQLExecutor {
 
     private final GraphQLSchema graphQLSchema;
@@ -66,7 +67,6 @@ public class GraphQLJpaExecutor implements GraphQLExecutor {
      * @see org.activiti.services.query.qraphql.jpa.QraphQLExecutor#execute(java.lang.String)
      */
     @Override
-    @Transactional(TxType.REQUIRED)
     public ExecutionResult execute(String query) {
         return execute(query, Collections.emptyMap());
     }
@@ -75,13 +75,11 @@ public class GraphQLJpaExecutor implements GraphQLExecutor {
      * @see org.activiti.services.query.qraphql.jpa.QraphQLExecutor#execute(java.lang.String, java.util.Map)
      */
     @Override
-    @Transactional(TxType.REQUIRED)
     public ExecutionResult execute(String query, Map<String, Object> arguments) {
         return execute(query, null, arguments);
     }
 
     @Override
-    @Transactional(TxType.REQUIRED)
     public ExecutionResult execute(String query, String operationName, Map<String, Object> arguments) {
         Map<String, Object> variables = Optional.ofNullable(arguments).orElseGet(Collections::emptyMap);
 

--- a/schema/src/main/java/com/introproventures/graphql/jpa/query/schema/impl/GraphQLJpaQueryFactory.java
+++ b/schema/src/main/java/com/introproventures/graphql/jpa/query/schema/impl/GraphQLJpaQueryFactory.java
@@ -282,9 +282,13 @@ public final class GraphQLJpaQueryFactory {
             );
         }
         // Let's execute query and wrap result into stream
-        final Stream<T> resultStream = this.resultStream ? query.getResultStream() : query.getResultList().stream();
+        // FIXME result stream is broken in StarwarsQueryExecutorTestsSupport.queryWithWhereInsideManyToOneRelations test since Hibernate 6.2.x
+        if (resultStream) {
+            logger.warn("Skipping result stream query due to regression in Hibernate 6.2.x");
+            // return query.getResultStream().map(this::unproxy).peek(this::detach);
+        }
 
-        return resultStream.map(this::unproxy).peek(this::detach);
+        return query.getResultList().stream().map(this::unproxy).peek(this::detach);
     }
 
     protected Object querySingleResult(final DataFetchingEnvironment environment) {

--- a/schema/src/main/java/com/introproventures/graphql/jpa/query/schema/impl/GraphQLJpaSchemaBuilder.java
+++ b/schema/src/main/java/com/introproventures/graphql/jpa/query/schema/impl/GraphQLJpaSchemaBuilder.java
@@ -115,7 +115,7 @@ public class GraphQLJpaSchemaBuilder implements GraphQLSchemaBuilder {
 
     private static final Logger log = LoggerFactory.getLogger(GraphQLJpaSchemaBuilder.class);
 
-    private EntityManager entityManager;
+    private final EntityManager entityManager;
 
     private String name = "GraphQLJPA";
 
@@ -145,6 +145,10 @@ public class GraphQLJpaSchemaBuilder implements GraphQLSchemaBuilder {
 
     public GraphQLJpaSchemaBuilder(EntityManager entityManager) {
         this.entityManager = entityManager;
+    }
+
+    public EntityManager getEntityManager() {
+        return entityManager;
     }
 
     /* (non-Javadoc)

--- a/schema/src/main/java/com/introproventures/graphql/jpa/query/schema/impl/GraphQLJpaToManyMappedBatchLoader.java
+++ b/schema/src/main/java/com/introproventures/graphql/jpa/query/schema/impl/GraphQLJpaToManyMappedBatchLoader.java
@@ -23,6 +23,6 @@ class GraphQLJpaToManyMappedBatchLoader implements MappedBatchLoaderWithContext<
         Object key = keys.iterator().next();
         DataFetchingEnvironment context = (DataFetchingEnvironment) environment.getKeyContexts().get(key);
 
-        return CompletableFuture.supplyAsync(() -> queryFactory.loadOneToMany(context, keys));
+        return CompletableFuture.supplyAsync(() -> queryFactory.loadOneToMany(context, keys), Runnable::run);
     }
 }

--- a/schema/src/main/java/com/introproventures/graphql/jpa/query/schema/impl/GraphQLJpaToManyMappedBatchLoader.java
+++ b/schema/src/main/java/com/introproventures/graphql/jpa/query/schema/impl/GraphQLJpaToManyMappedBatchLoader.java
@@ -8,9 +8,13 @@ import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionStage;
 import org.dataloader.BatchLoaderEnvironment;
 import org.dataloader.MappedBatchLoaderWithContext;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 // a batch loader function that will be called with N or more keys for batch loading
 class GraphQLJpaToManyMappedBatchLoader implements MappedBatchLoaderWithContext<Object, List<Object>> {
+
+    private static final Logger log = LoggerFactory.getLogger(GraphQLJpaToManyMappedBatchLoader.class);
 
     private final GraphQLJpaQueryFactory queryFactory;
 
@@ -23,6 +27,15 @@ class GraphQLJpaToManyMappedBatchLoader implements MappedBatchLoaderWithContext<
         Object key = keys.iterator().next();
         DataFetchingEnvironment context = (DataFetchingEnvironment) environment.getKeyContexts().get(key);
 
-        return CompletableFuture.supplyAsync(() -> queryFactory.loadOneToMany(context, keys), Runnable::run);
+        if (log.isTraceEnabled()) {
+            log.trace(
+                "Load batch context {} for keys {} on {}",
+                context.getField().getName(),
+                keys,
+                Thread.currentThread()
+            );
+        }
+
+        return CompletableFuture.completedStage(queryFactory.loadOneToMany(context, keys));
     }
 }

--- a/schema/src/main/java/com/introproventures/graphql/jpa/query/schema/impl/GraphQLJpaToOneMappedBatchLoader.java
+++ b/schema/src/main/java/com/introproventures/graphql/jpa/query/schema/impl/GraphQLJpaToOneMappedBatchLoader.java
@@ -22,6 +22,6 @@ class GraphQLJpaToOneMappedBatchLoader implements MappedBatchLoaderWithContext<O
         Object key = keys.iterator().next();
         DataFetchingEnvironment context = (DataFetchingEnvironment) environment.getKeyContexts().get(key);
 
-        return CompletableFuture.supplyAsync(() -> queryFactory.loadManyToOne(context, keys), Runnable::run);
+        return CompletableFuture.completedStage(queryFactory.loadManyToOne(context, keys));
     }
 }

--- a/schema/src/main/java/com/introproventures/graphql/jpa/query/schema/impl/GraphQLJpaToOneMappedBatchLoader.java
+++ b/schema/src/main/java/com/introproventures/graphql/jpa/query/schema/impl/GraphQLJpaToOneMappedBatchLoader.java
@@ -22,6 +22,6 @@ class GraphQLJpaToOneMappedBatchLoader implements MappedBatchLoaderWithContext<O
         Object key = keys.iterator().next();
         DataFetchingEnvironment context = (DataFetchingEnvironment) environment.getKeyContexts().get(key);
 
-        return CompletableFuture.supplyAsync(() -> queryFactory.loadManyToOne(context, keys));
+        return CompletableFuture.supplyAsync(() -> queryFactory.loadManyToOne(context, keys), Runnable::run);
     }
 }

--- a/schema/src/test/java/com/introproventures/graphql/jpa/query/converter/GraphQLJpaConverterTests.java
+++ b/schema/src/test/java/com/introproventures/graphql/jpa/query/converter/GraphQLJpaConverterTests.java
@@ -947,4 +947,28 @@ public class GraphQLJpaConverterTests extends AbstractSpringBootTestSupport {
 
         assertThat(result.toString()).isEqualTo(expected);
     }
+
+    @Test
+    public void testGraphqlTasksQueryWithEmbeddedVariablesWhereCriteria() throws InterruptedException {
+        // @formatter:off
+        String query =
+            "query getTasks {" +
+                "  Tasks(where: {businessKey: {EQ: \"bk1\"}}) {" +
+                "    select {" +
+                "      businessKey" +
+                "      variables(where: {name: {EQ: \"variable1\"}}) {" +
+                "        name" +
+                "        value" +
+                "      }" +
+                "    }" +
+                "  }" +
+                "}";
+        // @formatter:on
+
+        Object result = executor.execute(query).getData();
+
+        String expected = "{Tasks={select=[{businessKey=bk1, variables=[{name=variable1, value=data}]}]}}";
+
+        assertThat(result.toString()).isEqualTo(expected);
+    }
 }

--- a/tests/multiple-datasources/src/main/java/com/introproventures/graphql/jpa/query/example/Application.java
+++ b/tests/multiple-datasources/src/main/java/com/introproventures/graphql/jpa/query/example/Application.java
@@ -15,23 +15,13 @@
  */
 package com.introproventures.graphql.jpa.query.example;
 
-import static graphql.schema.visibility.DefaultGraphqlFieldVisibility.DEFAULT_FIELD_VISIBILITY;
-
-import graphql.GraphQLContext;
-import graphql.execution.instrumentation.Instrumentation;
-import graphql.execution.instrumentation.SimpleInstrumentation;
-import graphql.execution.instrumentation.tracing.TracingInstrumentation;
-import graphql.schema.visibility.BlockedFields;
-import graphql.schema.visibility.GraphqlFieldVisibility;
-import jakarta.servlet.http.HttpServletRequest;
-import java.util.function.Supplier;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Primary;
+import org.springframework.data.transaction.ChainedTransactionManager;
+import org.springframework.transaction.PlatformTransactionManager;
 import org.springframework.transaction.annotation.EnableTransactionManagement;
-import org.springframework.web.context.annotation.RequestScope;
 
 /**
  * GraphQL JPA Query Example with Spring Boot Autoconfiguration
@@ -45,28 +35,16 @@ import org.springframework.web.context.annotation.RequestScope;
 @EnableTransactionManagement
 public class Application {
 
-    private static final Logger logger = LoggerFactory.getLogger(Application.class);
-
     public static void main(String[] args) {
         SpringApplication.run(Application.class, args);
     }
 
     @Bean
-    @RequestScope
-    public Supplier<GraphqlFieldVisibility> graphqlFieldVisibility(HttpServletRequest request) {
-        return () ->
-            !request.isSecure() ? BlockedFields.newBlock().addPattern("Book.price").build() : DEFAULT_FIELD_VISIBILITY;
-    }
-
-    @Bean
-    @RequestScope
-    public Supplier<GraphQLContext> graphqlContext(HttpServletRequest request) {
-        return () -> GraphQLContext.newContext().of("request", request).of("user", request).build();
-    }
-
-    @Bean
-    @RequestScope
-    public Supplier<Instrumentation> instrumentation(HttpServletRequest request) {
-        return () -> logger.isDebugEnabled() ? new TracingInstrumentation() : SimpleInstrumentation.INSTANCE;
+    @Primary
+    PlatformTransactionManager transactionManager(
+        PlatformTransactionManager bookTransactionManager,
+        PlatformTransactionManager starWarsTransactionManager
+    ) {
+        return new ChainedTransactionManager(bookTransactionManager, starWarsTransactionManager);
     }
 }

--- a/web/src/main/java/com/introproventures/graphql/jpa/query/web/GraphQLController.java
+++ b/web/src/main/java/com/introproventures/graphql/jpa/query/web/GraphQLController.java
@@ -32,7 +32,6 @@ import org.reactivestreams.Publisher;
 import org.reactivestreams.Subscriber;
 import org.reactivestreams.Subscription;
 import org.springframework.http.MediaType;
-import org.springframework.transaction.annotation.Transactional;
 import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -49,7 +48,6 @@ import org.springframework.web.servlet.mvc.method.annotation.SseEmitter.SseEvent
  *
  */
 @RestController
-@Transactional
 public class GraphQLController {
 
     private static final String PATH = "${spring.graphql.jpa.query.web.path:/graphql}";


### PR DESCRIPTION
To fix intermittent incorrect empty query results due to Hibernate query result list containing proxied entities when executing query requests concurrently.  

The GraphQLJPAQueryBuilder was not using the Shared Entity Manager proxy provided by Spring ORM. Instead, it was configured using a static instance backed by non-thread safe Hibernate Session created by the entity manager factory method.

A Spring shared EntityManager will behave just like an EntityManager fetched from an application server's JNDI environment, as defined by the JPA specification. It will delegate all calls to the current transactional EntityManager already attached to a thread per transaction, if any; otherwise it will fall back to a newly created EntityManager per operation request.

The functional tests worked fine, but not concurrently. It also worked in Hibernate 5 by luck and stopped working in Hibernate 6 after upgrade to Spring Boot 3
