### PR TITLE
Extract aggregate query fields for nested associations into dedicated by field

### DIFF
--- a/schema/src/main/java/com/introproventures/graphql/jpa/query/schema/impl/GraphQLJpaSchemaBuilder.java
+++ b/schema/src/main/java/com/introproventures/graphql/jpa/query/schema/impl/GraphQLJpaSchemaBuilder.java
@@ -525,6 +525,10 @@ public class GraphQLJpaSchemaBuilder implements GraphQLSchemaBuilder {
                 )
             );
 
+        var aggregateByObjectType = newObject()
+            .name(selectTypeName.concat("AggregateBy"))
+            .description("%s aggregate query type groups by nested associations".formatted(selectTypeName));
+
         entityType
             .getAttributes()
             .stream()
@@ -544,11 +548,11 @@ public class GraphQLJpaSchemaBuilder implements GraphQLSchemaBuilder {
                     .toList();
 
                 if (!fields.isEmpty()) {
-                    aggregateObjectType.field(
+                    aggregateByObjectType.field(
                         newFieldDefinition()
                             .name(association.getName())
                             .description(
-                                "Aggregate %s query field definition for the associated %s entity".formatted(
+                                "Aggregate by %s query field definition for the associated %s entity".formatted(
                                         selectTypeName,
                                         association.getName()
                                     )
@@ -616,6 +620,15 @@ public class GraphQLJpaSchemaBuilder implements GraphQLSchemaBuilder {
             });
 
         aggregateObjectType.field(countFieldDefinition).field(groupFieldDefinition);
+
+        if (!aggregateByObjectType.build().getFieldDefinitions().isEmpty()) {
+            aggregateObjectType.field(
+                newFieldDefinition()
+                    .name("by")
+                    .description("Nested aggregate by query field for %s entity".formatted(selectTypeName))
+                    .type(aggregateByObjectType)
+            );
+        }
 
         var aggregateFieldDefinition = newFieldDefinition()
             .name("aggregate")

--- a/schema/src/test/java/com/introproventures/graphql/jpa/query/converter/GraphQLJpaQueryAggregateTests.java
+++ b/schema/src/test/java/com/introproventures/graphql/jpa/query/converter/GraphQLJpaQueryAggregateTests.java
@@ -602,9 +602,11 @@ public class GraphQLJpaQueryAggregateTests extends AbstractSpringBootTestSupport
                       # count by variables
                       variables: count
                       # Count by associated tasks
-                      tasks: task {
-                        by(field: status)
-                        count
+                      by {
+                        tasks: task {
+                          by(field: status)
+                          count
+                        }
                       }
                     }
                   }
@@ -612,7 +614,7 @@ public class GraphQLJpaQueryAggregateTests extends AbstractSpringBootTestSupport
             """;
 
         String expected =
-            "{TaskVariables={aggregate={variables=3, tasks=[{by=COMPLETED, count=1}, {by=CREATED, count=2}]}}}";
+            "{TaskVariables={aggregate={variables=3, by={tasks=[{by=COMPLETED, count=1}, {by=CREATED, count=2}]}}}}";
 
         //when
         ExecutionResult result = executor.execute(query);
@@ -636,9 +638,11 @@ public class GraphQLJpaQueryAggregateTests extends AbstractSpringBootTestSupport
                       # count by variables
                       variables: count
                       # Count by associated tasks
-                      tasks: task {
-                        status: by(field: status)
-                        count
+                      by {
+                        tasks: task {
+                          status: by(field: status)
+                          count
+                        }
                       }
                     }
                   }
@@ -646,7 +650,7 @@ public class GraphQLJpaQueryAggregateTests extends AbstractSpringBootTestSupport
             """;
 
         String expected =
-            "{TaskVariables={aggregate={variables=3, tasks=[{status=COMPLETED, count=1}, {status=CREATED, count=2}]}}}";
+            "{TaskVariables={aggregate={variables=3, by={tasks=[{status=COMPLETED, count=1}, {status=CREATED, count=2}]}}}}";
 
         //when
         ExecutionResult result = executor.execute(query);
@@ -674,14 +678,16 @@ public class GraphQLJpaQueryAggregateTests extends AbstractSpringBootTestSupport
                         name: by(field: name)
                         count
                       }
-                      groupByTaskStatus: task {
-                        status: by(field: status)
-                        count
-                      }
-                      # Count by associated tasks
-                      groupByTaskAssignee: task {
-                        assignee: by(field: assignee)
-                        count
+                      by {
+                        groupByTaskStatus: task {
+                          status: by(field: status)
+                          count
+                        }
+                        # Count by associated tasks
+                        groupByTaskAssignee: task {
+                          assignee: by(field: assignee)
+                          count
+                        }
                       }
                     }
                   }
@@ -689,7 +695,7 @@ public class GraphQLJpaQueryAggregateTests extends AbstractSpringBootTestSupport
             """;
 
         String expected =
-            "{TaskVariables={aggregate={variables=3, groupByVariableName=[{name=variable1, count=1}, {name=variable5, count=2}], groupByTaskStatus=[{status=COMPLETED, count=1}, {status=CREATED, count=2}], groupByTaskAssignee=[{assignee=assignee, count=3}]}}}";
+            "{TaskVariables={aggregate={variables=3, groupByVariableName=[{name=variable1, count=1}, {name=variable5, count=2}], by={groupByTaskStatus=[{status=COMPLETED, count=1}, {status=CREATED, count=2}], groupByTaskAssignee=[{assignee=assignee, count=3}]}}}}";
 
         //when
         ExecutionResult result = executor.execute(query);


### PR DESCRIPTION
Move all aggregate queries for nested aggregations into dedicated `by` field to improve schema definition and data fetching for further extension, i.e.

Before:

```graphql
                query {
                  TaskVariables(
                    # Apply filter criteria
                    where: {name: {IN: ["variable1", "variable5"]}}
                  ) {
                    aggregate {
                      # Count by associated tasks
                      task {
                        by(field: status)
                        count
                      }
                    }
                  }
                }
```

After 
```graphql
                query {
                  TaskVariables(
                    # Apply filter criteria
                    where: {name: {IN: ["variable1", "variable5"]}}
                  ) {
                    aggregate {
                      # Count by associated tasks
                      by {
                        task {
                          by(field: status)
                          count
                        }
                      }
                    }
                  }
                }
```
