### PR TITLE
Fix where query criteria with multiple associations joins

### DIFF
--- a/tests/gatling/src/main/resources/data.sql
+++ b/tests/gatling/src/main/resources/data.sql
@@ -1090,3 +1090,10 @@ insert into INTEGRATION_CONTEXT (id, client_id, client_name, execution_id, proce
 	('2', '1', 'serviceTask', '2', '1'),
 	('3', '1', 'serviceTask', '3', '1');
 
+insert into TASK_PROCESS_VARIABLE (task_id, process_variable_id) values
+    (1,1),
+    (1,2),
+    (1,3),
+    (1,4),
+    (1,5),
+    (1,6);


### PR DESCRIPTION
```graphql
query {
  Tasks(
    where: {
      status: { EQ: COMPLETED }
      AND: [
        { variables: { name: { EQ: "variable1" }, value: { EQ: "data" } } }
        { variables: { name: { EQ: "variable2" }, value: { EQ: true } } }
      ]
    }
  ) {
    select {
      id
      status
      variables {
        name
        value
      }
    }
  }
}
```