### PR TITLE
Skip redundant fetch query for empty query keys results

### DIFF
--- a/schema/src/main/java/com/introproventures/graphql/jpa/query/schema/impl/GraphQLJpaQueryDataFetcher.java
+++ b/schema/src/main/java/com/introproventures/graphql/jpa/query/schema/impl/GraphQLJpaQueryDataFetcher.java
@@ -34,7 +34,6 @@ import graphql.language.Field;
 import graphql.schema.DataFetcher;
 import graphql.schema.DataFetchingEnvironment;
 import graphql.schema.GraphQLScalarType;
-import java.util.ArrayList;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
@@ -53,6 +52,12 @@ import org.slf4j.LoggerFactory;
 class GraphQLJpaQueryDataFetcher implements DataFetcher<PagedResult<Object>> {
 
     private static final Logger logger = LoggerFactory.getLogger(GraphQLJpaQueryDataFetcher.class);
+    public static final String AGGREGATE_PARAM_NAME = "aggregate";
+    public static final String COUNT_FIELD_NAME = "count";
+    public static final String GROUP_FIELD_NAME = "group";
+    public static final String BY_FILED_NAME = "by";
+    public static final String FIELD_ARGUMENT_NAME = "field";
+    public static final String OF_ARGUMENT_NAME = "of";
 
     private final int defaultMaxResults;
     private final int defaultPageLimitSize;
@@ -76,7 +81,7 @@ class GraphQLJpaQueryDataFetcher implements DataFetcher<PagedResult<Object>> {
         Optional<Field> pagesSelection = getSelectionField(rootNode, PAGE_PAGES_PARAM_NAME);
         Optional<Field> totalSelection = getSelectionField(rootNode, PAGE_TOTAL_PARAM_NAME);
         Optional<Field> recordsSelection = searchByFieldName(rootNode, QUERY_SELECT_PARAM_NAME);
-        Optional<Field> aggregateSelection = getSelectionField(rootNode, "aggregate");
+        Optional<Field> aggregateSelection = getSelectionField(rootNode, AGGREGATE_PARAM_NAME);
 
         final int firstResult = page.getOffset();
         final int maxResults = Integer.min(page.getLimit(), defaultMaxResults); // Limit max results to avoid OoM
@@ -85,22 +90,29 @@ class GraphQLJpaQueryDataFetcher implements DataFetcher<PagedResult<Object>> {
             .builder()
             .withOffset(firstResult)
             .withLimit(maxResults);
-        Optional<List<Object>> restrictedKeys = queryFactory.getRestrictedKeys(environment);
+
+        final Optional<List<Object>> restrictedKeys = queryFactory.getRestrictedKeys(environment);
 
         if (recordsSelection.isPresent()) {
             if (restrictedKeys.isPresent()) {
-                final List<Object> queryKeys = new ArrayList<>();
-
                 if (pageArgument.isPresent() || enableDefaultMaxResults) {
-                    queryKeys.addAll(
-                        queryFactory.queryKeys(environment, firstResult, maxResults, restrictedKeys.get())
+                    final List<Object> queryKeys = queryFactory.queryKeys(
+                        environment,
+                        firstResult,
+                        maxResults,
+                        restrictedKeys.get()
                     );
-                } else {
-                    queryKeys.addAll(restrictedKeys.get());
-                }
 
-                final List<Object> resultList = queryFactory.queryResultList(environment, maxResults, queryKeys);
-                pagedResult.withSelect(resultList);
+                    if (!queryKeys.isEmpty()) {
+                        pagedResult.withSelect(
+                            queryFactory.queryResultList(environment, maxResults, restrictedKeys.get())
+                        );
+                    } else {
+                        pagedResult.withSelect(List.of());
+                    }
+                } else {
+                    pagedResult.withSelect(queryFactory.queryResultList(environment, maxResults, restrictedKeys.get()));
+                }
             }
         }
 
@@ -113,7 +125,7 @@ class GraphQLJpaQueryDataFetcher implements DataFetcher<PagedResult<Object>> {
         aggregateSelection.ifPresent(aggregateField -> {
             Map<String, Object> aggregate = new LinkedHashMap<>();
 
-            getFields(aggregateField.getSelectionSet(), "count")
+            getFields(aggregateField.getSelectionSet(), COUNT_FIELD_NAME)
                 .forEach(countField -> {
                     getCountOfArgument(countField)
                         .ifPresentOrElse(
@@ -130,16 +142,16 @@ class GraphQLJpaQueryDataFetcher implements DataFetcher<PagedResult<Object>> {
                         );
                 });
 
-            getFields(aggregateField.getSelectionSet(), "group")
+            getFields(aggregateField.getSelectionSet(), GROUP_FIELD_NAME)
                 .forEach(groupField -> {
-                    var countField = getFields(groupField.getSelectionSet(), "count")
+                    var countField = getFields(groupField.getSelectionSet(), COUNT_FIELD_NAME)
                         .stream()
                         .findFirst()
                         .orElseThrow(() -> new GraphQLException("Missing aggregate count for group: " + groupField));
 
                     var countOfArgumentValue = getCountOfArgument(countField);
 
-                    Map.Entry<String, String>[] groupings = getFields(groupField.getSelectionSet(), "by")
+                    Map.Entry<String, String>[] groupings = getFields(groupField.getSelectionSet(), BY_FILED_NAME)
                         .stream()
                         .map(GraphQLJpaQueryDataFetcher::groupByFieldEntry)
                         .toArray(Map.Entry[]::new);
@@ -176,21 +188,21 @@ class GraphQLJpaQueryDataFetcher implements DataFetcher<PagedResult<Object>> {
                     aggregate.put(getAliasOrName(groupField), resultList);
                 });
 
-            getSelectionField(aggregateField, "by")
+            getSelectionField(aggregateField, BY_FILED_NAME)
                 .map(byField -> byField.getSelectionSet().getSelections().stream().map(Field.class::cast).toList())
                 .filter(Predicate.not(List::isEmpty))
                 .ifPresent(aggregateBySelections -> {
                     var aggregatesBy = new LinkedHashMap<>();
-                    aggregate.put("by", aggregatesBy);
+                    aggregate.put(BY_FILED_NAME, aggregatesBy);
 
                     aggregateBySelections.forEach(groupField -> {
-                        var countField = getFields(groupField.getSelectionSet(), "count")
+                        var countField = getFields(groupField.getSelectionSet(), COUNT_FIELD_NAME)
                             .stream()
                             .findFirst()
                             .orElseThrow(() -> new GraphQLException("Missing aggregate count for group: " + groupField)
                             );
 
-                        Map.Entry<String, String>[] groupings = getFields(groupField.getSelectionSet(), "by")
+                        Map.Entry<String, String>[] groupings = getFields(groupField.getSelectionSet(), BY_FILED_NAME)
                             .stream()
                             .map(GraphQLJpaQueryDataFetcher::groupByFieldEntry)
                             .toArray(Map.Entry[]::new);
@@ -239,7 +251,7 @@ class GraphQLJpaQueryDataFetcher implements DataFetcher<PagedResult<Object>> {
     static Map.Entry<String, String> groupByFieldEntry(Field selectedField) {
         String key = Optional.ofNullable(selectedField.getAlias()).orElse(selectedField.getName());
 
-        String value = findArgument(selectedField, "field")
+        String value = findArgument(selectedField, FIELD_ARGUMENT_NAME)
             .map(Argument::getValue)
             .map(EnumValue.class::cast)
             .map(EnumValue::getName)
@@ -257,7 +269,7 @@ class GraphQLJpaQueryDataFetcher implements DataFetcher<PagedResult<Object>> {
     }
 
     static Optional<String> getCountOfArgument(Field selectedField) {
-        return findArgument(selectedField, "of")
+        return findArgument(selectedField, OF_ARGUMENT_NAME)
             .map(Argument::getValue)
             .map(EnumValue.class::cast)
             .map(EnumValue::getName);

--- a/schema/src/main/java/com/introproventures/graphql/jpa/query/schema/impl/GraphQLJpaQueryDataFetcher.java
+++ b/schema/src/main/java/com/introproventures/graphql/jpa/query/schema/impl/GraphQLJpaQueryDataFetcher.java
@@ -34,6 +34,7 @@ import graphql.language.Field;
 import graphql.schema.DataFetcher;
 import graphql.schema.DataFetchingEnvironment;
 import graphql.schema.GraphQLScalarType;
+import java.util.Collection;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
@@ -117,7 +118,12 @@ class GraphQLJpaQueryDataFetcher implements DataFetcher<PagedResult<Object>> {
         }
 
         if (totalSelection.isPresent() || pagesSelection.isPresent()) {
-            final Long total = queryFactory.queryTotalCount(environment, restrictedKeys);
+            final var selectResult = pagedResult.getSelect();
+
+            final long total = recordsSelection.isEmpty() ||
+                selectResult.filter(Predicate.not(Collection::isEmpty)).isPresent()
+                ? queryFactory.queryTotalCount(environment, restrictedKeys)
+                : 0L;
 
             pagedResult.withTotal(total);
         }

--- a/schema/src/main/java/com/introproventures/graphql/jpa/query/schema/impl/PagedResult.java
+++ b/schema/src/main/java/com/introproventures/graphql/jpa/query/schema/impl/PagedResult.java
@@ -20,6 +20,7 @@ import java.util.Collections;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 
 public class PagedResult<T> {
 
@@ -133,6 +134,10 @@ public class PagedResult<T> {
         public Builder<T> withSelect(List<T> select) {
             this.select = select;
             return this;
+        }
+
+        public Optional<List<T>> getSelect() {
+            return Optional.ofNullable(select);
         }
 
         /**

--- a/schema/src/main/java/com/introproventures/graphql/jpa/query/schema/impl/ResultStreamWrapper.java
+++ b/schema/src/main/java/com/introproventures/graphql/jpa/query/schema/impl/ResultStreamWrapper.java
@@ -63,6 +63,8 @@ class ResultStreamWrapper<T> {
                 return System.identityHashCode(proxy);
             } else if ("spliterator".equals(method.getName())) {
                 return stream.spliterator();
+            } else if ("isEmpty".equals(method.getName())) {
+                return size == 0;
             }
             throw new UnsupportedOperationException(method + " is not supported");
         }


### PR DESCRIPTION
Skip executing redundant paged fetch query that does not have any results, i.e.

```graphql
query tasksWithMultipleProcessVariables {
  Tasks(page: {limit : {Int}, start : {Int}}, where: {status : {IN : [CREATED]}, AND : [{processVariables : {name : {EQ : {String}}, value : {EQ : {String}}}}, {name : {LIKE : {String}}}]}) {
    total
    pages
    select {
      id
      processInstanceId
      assignee
      status
      candidateGroups
      createdDate(orderBy: ASC)
      processVariables(where: {name : {IN : [{String}]}}) {
        name
        type
        value
      }
    }
  }
}
```

The first generated SQL query fetches task keys with the empty result, i.e.

```
select te1_0.id 
from task te1_0 
    left join task_process_variable pv1_0 on te1_0.id = pv1_0.task_id 
    left join process_variable pv1_1 on pv1_1.id = pv1_0.process_variable_id 
where pv1_1.name = ? and pv1_1. value = ? and te1_0.name like ? escape ? and te1_0.status in ( ? ) 
order by te1_0.created_date offset ? rows 
fetch first ? rows only
```

After that, the second fetch query does not apply  in search criteria is when the list of ids from the id query is empty, which fetch all data without keys restrictions, i.e.

```
select distinct te1_0.id, te1_0.app_name, te1_0.app_version, te1_0.assignee, te1_0.business_key, te1_0.claimed_date, te1_0.completed_by, te1_0.completed_date, te1_0.completed_from, te1_0.completed_to, te1_0.created_date, te1_0.created_from, te1_0.created_to, te1_0.description, te1_0.due_date, te1_0.duration, te1_0.form_key, te1_0.last_claimed_from, te1_0.last_claimed_to, te1_0.last_modified, te1_0.last_modified_from, te1_0.last_modified_to, te1_0.name, te1_0.owner, te1_0.parent_task_id, te1_0.priority, te1_0.process_definition_id, te1_0.process_definition_name, te1_0.process_definition_version, te1_0.process_instance_id, pv1_0.task_id, pv1_1.id, pv1_1.app_name, pv1_1.app_version, pv1_1.create_time, pv1_1.execution_id, pv1_1.last_updated_time, pv1_1.marked_as_deleted, pv1_1.name, pv1_1.process_definition_key, pv1_1.process_instance_id, pv1_1.service_full_name, pv1_1.service_name, pv1_1.service_type, pv1_1.service_version, pv1_1.type, pv1_1.variable_definition_id, te1_0.service_full_name, te1_0.service_name, te1_0.service_type, te1_0.service_version, te1_0.status, te1_0.task_definition_key 
from task te1_0 
    left join task_process_variable pv1_0 on te1_0.id = pv1_0.task_id 
    left join process_variable pv1_1 on pv1_1.id = pv1_0.process_variable_id 
where pv1_1.name = ? and pv1_1. value = ? and te1_0.name like ? escape ? and te1_0.status in ( ? ) 
order by te1_0.created_date
```

This is a bug because, the second query should not need to execute at all if there are no ids found for the provided selection criteria. We also can skip `total` count if the select page result is empty.