### PR TITLE
Remove hibernate-core from graphql-jpa-query-dependencies managed dependencies

### DIFF
--- a/dependencies/pom.xml
+++ b/dependencies/pom.xml
@@ -90,11 +90,6 @@
         <artifactId>joda-time</artifactId>
         <version>${joda-time.version}</version>
       </dependency>
-      <dependency>
-        <groupId>org.hibernate.orm</groupId>
-        <artifactId>hibernate-core</artifactId>
-        <version>${hibernate.version}</version>
-      </dependency>
     </dependencies>
   </dependencyManagement>
 


### PR DESCRIPTION
Remove hibernate-core from graphql-jpa-query-dependencies managed dependencies