### PR TITLE
Add optional feature for aggregate count query support on plural entity object types

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -220,6 +220,7 @@
         <version>3.6.3</version>
         <configuration>
           <source>${java.version}</source>
+          <doclint>none</doclint>
         </configuration>
         <executions>
           <execution>

--- a/schema/src/main/java/com/introproventures/graphql/jpa/query/schema/impl/EntityIntrospector.java
+++ b/schema/src/main/java/com/introproventures/graphql/jpa/query/schema/impl/EntityIntrospector.java
@@ -441,7 +441,7 @@ public class EntityIntrospector {
     /**
      * Returns a String which capitalizes the first letter of the string.
      */
-    private static String capitalize(String name) {
+    public static String capitalize(String name) {
         if (name == null || name.length() == 0) {
             return name;
         }

--- a/schema/src/main/java/com/introproventures/graphql/jpa/query/schema/impl/GraphQLJpaQueryDataFetcher.java
+++ b/schema/src/main/java/com/introproventures/graphql/jpa/query/schema/impl/GraphQLJpaQueryDataFetcher.java
@@ -137,7 +137,7 @@ class GraphQLJpaQueryDataFetcher implements DataFetcher<PagedResult<Object>> {
                         .findFirst()
                         .orElseThrow(() -> new GraphQLException("Missing aggregate count for group: " + groupField));
 
-                    var countOfArgumentValue = getCountOfArgument(groupField);
+                    var countOfArgumentValue = getCountOfArgument(countField);
 
                     Map.Entry<String, String>[] groupings = getFields(groupField.getSelectionSet(), "by")
                         .stream()

--- a/schema/src/main/java/com/introproventures/graphql/jpa/query/schema/impl/GraphQLJpaQueryDataFetcher.java
+++ b/schema/src/main/java/com/introproventures/graphql/jpa/query/schema/impl/GraphQLJpaQueryDataFetcher.java
@@ -115,11 +115,17 @@ class GraphQLJpaQueryDataFetcher implements DataFetcher<PagedResult<Object>> {
             getFields(aggregateField.getSelectionSet(), "count")
                 .forEach(countField -> {
                     getCountOfArgument(countField)
-                        .ifPresentOrElse(argument ->
-                                aggregate.put(getAliasOrName(countField), queryFactory.queryAggregateCount(argument, environment, restrictedKeys))
-                            ,
+                        .ifPresentOrElse(
+                            argument ->
+                                aggregate.put(
+                                    getAliasOrName(countField),
+                                    queryFactory.queryAggregateCount(argument, environment, restrictedKeys)
+                                ),
                             () ->
-                                aggregate.put(getAliasOrName(countField), queryFactory.queryTotalCount(environment, restrictedKeys))
+                                aggregate.put(
+                                    getAliasOrName(countField),
+                                    queryFactory.queryTotalCount(environment, restrictedKeys)
+                                )
                         );
                 });
 
@@ -132,17 +138,23 @@ class GraphQLJpaQueryDataFetcher implements DataFetcher<PagedResult<Object>> {
 
                     var countOfArgumentValue = getCountOfArgument(groupField);
 
-                    Map.Entry<String, String>[] groupings =
-                        getFields(groupField.getSelectionSet(), "by")
-                           .stream()
-                           .map(GraphQLJpaQueryDataFetcher::groupByFieldEntry)
-                           .toArray(Map.Entry[]::new);
+                    Map.Entry<String, String>[] groupings = getFields(groupField.getSelectionSet(), "by")
+                        .stream()
+                        .map(GraphQLJpaQueryDataFetcher::groupByFieldEntry)
+                        .toArray(Map.Entry[]::new);
 
                     if (groupings.length == 0) {
                         throw new GraphQLException("At least one field is required for aggregate group: " + groupField);
                     }
 
-                    var resultList = queryFactory.queryAggregateGroupByCount(getAliasOrName(countField), countOfArgumentValue, environment, restrictedKeys, groupings)
+                    var resultList = queryFactory
+                        .queryAggregateGroupByCount(
+                            getAliasOrName(countField),
+                            countOfArgumentValue,
+                            environment,
+                            restrictedKeys,
+                            groupings
+                        )
                         .stream()
                         .peek(map ->
                             Stream
@@ -184,8 +196,7 @@ class GraphQLJpaQueryDataFetcher implements DataFetcher<PagedResult<Object>> {
     static Map.Entry<String, String> countFieldEntry(Field selectedField) {
         String key = Optional.ofNullable(selectedField.getAlias()).orElse(selectedField.getName());
 
-        String value = getCountOfArgument(selectedField)
-            .orElse(selectedField.getName());
+        String value = getCountOfArgument(selectedField).orElse(selectedField.getName());
 
         return Map.entry(key, value);
     }
@@ -196,7 +207,6 @@ class GraphQLJpaQueryDataFetcher implements DataFetcher<PagedResult<Object>> {
             .map(EnumValue.class::cast)
             .map(EnumValue::getName);
     }
-
 
     public int getDefaultMaxResults() {
         return defaultMaxResults;

--- a/schema/src/main/java/com/introproventures/graphql/jpa/query/schema/impl/GraphQLJpaQueryDataFetcher.java
+++ b/schema/src/main/java/com/introproventures/graphql/jpa/query/schema/impl/GraphQLJpaQueryDataFetcher.java
@@ -181,8 +181,8 @@ class GraphQLJpaQueryDataFetcher implements DataFetcher<PagedResult<Object>> {
                 .getSelections()
                 .stream()
                 .filter(Field.class::isInstance)
-                .map(Field.class::cast )
-                .filter(it -> !Arrays.asList("count","group").contains(it.getName()))
+                .map(Field.class::cast)
+                .filter(it -> !Arrays.asList("count", "group").contains(it.getName()))
                 .forEach(groupField -> {
                     var countField = getFields(groupField.getSelectionSet(), "count")
                         .stream()
@@ -224,7 +224,6 @@ class GraphQLJpaQueryDataFetcher implements DataFetcher<PagedResult<Object>> {
                         .toList();
 
                     aggregate.put(getAliasOrName(groupField), resultList);
-
                 });
 
             pagedResult.withAggregate(aggregate);

--- a/schema/src/main/java/com/introproventures/graphql/jpa/query/schema/impl/GraphQLJpaQueryFactory.java
+++ b/schema/src/main/java/com/introproventures/graphql/jpa/query/schema/impl/GraphQLJpaQueryFactory.java
@@ -356,7 +356,11 @@ public final class GraphQLJpaQueryFactory {
         return 0L;
     }
 
-    public Long queryAggregateCount(String aggregate, DataFetchingEnvironment environment, Optional<List<Object>> restrictedKeys) {
+    public Long queryAggregateCount(
+        String aggregate,
+        DataFetchingEnvironment environment,
+        Optional<List<Object>> restrictedKeys
+    ) {
         final MergedField queryField = flattenEmbeddedIdArguments(environment.getField());
 
         final DataFetchingEnvironment queryEnvironment = getQueryEnvironment(environment, queryField);
@@ -379,7 +383,13 @@ public final class GraphQLJpaQueryFactory {
         return 0L;
     }
 
-    public List<Map> queryAggregateGroupByCount(String alias, Optional<String> countOf, DataFetchingEnvironment environment, Optional<List<Object>> restrictedKeys, Map.Entry<String,String>... groupings) {
+    public List<Map> queryAggregateGroupByCount(
+        String alias,
+        Optional<String> countOf,
+        DataFetchingEnvironment environment,
+        Optional<List<Object>> restrictedKeys,
+        Map.Entry<String, String>... groupings
+    ) {
         final MergedField queryField = flattenEmbeddedIdArguments(environment.getField());
 
         final DataFetchingEnvironment queryEnvironment = getQueryEnvironment(environment, queryField);
@@ -451,11 +461,17 @@ public final class GraphQLJpaQueryFactory {
         return entityManager.createQuery(query);
     }
 
-    protected TypedQuery<Long> getAggregateCountQuery(DataFetchingEnvironment environment, Field field, String aggregate, List<Object> keys, String... groupings) {
+    protected TypedQuery<Long> getAggregateCountQuery(
+        DataFetchingEnvironment environment,
+        Field field,
+        String aggregate,
+        List<Object> keys,
+        String... groupings
+    ) {
         CriteriaBuilder cb = entityManager.getCriteriaBuilder();
         CriteriaQuery<Long> query = cb.createQuery(Long.class);
         Root<?> root = query.from(entityType);
-        Join<?,?> join = root.join(aggregate);
+        Join<?, ?> join = root.join(aggregate);
 
         DataFetchingEnvironment queryEnvironment = DataFetchingEnvironmentBuilder
             .newDataFetchingEnvironment(environment)
@@ -482,7 +498,14 @@ public final class GraphQLJpaQueryFactory {
         return entityManager.createQuery(query);
     }
 
-    protected TypedQuery<Map> getAggregateGroupByCountQuery(DataFetchingEnvironment environment, Field field, String alias, Optional<String> countOfJoin, List<Object> keys, Map.Entry<String,String>... groupBy) {
+    protected TypedQuery<Map> getAggregateGroupByCountQuery(
+        DataFetchingEnvironment environment,
+        Field field,
+        String alias,
+        Optional<String> countOfJoin,
+        List<Object> keys,
+        Map.Entry<String, String>... groupBy
+    ) {
         final CriteriaBuilder cb = entityManager.getCriteriaBuilder();
         final CriteriaQuery<Map> query = cb.createQuery(Map.class);
         final Root<?> root = query.from(entityType);
@@ -494,20 +517,17 @@ public final class GraphQLJpaQueryFactory {
 
         final List<Selection<?>> selections = new ArrayList<>();
 
-        Stream.of(groupBy)
-            .map(group ->  root.get(group.getValue()).alias(group.getKey()))
-            .forEach(selections::add);
+        Stream.of(groupBy).map(group -> root.get(group.getValue()).alias(group.getKey())).forEach(selections::add);
 
         final Expression<?>[] groupings = Stream
             .of(groupBy)
-            .map(group ->  root.get(group.getValue()))
+            .map(group -> root.get(group.getValue()))
             .toArray(Expression[]::new);
 
-        countOfJoin
-            .ifPresentOrElse(
-                it ->selections.add(cb.count(root.join(it)).alias(alias)),
-                () -> selections.add(cb.count(root).alias(alias))
-            );
+        countOfJoin.ifPresentOrElse(
+            it -> selections.add(cb.count(root.join(it)).alias(alias)),
+            () -> selections.add(cb.count(root).alias(alias))
+        );
 
         query.multiselect(selections).groupBy(groupings);
 

--- a/schema/src/main/java/com/introproventures/graphql/jpa/query/schema/impl/GraphQLJpaSchemaBuilder.java
+++ b/schema/src/main/java/com/introproventures/graphql/jpa/query/schema/impl/GraphQLJpaSchemaBuilder.java
@@ -19,7 +19,6 @@ package com.introproventures.graphql.jpa.query.schema.impl;
 import static com.introproventures.graphql.jpa.query.support.GraphQLSupport.getAliasOrName;
 import static graphql.Scalars.GraphQLBoolean;
 import static graphql.Scalars.GraphQLInt;
-import static graphql.Scalars.GraphQLString;
 import static graphql.schema.GraphQLArgument.newArgument;
 import static graphql.schema.GraphQLEnumType.newEnum;
 import static graphql.schema.GraphQLEnumValueDefinition.newEnumValueDefinition;
@@ -486,7 +485,7 @@ public class GraphQLJpaSchemaBuilder implements GraphQLSchemaBuilder {
                                                 .build()
                                         )
                                 )
-                                .type(GraphQLString)
+                                .type(JavaScalars.GraphQLObjectScalar)
                         )
                         .field(newFieldDefinition().name("count").type(GraphQLInt))
                         .build()

--- a/schema/src/main/java/com/introproventures/graphql/jpa/query/schema/impl/GraphQLJpaSchemaBuilder.java
+++ b/schema/src/main/java/com/introproventures/graphql/jpa/query/schema/impl/GraphQLJpaSchemaBuilder.java
@@ -147,6 +147,7 @@ public class GraphQLJpaSchemaBuilder implements GraphQLSchemaBuilder {
     private boolean toManyDefaultOptional = true; // the many end is a collection, and it is always optional by default (empty collection)
     private boolean enableSubscription = false; // experimental
     private boolean enableRelay = false; // experimental
+    private boolean enableAggregate = false; // experimental
     private int defaultMaxResults = 100;
     private int defaultFetchSize = 100;
     private int defaultPageLimitSize = 100;
@@ -380,7 +381,7 @@ public class GraphQLJpaSchemaBuilder implements GraphQLSchemaBuilder {
         final GraphQLObjectType selectObjectType = getEntityObjectType(entityType);
         final var selectTypeName = resolveSelectTypeName(entityType);
 
-        GraphQLObjectType selectPagedResultType = newObject()
+        var selectPagedResultType = newObject()
             .name(selectTypeName)
             .description(
                 "Query response wrapper object for " +
@@ -407,11 +408,13 @@ public class GraphQLJpaSchemaBuilder implements GraphQLSchemaBuilder {
                     .description("The queried records container")
                     .type(new GraphQLList(selectObjectType))
                     .build()
-            )
-            .field(getAggregateFieldDefinition(entityType))
-            .build();
+            );
 
-        return selectPagedResultType;
+        if (enableAggregate) {
+            selectPagedResultType.field(getAggregateFieldDefinition(entityType));
+        }
+
+        return selectPagedResultType.build();
     }
 
     private GraphQLFieldDefinition getAggregateFieldDefinition(EntityType<?> entityType) {
@@ -1683,6 +1686,12 @@ public class GraphQLJpaSchemaBuilder implements GraphQLSchemaBuilder {
     @Deprecated
     public void setNamingStrategy(NamingStrategy namingStrategy) {
         this.namingStrategy = namingStrategy;
+    }
+
+    public GraphQLSchemaBuilder enableAggregate(boolean enableAggregate) {
+        this.enableAggregate = enableAggregate;
+
+        return this;
     }
 
     static class NoOpCoercing implements Coercing<Object, Object> {

--- a/schema/src/main/java/com/introproventures/graphql/jpa/query/schema/impl/GraphQLJpaSchemaBuilder.java
+++ b/schema/src/main/java/com/introproventures/graphql/jpa/query/schema/impl/GraphQLJpaSchemaBuilder.java
@@ -488,23 +488,10 @@ public class GraphQLJpaSchemaBuilder implements GraphQLSchemaBuilder {
                                 )
                                 .type(JavaScalars.GraphQLObjectScalar)
                         )
-                        .field(newFieldDefinition().name("count").type(GraphQLInt))
+                        .field(countFieldDefinition)
                         .build()
                 )
             );
-
-        if (entityType.getAttributes().stream().anyMatch(Attribute::isAssociation)) {
-            groupFieldDefinition.argument(
-                newArgument()
-                    .name("of")
-                    .type(
-                        newEnum()
-                            .name(aggregateObjectTypeName.concat("GroupOfAssociationsEnum"))
-                            .values(associationEnumValueDefinitions)
-                            .build()
-                    )
-            );
-        }
 
         entityType
             .getAttributes()

--- a/schema/src/main/java/com/introproventures/graphql/jpa/query/schema/impl/GraphQLJpaSchemaBuilder.java
+++ b/schema/src/main/java/com/introproventures/graphql/jpa/query/schema/impl/GraphQLJpaSchemaBuilder.java
@@ -449,58 +449,63 @@ public class GraphQLJpaSchemaBuilder implements GraphQLSchemaBuilder {
             .map(name -> newEnumValueDefinition().name(name).build())
             .toList();
 
-        if (entityType.getAttributes()
-            .stream()
-            .anyMatch(Attribute::isAssociation)) {
-            countFieldDefinition
-                .argument(newArgument()
+        if (entityType.getAttributes().stream().anyMatch(Attribute::isAssociation)) {
+            countFieldDefinition.argument(
+                newArgument()
                     .name("of")
-                    .type(newEnum()
-                        .name(aggregateObjectTypeName.concat("CountOfAssociationsEnum"))
-                        .values(associationEnumValueDefinitions)
-                        .build()));
+                    .type(
+                        newEnum()
+                            .name(aggregateObjectTypeName.concat("CountOfAssociationsEnum"))
+                            .values(associationEnumValueDefinitions)
+                            .build()
+                    )
+            );
         }
-
 
         var groupFieldDefinition = newFieldDefinition()
             .name("group")
             .dataFetcher(aggregateDataFetcher)
-            .type(new GraphQLList(newObject()
-                .name(aggregateObjectTypeName.concat("GroupBy"))
-                .field(newFieldDefinition()
-                    .name("by")
-                    .dataFetcher(aggregateDataFetcher)
-                    .argument(newArgument()
-                        .name("field")
-                        .type(newEnum()
-                            .name(aggregateObjectTypeName.concat("GroupByFieldsEnum"))
-                            .values(fieldsEnumValueDefinitions)
-                            .build()))
-                    .type(GraphQLString))
-                .field(newFieldDefinition()
-                    .name("count")
-                    .type(GraphQLInt))
-                .build()));
+            .type(
+                new GraphQLList(
+                    newObject()
+                        .name(aggregateObjectTypeName.concat("GroupBy"))
+                        .field(
+                            newFieldDefinition()
+                                .name("by")
+                                .dataFetcher(aggregateDataFetcher)
+                                .argument(
+                                    newArgument()
+                                        .name("field")
+                                        .type(
+                                            newEnum()
+                                                .name(aggregateObjectTypeName.concat("GroupByFieldsEnum"))
+                                                .values(fieldsEnumValueDefinitions)
+                                                .build()
+                                        )
+                                )
+                                .type(GraphQLString)
+                        )
+                        .field(newFieldDefinition().name("count").type(GraphQLInt))
+                        .build()
+                )
+            );
 
-        if (entityType.getAttributes()
-            .stream()
-            .anyMatch(Attribute::isAssociation)) {
-            groupFieldDefinition
-                .argument(newArgument()
+        if (entityType.getAttributes().stream().anyMatch(Attribute::isAssociation)) {
+            groupFieldDefinition.argument(
+                newArgument()
                     .name("of")
-                    .type(newEnum()
-                        .name(aggregateObjectTypeName.concat("GroupOfAssociationsEnum"))
-                        .values(associationEnumValueDefinitions)
-                        .build()));
+                    .type(
+                        newEnum()
+                            .name(aggregateObjectTypeName.concat("GroupOfAssociationsEnum"))
+                            .values(associationEnumValueDefinitions)
+                            .build()
+                    )
+            );
         }
 
-        aggregateObjectType
-            .field(countFieldDefinition)
-            .field(groupFieldDefinition);
+        aggregateObjectType.field(countFieldDefinition).field(groupFieldDefinition);
 
-        var aggregateFieldDefinition = newFieldDefinition()
-            .name("aggregate")
-            .type(aggregateObjectType);
+        var aggregateFieldDefinition = newFieldDefinition().name("aggregate").type(aggregateObjectType);
 
         return aggregateFieldDefinition.build();
     }
@@ -1211,8 +1216,7 @@ public class GraphQLJpaSchemaBuilder implements GraphQLSchemaBuilder {
         DataFetcher dataFetcher = PropertyDataFetcher.fetching(attribute.getName());
 
         // Only add the orderBy argument for basic attribute types
-        if (isBasic(attribute) && isNotIgnoredOrder(attribute)
-        ) {
+        if (isBasic(attribute) && isNotIgnoredOrder(attribute)) {
             arguments.add(
                 GraphQLArgument
                     .newArgument()
@@ -1235,9 +1239,7 @@ public class GraphQLJpaSchemaBuilder implements GraphQLSchemaBuilder {
             // to-one end could be optional
             arguments.add(optionalArgument(singularAttribute.isOptional()));
 
-            GraphQLObjectType entityObjectType = newObject()
-                .name(resolveEntityObjectTypeName(baseEntity))
-                .build();
+            GraphQLObjectType entityObjectType = newObject().name(resolveEntityObjectTypeName(baseEntity)).build();
 
             GraphQLJpaQueryFactory graphQLJpaQueryFactory = GraphQLJpaQueryFactory
                 .builder()
@@ -1273,9 +1275,7 @@ public class GraphQLJpaSchemaBuilder implements GraphQLSchemaBuilder {
             // make it configurable via builder api
             arguments.add(optionalArgument(toManyDefaultOptional));
 
-            GraphQLObjectType entityObjectType = newObject()
-                .name(resolveEntityObjectTypeName(baseEntity))
-                .build();
+            GraphQLObjectType entityObjectType = newObject().name(resolveEntityObjectTypeName(baseEntity)).build();
 
             GraphQLJpaQueryFactory graphQLJpaQueryFactory = GraphQLJpaQueryFactory
                 .builder()
@@ -1420,8 +1420,10 @@ public class GraphQLJpaSchemaBuilder implements GraphQLSchemaBuilder {
     }
 
     protected final boolean isBasic(Attribute<?, ?> attribute) {
-        return attribute instanceof SingularAttribute &&
-            attribute.getPersistentAttributeType() == Attribute.PersistentAttributeType.BASIC;
+        return (
+            attribute instanceof SingularAttribute &&
+            attribute.getPersistentAttributeType() == Attribute.PersistentAttributeType.BASIC
+        );
     }
 
     protected final boolean isElementCollection(Attribute<?, ?> attribute) {
@@ -1446,17 +1448,21 @@ public class GraphQLJpaSchemaBuilder implements GraphQLSchemaBuilder {
         );
     }
 
-    private boolean isPlural(Attribute<?,?> attribute) {
-        return attribute instanceof PluralAttribute &&
+    private boolean isPlural(Attribute<?, ?> attribute) {
+        return (
+            attribute instanceof PluralAttribute &&
             (
                 attribute.getPersistentAttributeType() == Attribute.PersistentAttributeType.ONE_TO_MANY ||
-                    attribute.getPersistentAttributeType() == Attribute.PersistentAttributeType.MANY_TO_MANY
-            );
+                attribute.getPersistentAttributeType() == Attribute.PersistentAttributeType.MANY_TO_MANY
+            )
+        );
     }
 
-    private boolean isSingular(Attribute<?,?> attribute) {
-        return attribute instanceof SingularAttribute &&
-            attribute.getPersistentAttributeType() != Attribute.PersistentAttributeType.BASIC;
+    private boolean isSingular(Attribute<?, ?> attribute) {
+        return (
+            attribute instanceof SingularAttribute &&
+            attribute.getPersistentAttributeType() != Attribute.PersistentAttributeType.BASIC
+        );
     }
 
     protected final boolean isValidInput(Attribute<?, ?> attribute) {

--- a/schema/src/main/java/com/introproventures/graphql/jpa/query/schema/impl/GraphQLJpaSchemaBuilder.java
+++ b/schema/src/main/java/com/introproventures/graphql/jpa/query/schema/impl/GraphQLJpaSchemaBuilder.java
@@ -444,7 +444,7 @@ public class GraphQLJpaSchemaBuilder implements GraphQLSchemaBuilder {
             .getAttributes()
             .stream()
             .filter(it -> EntityIntrospector.introspect(entityType).isNotIgnored(it.getName()))
-            .filter(this::isBasic)
+            .filter(it -> isBasic(it) || isEmbeddable(it))
             .map(Attribute::getName)
             .map(name -> newEnumValueDefinition().name(name).build())
             .toList();

--- a/schema/src/main/java/com/introproventures/graphql/jpa/query/schema/impl/GraphQLJpaSchemaBuilder.java
+++ b/schema/src/main/java/com/introproventures/graphql/jpa/query/schema/impl/GraphQLJpaSchemaBuilder.java
@@ -512,9 +512,11 @@ public class GraphQLJpaSchemaBuilder implements GraphQLSchemaBuilder {
             .filter(it -> EntityIntrospector.introspect(entityType).isNotIgnored(it.getName()))
             .filter(Attribute::isAssociation)
             .forEach(association -> {
-                var javaType = isPlural(association) ? PluralAttribute.class.cast(association).getBindableJavaType() : association.getJavaType();
+                var javaType = isPlural(association)
+                    ? PluralAttribute.class.cast(association).getBindableJavaType()
+                    : association.getJavaType();
                 var attributes = EntityIntrospector.resultOf(javaType).getAttributes();
-                var fields =  attributes
+                var fields = attributes
                     .values()
                     .stream()
                     .filter(it -> isBasic(it) || isEmbeddable(it))
@@ -527,32 +529,41 @@ public class GraphQLJpaSchemaBuilder implements GraphQLSchemaBuilder {
                         newFieldDefinition()
                             .name(association.getName())
                             .dataFetcher(aggregateDataFetcher)
-                            .type(new GraphQLList(
-                                newObject()
-                                .name(aggregateObjectTypeName.concat(capitalize(association.getName())).concat("GroupByNestedAssociation"))
-                                .field(                            newFieldDefinition()
-                                    .name("by")
-                                    .dataFetcher(aggregateDataFetcher)
-                                    .argument(
-                                        newArgument()
-                                            .name("field")
-                                            .type(
-                                                newEnum()
-                                                    .name(aggregateObjectTypeName.concat(capitalize(association.getName())).concat("GroupByNestedAssociationEnum"))
-                                                    .values(fields)
-                                                    .build()
-                                            )
-                                    )
-                                    .type(JavaScalars.GraphQLObjectScalar)
+                            .type(
+                                new GraphQLList(
+                                    newObject()
+                                        .name(
+                                            aggregateObjectTypeName
+                                                .concat(capitalize(association.getName()))
+                                                .concat("GroupByNestedAssociation")
+                                        )
+                                        .field(
+                                            newFieldDefinition()
+                                                .name("by")
+                                                .dataFetcher(aggregateDataFetcher)
+                                                .argument(
+                                                    newArgument()
+                                                        .name("field")
+                                                        .type(
+                                                            newEnum()
+                                                                .name(
+                                                                    aggregateObjectTypeName
+                                                                        .concat(capitalize(association.getName()))
+                                                                        .concat("GroupByNestedAssociationEnum")
+                                                                )
+                                                                .values(fields)
+                                                                .build()
+                                                        )
+                                                )
+                                                .type(JavaScalars.GraphQLObjectScalar)
+                                        )
+                                        .field(newFieldDefinition().name("count").type(GraphQLInt))
+                                        .build()
                                 )
-                                .field(newFieldDefinition().name("count").type(GraphQLInt))
-                                .build()
                             )
-                        )
                     );
                 }
             });
-
 
         aggregateObjectType.field(countFieldDefinition).field(groupFieldDefinition);
 

--- a/schema/src/main/java/com/introproventures/graphql/jpa/query/schema/impl/PagedResult.java
+++ b/schema/src/main/java/com/introproventures/graphql/jpa/query/schema/impl/PagedResult.java
@@ -17,7 +17,9 @@
 package com.introproventures.graphql.jpa.query.schema.impl;
 
 import java.util.Collections;
+import java.util.LinkedHashMap;
 import java.util.List;
+import java.util.Map;
 
 public class PagedResult<T> {
 
@@ -26,6 +28,7 @@ public class PagedResult<T> {
     private final long pages;
     private final int offset;
     private final List<T> select;
+    private final Map<String, Object> aggregate;
 
     private PagedResult(Builder<T> builder) {
         this.limit = builder.limit;
@@ -33,6 +36,7 @@ public class PagedResult<T> {
         this.offset = builder.offset;
         this.select = builder.select;
         this.pages = ((Double) Math.ceil(total / (double) limit)).longValue();
+        this.aggregate = builder.aggregate;
     }
 
     public Long getTotal() {
@@ -55,6 +59,10 @@ public class PagedResult<T> {
         return limit;
     }
 
+    public Map<String, Object> getAggregate() {
+        return aggregate;
+    }
+
     /**
      * Creates builder to build {@link PagedResult}.
      * @return created builder
@@ -73,6 +81,7 @@ public class PagedResult<T> {
         private long pages;
         private int offset;
         private List<T> select = Collections.emptyList();
+        private Map<String, Object> aggregate = new LinkedHashMap<>();
 
         private Builder() {}
 
@@ -123,6 +132,16 @@ public class PagedResult<T> {
          */
         public Builder<T> withSelect(List<T> select) {
             this.select = select;
+            return this;
+        }
+
+        /**
+         * Builder method for select parameter.
+         * @param select field to set
+         * @return builder
+         */
+        public Builder<T> withAggregate(Map<String, Object> aggregate) {
+            this.aggregate.putAll(aggregate);
             return this;
         }
 

--- a/schema/src/main/java/com/introproventures/graphql/jpa/query/support/GraphQLSupport.java
+++ b/schema/src/main/java/com/introproventures/graphql/jpa/query/support/GraphQLSupport.java
@@ -139,10 +139,7 @@ public class GraphQLSupport {
     public static Optional<Argument> findArgument(Field selectedField, String name) {
         return Optional
             .ofNullable(selectedField.getArguments())
-            .flatMap(arguments -> arguments
-                .stream()
-                .filter(argument -> name.equals(argument.getName()))
-                .findFirst());
+            .flatMap(arguments -> arguments.stream().filter(argument -> name.equals(argument.getName())).findFirst());
     }
 
     public static List<Field> getFields(SelectionSet selections, String fieldName) {

--- a/schema/src/main/java/com/introproventures/graphql/jpa/query/support/GraphQLSupport.java
+++ b/schema/src/main/java/com/introproventures/graphql/jpa/query/support/GraphQLSupport.java
@@ -136,6 +136,28 @@ public class GraphQLSupport {
         return GraphQLSupport.fields(field.getSelectionSet()).filter(it -> fieldName.equals(it.getName())).findFirst();
     }
 
+    public static Optional<Argument> findArgument(Field selectedField, String name) {
+        return Optional
+            .ofNullable(selectedField.getArguments())
+            .flatMap(arguments -> arguments
+                .stream()
+                .filter(argument -> name.equals(argument.getName()))
+                .findFirst());
+    }
+
+    public static List<Field> getFields(SelectionSet selections, String fieldName) {
+        return selections
+            .getSelections()
+            .stream()
+            .map(Field.class::cast)
+            .filter(it -> fieldName.equals(it.getName()))
+            .collect(Collectors.toList());
+    }
+
+    public static String getAliasOrName(Field field) {
+        return Optional.ofNullable(field.getAlias()).orElse(field.getName());
+    }
+
     public static Collector<Object, List<Object>, List<Object>> toResultList() {
         return Collector.of(
             ArrayList::new,

--- a/schema/src/test/java/com/introproventures/graphql/jpa/query/converter/GraphQLJpaQueryAggregateTests.java
+++ b/schema/src/test/java/com/introproventures/graphql/jpa/query/converter/GraphQLJpaQueryAggregateTests.java
@@ -79,7 +79,7 @@ public class GraphQLJpaQueryAggregateTests extends AbstractSpringBootTestSupport
                                         .ofNullable(input)
                                         .filter(VariableValue.class::isInstance)
                                         .map(VariableValue.class::cast)
-                                        .map(it -> Optional.ofNullable(it.getValue()).orElse("null"))
+                                        .map(it -> Optional.ofNullable(it.getValue()).orElse(Optional.empty()))
                                         .orElse(input);
                                 }
                             }

--- a/schema/src/test/java/com/introproventures/graphql/jpa/query/converter/GraphQLJpaQueryAggregateTests.java
+++ b/schema/src/test/java/com/introproventures/graphql/jpa/query/converter/GraphQLJpaQueryAggregateTests.java
@@ -66,6 +66,7 @@ public class GraphQLJpaQueryAggregateTests extends AbstractSpringBootTestSupport
             return new GraphQLJpaSchemaBuilder(entityManager)
                 .name("CustomAttributeConverterSchema")
                 .description("Custom Attribute Converter Schema")
+                .enableAggregate(true)
                 .scalar(
                     VariableValue.class,
                     newScalar()

--- a/schema/src/test/java/com/introproventures/graphql/jpa/query/converter/GraphQLJpaQueryAggregateTests.java
+++ b/schema/src/test/java/com/introproventures/graphql/jpa/query/converter/GraphQLJpaQueryAggregateTests.java
@@ -587,4 +587,115 @@ public class GraphQLJpaQueryAggregateTests extends AbstractSpringBootTestSupport
         assertThat(result.getErrors()).isEmpty();
         assertThat(result.getData().toString()).isEqualTo(expected);
     }
+
+    @Test
+    public void queryVariablesTaskNestedAggregateCountByNestedAssociation() {
+        //given
+        String query =
+            """
+                query {
+                  TaskVariables(
+                    # Apply filter criteria
+                    where: {name: {IN: ["variable1", "variable5"]}}
+                  ) {
+                    aggregate {
+                      # count by variables
+                      variables: count
+                      # Count by associated tasks
+                      tasks: task {
+                        by(field: status)
+                        count
+                      }
+                    }
+                  }
+                }
+            """;
+
+        String expected =
+            "{TaskVariables={aggregate={variables=3, tasks=[{by=COMPLETED, count=1}, {by=CREATED, count=2}]}}}";
+
+        //when
+        ExecutionResult result = executor.execute(query);
+
+        // then
+        assertThat(result.getErrors()).isEmpty();
+        assertThat(result.getData().toString()).isEqualTo(expected);
+    }
+
+    @Test
+    public void queryVariablesTaskNestedAggregateCountByNestedAssociationAlias() {
+        //given
+        String query =
+            """
+                query {
+                  TaskVariables(
+                    # Apply filter criteria
+                    where: {name: {IN: ["variable1", "variable5"]}}
+                  ) {
+                    aggregate {
+                      # count by variables
+                      variables: count
+                      # Count by associated tasks
+                      tasks: task {
+                        status: by(field: status)
+                        count
+                      }
+                    }
+                  }
+                }
+            """;
+
+        String expected =
+            "{TaskVariables={aggregate={variables=3, tasks=[{status=COMPLETED, count=1}, {status=CREATED, count=2}]}}}";
+
+        //when
+        ExecutionResult result = executor.execute(query);
+
+        // then
+        assertThat(result.getErrors()).isEmpty();
+        assertThat(result.getData().toString()).isEqualTo(expected);
+    }
+
+    @Test
+    public void queryVariablesTaskNestedAggregateCountByNestedAssociationMultipleAliases() {
+        //given
+        String query =
+            """
+                query {
+                  TaskVariables(
+                    # Apply filter criteria
+                    where: {name: {IN: ["variable1", "variable5"]}}
+                  ) {
+                    aggregate {
+                      # count by variables
+                      variables: count
+                      # Count by associated tasks
+                      groupByVariableName: group {
+                        name: by(field: name)
+                        count
+                      }
+                      groupByTaskStatus: task {
+                        status: by(field: status)
+                        count
+                      }
+                      # Count by associated tasks
+                      groupByTaskAssignee: task {
+                        assignee: by(field: assignee)
+                        count
+                      }
+                    }
+                  }
+                }
+            """;
+
+        String expected =
+            "{TaskVariables={aggregate={variables=3, groupByVariableName=[{name=variable1, count=1}, {name=variable5, count=2}], groupByTaskStatus=[{status=COMPLETED, count=1}, {status=CREATED, count=2}], groupByTaskAssignee=[{assignee=assignee, count=3}]}}}";
+
+        //when
+        ExecutionResult result = executor.execute(query);
+
+        // then
+        assertThat(result.getErrors()).isEmpty();
+        assertThat(result.getData().toString()).isEqualTo(expected);
+    }
 }

--- a/schema/src/test/java/com/introproventures/graphql/jpa/query/converter/GraphQLJpaQueryAggregateTests.java
+++ b/schema/src/test/java/com/introproventures/graphql/jpa/query/converter/GraphQLJpaQueryAggregateTests.java
@@ -66,21 +66,24 @@ public class GraphQLJpaQueryAggregateTests extends AbstractSpringBootTestSupport
             return new GraphQLJpaSchemaBuilder(entityManager)
                 .name("CustomAttributeConverterSchema")
                 .description("Custom Attribute Converter Schema")
-                .scalar(VariableValue.class,
+                .scalar(
+                    VariableValue.class,
                     newScalar()
                         .name("VariableValue")
-                        .coercing(new JavaScalars.GraphQLObjectCoercing() {
-                            public Object serialize(final Object input) {
-                                return Optional
-                                    .ofNullable(input)
-                                    .filter(VariableValue.class::isInstance)
-                                    .map(VariableValue.class::cast)
-                                    .map(it -> Optional.ofNullable(it.getValue()).orElse("null"))
-                                    .orElse(input);
+                        .coercing(
+                            new JavaScalars.GraphQLObjectCoercing() {
+                                public Object serialize(final Object input) {
+                                    return Optional
+                                        .ofNullable(input)
+                                        .filter(VariableValue.class::isInstance)
+                                        .map(VariableValue.class::cast)
+                                        .map(it -> Optional.ofNullable(it.getValue()).orElse("null"))
+                                        .orElse(input);
+                                }
                             }
-                        })
-                        .build());
-
+                        )
+                        .build()
+                );
         }
     }
 
@@ -101,7 +104,7 @@ public class GraphQLJpaQueryAggregateTests extends AbstractSpringBootTestSupport
         Root<TaskVariableEntity> taskVariable = query.from(TaskVariableEntity.class);
         var taskJoin = taskVariable.join("task");
 
-        Selection<?>[] selections = List.of(taskVariable.get("name"),cb.count(taskJoin)).toArray(Selection[]::new);
+        Selection<?>[] selections = List.of(taskVariable.get("name"), cb.count(taskJoin)).toArray(Selection[]::new);
         Expression<?>[] groupings = List.of(taskVariable.get("name")).toArray(Expression[]::new);
 
         query.multiselect(selections).groupBy(groupings);
@@ -113,13 +116,15 @@ public class GraphQLJpaQueryAggregateTests extends AbstractSpringBootTestSupport
         assertThat(result)
             .isNotEmpty()
             .hasSize(7)
-            .contains(new Object[]{"variable1", 1L},
-                new Object[]{"variable2", 1L},
-                new Object[]{"variable3", 1L},
-                new Object[]{"variable4", 1L},
-                new Object[]{"variable5", 2L},
-                new Object[]{"variable6", 1L},
-                new Object[]{"variable7", 1L});
+            .contains(
+                new Object[] { "variable1", 1L },
+                new Object[] { "variable2", 1L },
+                new Object[] { "variable3", 1L },
+                new Object[] { "variable4", 1L },
+                new Object[] { "variable5", 2L },
+                new Object[] { "variable6", 1L },
+                new Object[] { "variable7", 1L }
+            );
     }
 
     @Test
@@ -130,7 +135,9 @@ public class GraphQLJpaQueryAggregateTests extends AbstractSpringBootTestSupport
         Root<TaskVariableEntity> taskVariable = query.from(TaskVariableEntity.class);
         var taskJoin = taskVariable.join("task");
 
-        Selection<?>[] selections = List.of(taskVariable.get("name").alias("by"),cb.count(taskJoin).alias("count")).toArray(Selection[]::new);
+        Selection<?>[] selections = List
+            .of(taskVariable.get("name").alias("by"), cb.count(taskJoin).alias("count"))
+            .toArray(Selection[]::new);
         Expression<?>[] groupings = List.of(taskVariable.get("name")).toArray(Expression[]::new);
 
         query.multiselect(selections).groupBy(groupings);
@@ -142,13 +149,15 @@ public class GraphQLJpaQueryAggregateTests extends AbstractSpringBootTestSupport
         assertThat(result)
             .isNotEmpty()
             .hasSize(7)
-            .contains(Map.of("by", "variable1", "count", 1L),
+            .contains(
+                Map.of("by", "variable1", "count", 1L),
                 Map.of("by", "variable2", "count", 1L),
                 Map.of("by", "variable3", "count", 1L),
                 Map.of("by", "variable4", "count", 1L),
                 Map.of("by", "variable5", "count", 2L),
                 Map.of("by", "variable6", "count", 1L),
-                Map.of("by", "variable7", "count", 1L));
+                Map.of("by", "variable7", "count", 1L)
+            );
     }
 
     @Test
@@ -168,10 +177,7 @@ public class GraphQLJpaQueryAggregateTests extends AbstractSpringBootTestSupport
         List<Object> result = entityManager.createQuery(query).getResultList();
 
         // then:
-        assertThat(result)
-            .isNotEmpty()
-            .hasSize(1)
-            .contains(6L);
+        assertThat(result).isNotEmpty().hasSize(1).contains(6L);
     }
 
     @Test
@@ -191,10 +197,7 @@ public class GraphQLJpaQueryAggregateTests extends AbstractSpringBootTestSupport
         List<Object> result = entityManager.createQuery(query).getResultList();
 
         // then:
-        assertThat(result)
-            .isNotEmpty()
-            .hasSize(1)
-            .contains(8L);
+        assertThat(result).isNotEmpty().hasSize(1).contains(8L);
     }
 
     @Test
@@ -205,7 +208,9 @@ public class GraphQLJpaQueryAggregateTests extends AbstractSpringBootTestSupport
         Root<TaskEntity> tasks = query.from(TaskEntity.class);
         var variablesJoin = tasks.join("variables");
 
-        Selection<?>[] selections = List.of(variablesJoin.get("name"), cb.count(variablesJoin)).toArray(Selection[]::new);
+        Selection<?>[] selections = List
+            .of(variablesJoin.get("name"), cb.count(variablesJoin))
+            .toArray(Selection[]::new);
         Expression<?>[] groupings = List.of(variablesJoin.get("name")).toArray(Expression[]::new);
 
         query.distinct(true).multiselect(selections).groupBy(groupings);
@@ -217,13 +222,15 @@ public class GraphQLJpaQueryAggregateTests extends AbstractSpringBootTestSupport
         assertThat(result)
             .isNotEmpty()
             .hasSize(7)
-            .contains(new Object[]{"variable1", 1L},
-                new Object[]{"variable2", 1L},
-                new Object[]{"variable3", 1L},
-                new Object[]{"variable4", 1L},
-                new Object[]{"variable5", 2L},
-                new Object[]{"variable6", 1L},
-                new Object[]{"variable7", 1L});
+            .contains(
+                new Object[] { "variable1", 1L },
+                new Object[] { "variable2", 1L },
+                new Object[] { "variable3", 1L },
+                new Object[] { "variable4", 1L },
+                new Object[] { "variable5", 2L },
+                new Object[] { "variable6", 1L },
+                new Object[] { "variable7", 1L }
+            );
     }
 
     @Test
@@ -231,34 +238,34 @@ public class GraphQLJpaQueryAggregateTests extends AbstractSpringBootTestSupport
         //given
         String query =
             "query {" +
-                "  Tasks(where: {" +
-                "    status: {EQ: COMPLETED}" +
-                "    AND: [" +
-                "      {  " +
-                "         variables: {" +
-                "           name: {EQ: \"variable1\"}" +
-                "        value: {EQ: \"data\"}" +
-                "        }" +
-                "      }" +
-                "    ]" +
-                "  }) {" +
-                "    select {" +
-                "      id" +
-                "      status" +
-                "      variables(where: {name: {IN: [\"variable2\",\"variable1\"]}} ) {" +
-                "        name" +
-                "        value" +
-                "      }" +
-                "    }" +
-                "  }" +
-                "}";
+            "  Tasks(where: {" +
+            "    status: {EQ: COMPLETED}" +
+            "    AND: [" +
+            "      {  " +
+            "         variables: {" +
+            "           name: {EQ: \"variable1\"}" +
+            "        value: {EQ: \"data\"}" +
+            "        }" +
+            "      }" +
+            "    ]" +
+            "  }) {" +
+            "    select {" +
+            "      id" +
+            "      status" +
+            "      variables(where: {name: {IN: [\"variable2\",\"variable1\"]}} ) {" +
+            "        name" +
+            "        value" +
+            "      }" +
+            "    }" +
+            "  }" +
+            "}";
 
         String expected =
             "{Tasks={select=[" +
-                "{id=1, status=COMPLETED, variables=[" +
-                "{name=variable1, value=data}, " +
-                "{name=variable2, value=true}]}" +
-                "]}}";
+            "{id=1, status=COMPLETED, variables=[" +
+            "{name=variable1, value=data}, " +
+            "{name=variable2, value=true}]}" +
+            "]}}";
 
         //when
         Object result = executor.execute(query).getData();
@@ -270,7 +277,8 @@ public class GraphQLJpaQueryAggregateTests extends AbstractSpringBootTestSupport
     @Test
     public void queryTasksVariablesAggregateCount() {
         //given
-        String query = """
+        String query =
+            """
                 query {
                   Tasks(
                     where: {
@@ -288,8 +296,7 @@ public class GraphQLJpaQueryAggregateTests extends AbstractSpringBootTestSupport
                 }
             """;
 
-        String expected =
-            "{Tasks={select=[{id=1, status=COMPLETED}, {id=5, status=COMPLETED}], aggregate={count=2}}}";
+        String expected = "{Tasks={select=[{id=1, status=COMPLETED}, {id=5, status=COMPLETED}], aggregate={count=2}}}";
 
         //when
         Object result = executor.execute(query).getData();
@@ -301,7 +308,8 @@ public class GraphQLJpaQueryAggregateTests extends AbstractSpringBootTestSupport
     @Test
     public void queryTasksVariablesNestedAggregateCount() {
         //given
-        String query = """
+        String query =
+            """
                 query {
                   Tasks(
                     where: {
@@ -333,7 +341,8 @@ public class GraphQLJpaQueryAggregateTests extends AbstractSpringBootTestSupport
     @Test
     public void queryVariablesTaskNestedAggregateCount() {
         //given
-        String query = """
+        String query =
+            """
                 query {
                   TaskVariables {
                     aggregate {
@@ -344,8 +353,7 @@ public class GraphQLJpaQueryAggregateTests extends AbstractSpringBootTestSupport
                 }
             """;
 
-        String expected =
-            "{TaskVariables={aggregate={count=8, tasks=8}}}";
+        String expected = "{TaskVariables={aggregate={count=8, tasks=8}}}";
 
         //when
         Object result = executor.execute(query).getData();
@@ -357,7 +365,8 @@ public class GraphQLJpaQueryAggregateTests extends AbstractSpringBootTestSupport
     @Test
     public void queryVariablesTaskNestedAggregateCountWhere() {
         //given
-        String query = """
+        String query =
+            """
                 query {
                   TaskVariables(where:{task: {status: {EQ: COMPLETED}}}) {
                     aggregate {
@@ -368,8 +377,7 @@ public class GraphQLJpaQueryAggregateTests extends AbstractSpringBootTestSupport
                 }
             """;
 
-        String expected =
-            "{TaskVariables={aggregate={count=2, tasks=2}}}";
+        String expected = "{TaskVariables={aggregate={count=2, tasks=2}}}";
 
         //when
         Object result = executor.execute(query).getData();
@@ -381,7 +389,8 @@ public class GraphQLJpaQueryAggregateTests extends AbstractSpringBootTestSupport
     @Test
     public void queryVariablesTaskNestedAggregateCountGroupBy() {
         //given
-        String query = """
+        String query =
+            """
             query {
               TaskVariables {
                 aggregate {
@@ -409,7 +418,8 @@ public class GraphQLJpaQueryAggregateTests extends AbstractSpringBootTestSupport
     @Test
     public void queryVariablesTaskNestedAggregateCountGroupByMultipleFields() {
         //given
-        String query = """
+        String query =
+            """
             query {
               TaskVariables {
                 aggregate {
@@ -434,6 +444,4 @@ public class GraphQLJpaQueryAggregateTests extends AbstractSpringBootTestSupport
         assertThat(result.getErrors()).isEmpty();
         assertThat(result.getData().toString()).isEqualTo(expected);
     }
-
-
 }

--- a/schema/src/test/java/com/introproventures/graphql/jpa/query/converter/GraphQLJpaQueryAggregateTests.java
+++ b/schema/src/test/java/com/introproventures/graphql/jpa/query/converter/GraphQLJpaQueryAggregateTests.java
@@ -558,9 +558,9 @@ public class GraphQLJpaQueryAggregateTests extends AbstractSpringBootTestSupport
                       count
                     }
                     # Group by associated tasks
-                    groupTasksByVariableName: group(of: task) {
+                    groupTasksByVariableName: group {
                       variable: by(field: name)
-                      count
+                      count(of: task)
                     }
                   }
                 }

--- a/schema/src/test/java/com/introproventures/graphql/jpa/query/converter/GraphQLJpaQueryAggregateTests.java
+++ b/schema/src/test/java/com/introproventures/graphql/jpa/query/converter/GraphQLJpaQueryAggregateTests.java
@@ -1,0 +1,439 @@
+/*
+ * Copyright 2017 IntroPro Ventures Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.introproventures.graphql.jpa.query.converter;
+
+import static graphql.schema.GraphQLScalarType.newScalar;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.introproventures.graphql.jpa.query.AbstractSpringBootTestSupport;
+import com.introproventures.graphql.jpa.query.converter.model.TaskEntity;
+import com.introproventures.graphql.jpa.query.converter.model.TaskVariableEntity;
+import com.introproventures.graphql.jpa.query.converter.model.VariableValue;
+import com.introproventures.graphql.jpa.query.schema.GraphQLExecutor;
+import com.introproventures.graphql.jpa.query.schema.GraphQLSchemaBuilder;
+import com.introproventures.graphql.jpa.query.schema.JavaScalars;
+import com.introproventures.graphql.jpa.query.schema.impl.GraphQLJpaExecutor;
+import com.introproventures.graphql.jpa.query.schema.impl.GraphQLJpaSchemaBuilder;
+import graphql.ExecutionResult;
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.criteria.CriteriaBuilder;
+import jakarta.persistence.criteria.CriteriaQuery;
+import jakarta.persistence.criteria.Expression;
+import jakarta.persistence.criteria.Root;
+import jakarta.persistence.criteria.Selection;
+import jakarta.transaction.Transactional;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.context.annotation.Bean;
+
+@SpringBootTest(
+    properties = {
+        "spring.sql.init.data-locations=GraphQLJpaAggregateTests.sql",
+        "spring.datasource.url=jdbc:h2:mem:db;NON_KEYWORDS=VALUE",
+    }
+)
+public class GraphQLJpaQueryAggregateTests extends AbstractSpringBootTestSupport {
+
+    @SpringBootApplication
+    static class Application {
+
+        @Bean
+        public GraphQLExecutor graphQLExecutor(final GraphQLSchemaBuilder graphQLSchemaBuilder) {
+            return new GraphQLJpaExecutor(graphQLSchemaBuilder.build());
+        }
+
+        @Bean
+        public GraphQLSchemaBuilder graphQLSchemaBuilder(final EntityManager entityManager) {
+            return new GraphQLJpaSchemaBuilder(entityManager)
+                .name("CustomAttributeConverterSchema")
+                .description("Custom Attribute Converter Schema")
+                .scalar(VariableValue.class,
+                    newScalar()
+                        .name("VariableValue")
+                        .coercing(new JavaScalars.GraphQLObjectCoercing() {
+                            public Object serialize(final Object input) {
+                                return Optional
+                                    .ofNullable(input)
+                                    .filter(VariableValue.class::isInstance)
+                                    .map(VariableValue.class::cast)
+                                    .map(it -> Optional.ofNullable(it.getValue()).orElse("null"))
+                                    .orElse(input);
+                            }
+                        })
+                        .build());
+
+        }
+    }
+
+    @Autowired
+    private GraphQLExecutor executor;
+
+    @Autowired
+    private EntityManager entityManager;
+
+    @Test
+    public void contextLoads() {}
+
+    @Test
+    @Transactional
+    public void criteriaTesterAggregateCountByName() {
+        CriteriaBuilder cb = entityManager.getCriteriaBuilder();
+        CriteriaQuery<Object> query = cb.createQuery(Object.class);
+        Root<TaskVariableEntity> taskVariable = query.from(TaskVariableEntity.class);
+        var taskJoin = taskVariable.join("task");
+
+        Selection<?>[] selections = List.of(taskVariable.get("name"),cb.count(taskJoin)).toArray(Selection[]::new);
+        Expression<?>[] groupings = List.of(taskVariable.get("name")).toArray(Expression[]::new);
+
+        query.multiselect(selections).groupBy(groupings);
+
+        // when:
+        List<Object> result = entityManager.createQuery(query).getResultList();
+
+        // then:
+        assertThat(result)
+            .isNotEmpty()
+            .hasSize(7)
+            .contains(new Object[]{"variable1", 1L},
+                new Object[]{"variable2", 1L},
+                new Object[]{"variable3", 1L},
+                new Object[]{"variable4", 1L},
+                new Object[]{"variable5", 2L},
+                new Object[]{"variable6", 1L},
+                new Object[]{"variable7", 1L});
+    }
+
+    @Test
+    @Transactional
+    public void criteriaTesterAggregateCountByNameMapProjection() {
+        CriteriaBuilder cb = entityManager.getCriteriaBuilder();
+        CriteriaQuery<Map> query = cb.createQuery(Map.class);
+        Root<TaskVariableEntity> taskVariable = query.from(TaskVariableEntity.class);
+        var taskJoin = taskVariable.join("task");
+
+        Selection<?>[] selections = List.of(taskVariable.get("name").alias("by"),cb.count(taskJoin).alias("count")).toArray(Selection[]::new);
+        Expression<?>[] groupings = List.of(taskVariable.get("name")).toArray(Expression[]::new);
+
+        query.multiselect(selections).groupBy(groupings);
+
+        // when:
+        List<Map> result = entityManager.createQuery(query).getResultList();
+
+        // then:
+        assertThat(result)
+            .isNotEmpty()
+            .hasSize(7)
+            .contains(Map.of("by", "variable1", "count", 1L),
+                Map.of("by", "variable2", "count", 1L),
+                Map.of("by", "variable3", "count", 1L),
+                Map.of("by", "variable4", "count", 1L),
+                Map.of("by", "variable5", "count", 2L),
+                Map.of("by", "variable6", "count", 1L),
+                Map.of("by", "variable7", "count", 1L));
+    }
+
+    @Test
+    @Transactional
+    public void criteriaTesterTaskAggregateCount() {
+        CriteriaBuilder cb = entityManager.getCriteriaBuilder();
+        CriteriaQuery<Object> query = cb.createQuery(Object.class);
+        Root<TaskEntity> tasks = query.from(TaskEntity.class);
+        //var variablesJoin = tasks.join("variables");
+
+        Selection<?>[] selections = List.of(cb.count(tasks)).toArray(Selection[]::new);
+        Expression<?>[] groupings = List.of().toArray(Expression[]::new);
+
+        query.multiselect(selections).groupBy(groupings);
+
+        // when:
+        List<Object> result = entityManager.createQuery(query).getResultList();
+
+        // then:
+        assertThat(result)
+            .isNotEmpty()
+            .hasSize(1)
+            .contains(6L);
+    }
+
+    @Test
+    @Transactional
+    public void criteriaTesterTaskVariablesAggregateCount() {
+        CriteriaBuilder cb = entityManager.getCriteriaBuilder();
+        CriteriaQuery<Object> query = cb.createQuery(Object.class);
+        Root<TaskEntity> tasks = query.from(TaskEntity.class);
+        var variablesJoin = tasks.join("variables");
+
+        Selection<?>[] selections = List.of(cb.count(variablesJoin)).toArray(Selection[]::new);
+        Expression<?>[] groupings = List.of().toArray(Expression[]::new);
+
+        query.distinct(true).multiselect(selections).groupBy(groupings);
+
+        // when:
+        List<Object> result = entityManager.createQuery(query).getResultList();
+
+        // then:
+        assertThat(result)
+            .isNotEmpty()
+            .hasSize(1)
+            .contains(8L);
+    }
+
+    @Test
+    @Transactional
+    public void criteriaTesterTaskVariablesAggregateCountByName() {
+        CriteriaBuilder cb = entityManager.getCriteriaBuilder();
+        CriteriaQuery<Object> query = cb.createQuery(Object.class);
+        Root<TaskEntity> tasks = query.from(TaskEntity.class);
+        var variablesJoin = tasks.join("variables");
+
+        Selection<?>[] selections = List.of(variablesJoin.get("name"), cb.count(variablesJoin)).toArray(Selection[]::new);
+        Expression<?>[] groupings = List.of(variablesJoin.get("name")).toArray(Expression[]::new);
+
+        query.distinct(true).multiselect(selections).groupBy(groupings);
+
+        // when:
+        List<Object> result = entityManager.createQuery(query).getResultList();
+
+        // then:
+        assertThat(result)
+            .isNotEmpty()
+            .hasSize(7)
+            .contains(new Object[]{"variable1", 1L},
+                new Object[]{"variable2", 1L},
+                new Object[]{"variable3", 1L},
+                new Object[]{"variable4", 1L},
+                new Object[]{"variable5", 2L},
+                new Object[]{"variable6", 1L},
+                new Object[]{"variable7", 1L});
+    }
+
+    @Test
+    public void queryTasksVariablesWhereWithExplicitANDByMultipleNameAndValueCriteria2() {
+        //given
+        String query =
+            "query {" +
+                "  Tasks(where: {" +
+                "    status: {EQ: COMPLETED}" +
+                "    AND: [" +
+                "      {  " +
+                "         variables: {" +
+                "           name: {EQ: \"variable1\"}" +
+                "        value: {EQ: \"data\"}" +
+                "        }" +
+                "      }" +
+                "    ]" +
+                "  }) {" +
+                "    select {" +
+                "      id" +
+                "      status" +
+                "      variables(where: {name: {IN: [\"variable2\",\"variable1\"]}} ) {" +
+                "        name" +
+                "        value" +
+                "      }" +
+                "    }" +
+                "  }" +
+                "}";
+
+        String expected =
+            "{Tasks={select=[" +
+                "{id=1, status=COMPLETED, variables=[" +
+                "{name=variable1, value=data}, " +
+                "{name=variable2, value=true}]}" +
+                "]}}";
+
+        //when
+        Object result = executor.execute(query).getData();
+
+        // then
+        assertThat(result.toString()).isEqualTo(expected);
+    }
+
+    @Test
+    public void queryTasksVariablesAggregateCount() {
+        //given
+        String query = """
+                query {
+                  Tasks(
+                    where: {
+                      status: { EQ: COMPLETED }
+                    }
+                  ) {
+                    select {
+                      id
+                      status
+                    }
+                    aggregate {
+                      count
+                    }
+                  }
+                }
+            """;
+
+        String expected =
+            "{Tasks={select=[{id=1, status=COMPLETED}, {id=5, status=COMPLETED}], aggregate={count=2}}}";
+
+        //when
+        Object result = executor.execute(query).getData();
+
+        // then
+        assertThat(result.toString()).isEqualTo(expected);
+    }
+
+    @Test
+    public void queryTasksVariablesNestedAggregateCount() {
+        //given
+        String query = """
+                query {
+                  Tasks(
+                    where: {
+                      status: { EQ: COMPLETED }
+                    }
+                  ) {
+                    select {
+                      id
+                      status
+                    }
+                    aggregate {
+                      count
+                      variables: count(of: variables)
+                    }
+                  }
+                }
+            """;
+
+        String expected =
+            "{Tasks={select=[{id=1, status=COMPLETED}, {id=5, status=COMPLETED}], aggregate={count=2, variables=2}}}";
+
+        //when
+        Object result = executor.execute(query).getData();
+
+        // then
+        assertThat(result.toString()).isEqualTo(expected);
+    }
+
+    @Test
+    public void queryVariablesTaskNestedAggregateCount() {
+        //given
+        String query = """
+                query {
+                  TaskVariables {
+                    aggregate {
+                      count
+                      tasks: count(of: task)
+                    }
+                  }
+                }
+            """;
+
+        String expected =
+            "{TaskVariables={aggregate={count=8, tasks=8}}}";
+
+        //when
+        Object result = executor.execute(query).getData();
+
+        // then
+        assertThat(result.toString()).isEqualTo(expected);
+    }
+
+    @Test
+    public void queryVariablesTaskNestedAggregateCountWhere() {
+        //given
+        String query = """
+                query {
+                  TaskVariables(where:{task: {status: {EQ: COMPLETED}}}) {
+                    aggregate {
+                      count
+                      tasks: count(of: task)
+                    }
+                  }
+                }
+            """;
+
+        String expected =
+            "{TaskVariables={aggregate={count=2, tasks=2}}}";
+
+        //when
+        Object result = executor.execute(query).getData();
+
+        // then
+        assertThat(result.toString()).isEqualTo(expected);
+    }
+
+    @Test
+    public void queryVariablesTaskNestedAggregateCountGroupBy() {
+        //given
+        String query = """
+            query {
+              TaskVariables {
+                aggregate {
+                  # Aggregate by group of fields
+                  group {
+                    by(field: name)
+                    count
+                  }
+                }
+              }
+            }
+            """;
+
+        String expected =
+            "{TaskVariables={aggregate={group=[{by=variable1, count=1}, {by=variable2, count=1}, {by=variable3, count=1}, {by=variable4, count=1}, {by=variable5, count=2}, {by=variable6, count=1}, {by=variable7, count=1}]}}}";
+
+        //when
+        ExecutionResult result = executor.execute(query);
+
+        // then
+        assertThat(result.getErrors()).isEmpty();
+        assertThat(result.getData().toString()).isEqualTo(expected);
+    }
+
+    @Test
+    public void queryVariablesTaskNestedAggregateCountGroupByMultipleFields() {
+        //given
+        String query = """
+            query {
+              TaskVariables {
+                aggregate {
+                  # Aggregate by group of fields
+                  group {
+                    name: by(field: name)
+                    value: by(field: value)
+                    count
+                  }
+                }
+              }
+            }
+            """;
+
+        String expected =
+            "{TaskVariables={aggregate={group=[{name=variable1, value=data, count=1}, {name=variable2, value=true, count=1}, {name=variable3, value=null, count=1}, {name=variable4, value={key=data}, count=1}, {name=variable5, value=1.2345, count=2}, {name=variable6, value=12345, count=1}, {name=variable7, value=[1, 2, 3, 4, 5], count=1}]}}}";
+
+        //when
+        ExecutionResult result = executor.execute(query);
+
+        // then
+        assertThat(result.getErrors()).isEmpty();
+        assertThat(result.getData().toString()).isEqualTo(expected);
+    }
+
+
+}

--- a/schema/src/test/resources/GraphQLJpaAggregateTests.sql
+++ b/schema/src/test/resources/GraphQLJpaAggregateTests.sql
@@ -1,0 +1,25 @@
+-- Json entity
+insert into json_entity (id, first_name, last_name, attributes) values
+	(1, 'john', 'doe', '{"attr":{"key":["1","2","3","4","5"]}}'),
+	(2, 'joe', 'smith', '{"attr":["1","2","3","4","5"]}');
+
+insert into task (id, assignee, business_key, created_date, description, due_date, last_modified, last_modified_from, last_modified_to, name, priority, process_definition_id, process_instance_id, status, owner, claimed_date) values
+('1', 'assignee', 'bk1', CURRENT_TIMESTAMP, 'description', null, null, null, null, 'task1', 5, 'process_definition_id', 0, 'COMPLETED'  , 'owner', null),
+('2', 'assignee', null, CURRENT_TIMESTAMP, 'description', null, null, null, null, 'task2', 10, 'process_definition_id', 0, 'CREATED'  , 'owner', null),
+('3', 'assignee', null, CURRENT_TIMESTAMP, 'description', null, null, null, null, 'task3', 5, 'process_definition_id', 0, 'CREATED'  , 'owner', null),
+('4', 'assignee', null, CURRENT_TIMESTAMP, 'description', null, null, null, null, 'task4', 10, 'process_definition_id', 1, 'CREATED'  , 'owner', null),
+('5', 'assignee', null, CURRENT_TIMESTAMP, 'description', null, null, null, null, 'task5', 10, 'process_definition_id', 1, 'COMPLETED'  , 'owner', null),
+('6', 'assignee', 'bk6', CURRENT_TIMESTAMP, 'description', null, null, null, null, 'task6', 10, 'process_definition_id', 0, 'ASSIGNED'  , 'owner', null);
+
+insert into PROCESS_VARIABLE (create_time, execution_id, last_updated_time, name, process_instance_id, type, value) values
+  (CURRENT_TIMESTAMP, 'execution_id', CURRENT_TIMESTAMP, 'document', 1, 'json', '{"value":{"key":["1","2","3","4","5"]}}');
+
+insert into TASK_VARIABLE (create_time, execution_id, last_updated_time, name, process_instance_id, task_id, type, value) values
+  (CURRENT_TIMESTAMP, 'execution_id', CURRENT_TIMESTAMP, 'variable1', 0, '1', 'string', '{"value":"data"}'),
+  (CURRENT_TIMESTAMP, 'execution_id', CURRENT_TIMESTAMP, 'variable2', 0, '1', 'boolean', '{"value":true}'),
+  (CURRENT_TIMESTAMP, 'execution_id', CURRENT_TIMESTAMP, 'variable3', 0, '2', 'null', '{"value":null}'),
+  (CURRENT_TIMESTAMP, 'execution_id', CURRENT_TIMESTAMP, 'variable4', 0, '2', 'json', '{"value":{"key":"data"}}'),
+  (CURRENT_TIMESTAMP, 'execution_id', CURRENT_TIMESTAMP, 'variable5', 1, '3', 'double', '{"value":1.2345}'),
+  (CURRENT_TIMESTAMP, 'execution_id', CURRENT_TIMESTAMP, 'variable5', 1, '4', 'double', '{"value":1.2345}'),
+  (CURRENT_TIMESTAMP, 'execution_id', CURRENT_TIMESTAMP, 'variable6', 1, '4', 'int', '{"value":12345}'),
+  (CURRENT_TIMESTAMP, 'execution_id', CURRENT_TIMESTAMP, 'variable7', 1, '4', 'json', '{"value":[1,2,3,4,5]}'); 

--- a/tests/gatling/src/main/java/com/introproventures/graphql/jpa/query/example/Application.java
+++ b/tests/gatling/src/main/java/com/introproventures/graphql/jpa/query/example/Application.java
@@ -63,7 +63,7 @@ public class Application {
                                             .ofNullable(input)
                                             .filter(VariableValue.class::isInstance)
                                             .map(VariableValue.class::cast)
-                                            .map(it -> Optional.ofNullable(it.getValue()).orElse("null"))
+                                            .map(it -> Optional.ofNullable(it.getValue()).orElse(Optional.empty()))
                                             .orElse(input);
                                     }
                                 }

--- a/tests/gatling/src/main/java/com/introproventures/graphql/jpa/query/example/Application.java
+++ b/tests/gatling/src/main/java/com/introproventures/graphql/jpa/query/example/Application.java
@@ -50,6 +50,7 @@ public class Application {
                 builder
                     .name("Query")
                     .description("Activiti Cloud Query Schema")
+                    .enableAggregate(true)
                     .scalar(
                         VariableValue.class,
                         newScalar()

--- a/tests/gatling/src/main/java/com/introproventures/graphql/jpa/query/example/Application.java
+++ b/tests/gatling/src/main/java/com/introproventures/graphql/jpa/query/example/Application.java
@@ -55,16 +55,18 @@ public class Application {
                         newScalar()
                             .name("VariableValue")
                             .description("VariableValue type")
-                            .coercing(new JavaScalars.GraphQLObjectCoercing() {
-                                public Object serialize(final Object input) {
-                                    return Optional
-                                        .ofNullable(input)
-                                        .filter(VariableValue.class::isInstance)
-                                        .map(VariableValue.class::cast)
-                                        .map(it -> Optional.ofNullable(it.getValue()).orElse("null"))
-                                        .orElse(input);
+                            .coercing(
+                                new JavaScalars.GraphQLObjectCoercing() {
+                                    public Object serialize(final Object input) {
+                                        return Optional
+                                            .ofNullable(input)
+                                            .filter(VariableValue.class::isInstance)
+                                            .map(VariableValue.class::cast)
+                                            .map(it -> Optional.ofNullable(it.getValue()).orElse("null"))
+                                            .orElse(input);
+                                    }
                                 }
-                            })
+                            )
                             .build()
                     )
                     .scalar(

--- a/tests/gatling/src/main/java/com/introproventures/graphql/jpa/query/example/Application.java
+++ b/tests/gatling/src/main/java/com/introproventures/graphql/jpa/query/example/Application.java
@@ -21,6 +21,7 @@ import com.introproventures.graphql.jpa.query.autoconfigure.EnableGraphQLJpaQuer
 import com.introproventures.graphql.jpa.query.autoconfigure.GraphQLJPASchemaBuilderCustomizer;
 import com.introproventures.graphql.jpa.query.schema.JavaScalars;
 import java.util.Date;
+import java.util.Optional;
 import org.activiti.cloud.services.query.model.ProcessInstanceEntity;
 import org.activiti.cloud.services.query.model.VariableValue;
 import org.springframework.beans.factory.annotation.Value;
@@ -54,7 +55,16 @@ public class Application {
                         newScalar()
                             .name("VariableValue")
                             .description("VariableValue type")
-                            .coercing(new JavaScalars.GraphQLObjectCoercing())
+                            .coercing(new JavaScalars.GraphQLObjectCoercing() {
+                                public Object serialize(final Object input) {
+                                    return Optional
+                                        .ofNullable(input)
+                                        .filter(VariableValue.class::isInstance)
+                                        .map(VariableValue.class::cast)
+                                        .map(it -> Optional.ofNullable(it.getValue()).orElse("null"))
+                                        .orElse(input);
+                                }
+                            })
                             .build()
                     )
                     .scalar(


### PR DESCRIPTION
Added an optional feature to generate aggregate count query for plural entities object types. The aggregate feature can be enabled on GraphQLSchemaBuilderCustomizer:

```java
@Bean
GraphQLJPASchemaBuilderCustomizer graphQLJPASchemaBuilderCustomizer() {
   return builder ->
      builder
         .name("Query")
         .enableAggregate(true);
});

```

The GraphQL Schema builder will generate `aggregate` selection field to be able to request counts. The count can be grouped by entity fields and nested associations, i.e.

```graphql
query {
  Tasks {
    aggregate {
      countTasks: count
      countProcessVariables: count(of: processVariables)
      countTaskVariables: count(of: variables)
      countTasksGroupedByStatus: group {
        status: by(field: status)
        count
      }
      countProcessVariablesGroupedByTaskName: group {
        name: by(field: name)
        count(of: processVariables)
      }
      countTaskProcessVariablesGroupedByVariableNameAndValue: processVariables {
        name: by(field: name)
        value: by(field: value)
        count
      }
      countTaskVariablesGroupedByVariableName: variables {
        name: by(field: name)
        count
      }
    }
  }
}

```

Will return counts by different groups including nested associations:

```json
{
  "data": {
    "Tasks": {
      "aggregate": {
        "countTasks": 1000,
        "countProcessVariables": 6,
        "countTaskVariables": 42,
        "countTasksGroupedByStatus": [
          {
            "status": "COMPLETED",
            "count": 335
          },
          {
            "status": "ASSIGNED",
            "count": 337
          },
          {
            "status": "CREATED",
            "count": 328
          }
        ],
        "countProcessVariablesGroupedByTaskName": [
          {
            "name": "Solarbreeze",
            "count": 6
          }
        ],
        "countTaskProcessVariablesGroupedByVariableNameAndValue": [
          {
            "name": "applicationId",
            "value": "232951752337576",
            "count": 1
          },
          {
            "name": "moduleid",
            "value": "LBU",
            "count": 1
          },
          {
            "name": "isApproved",
            "value": true,
            "count": 1
          },
          {
            "name": "approverlist",
            "value": [
              "andrelaksmana"
            ],
            "count": 1
          },
          {
            "name": "applicationDate",
            "value": "2023-10-22T00:00:00.000+0000",
            "count": 1
          },
          {
            "name": "nullable",
            "value": null,
            "count": 1
          }
        ],
        "countTaskVariablesGroupedByVariableName": [
          {
            "name": "accountNumber",
            "count": 7
          },
          {
            "name": "variable1",
            "count": 5
          },
          {
            "name": "variable2",
            "count": 6
          },
          {
            "name": "variable3",
            "count": 6
          },
          {
            "name": "variable4",
            "count": 6
          },
          {
            "name": "variable5",
            "count": 6
          },
          {
            "name": "variable7",
            "count": 6
          }
        ]
      }
    }
  }
}

```