### PR TITLE
fix query for non empty query keys

### DIFF
--- a/schema/src/main/java/com/introproventures/graphql/jpa/query/schema/impl/GraphQLJpaQueryDataFetcher.java
+++ b/schema/src/main/java/com/introproventures/graphql/jpa/query/schema/impl/GraphQLJpaQueryDataFetcher.java
@@ -105,7 +105,7 @@ class GraphQLJpaQueryDataFetcher implements DataFetcher<PagedResult<Object>> {
 
                     if (!queryKeys.isEmpty()) {
                         pagedResult.withSelect(
-                            queryFactory.queryResultList(environment, maxResults, restrictedKeys.get())
+                            queryFactory.queryResultList(environment, maxResults, queryKeys)
                         );
                     } else {
                         pagedResult.withSelect(List.of());


### PR DESCRIPTION
There is a new problem after fixing redundant fetch query for empty query keys results (https://github.com/introproventures/graphql-jpa-query/pull/508). If the query results are not empty, queryBuilder doesn't use them, so complexity of second query increases exponentially. Especially if the selection is made not based on the attributes of the root entity. Good example is testGraphqlTasksQueryWithEQNullValues in GraphQLJpaConverterTests.java.

Before fix query was:

```
    select
        distinct te1_0.id,
...
        te1_0.status 
    from
        task te1_0 
    where
        te1_0.status in (?, ?) 
        and te1_0.due_date is null 
    order by
        te1_0.priority desc,
        te1_0.due_date
```


and after is:
```
    select
        distinct te1_0.id,
...
        te1_0.status 
    from
        task te1_0 
    where
        te1_0.status in (?, ?) 
        and te1_0.due_date is null 
        and te1_0.id in (?, ?, ?, ?)
    order by
        te1_0.priority desc,
        te1_0.due_date
```