### PR TITLE
Fix NPE when parsing invalid timestamp variable inputs

### DIFF
--- a/scalars/src/main/java/com/introproventures/graphql/jpa/query/schema/JavaScalars.java
+++ b/scalars/src/main/java/com/introproventures/graphql/jpa/query/schema/JavaScalars.java
@@ -741,8 +741,7 @@ public class JavaScalars {
             if (input instanceof Long longInput) {
                 return new Timestamp(longInput);
             } else if (input instanceof String stringInput) {
-                Instant instant = DateTimeHelper.parseDate(stringInput);
-                return Timestamp.from(instant);
+                return Optional.of(stringInput).map(DateTimeHelper::parseDate).map(Timestamp::from).orElse(null);
             } else if (input instanceof Timestamp timestampInput) {
                 return timestampInput;
             } else if (input instanceof Date dateInput) {

--- a/scalars/src/test/java/com/introproventures/graphql/jpa/query/schema/JavaScalarsTest.java
+++ b/scalars/src/test/java/com/introproventures/graphql/jpa/query/schema/JavaScalarsTest.java
@@ -273,7 +273,7 @@ public class JavaScalarsTest {
 
         ZonedDateTime resultLDT = (ZonedDateTime) result;
 
-        assert resultLDT.getDayOfMonth() == 05;
+        assert resultLDT.getDayOfMonth() == 5;
         assert resultLDT.getMonth() == Month.AUGUST;
         assert resultLDT.getYear() == 2019;
         assert resultLDT.getHour() == 13;
@@ -363,6 +363,20 @@ public class JavaScalarsTest {
         assertThat(result)
             .asInstanceOf(new InstanceOfAssertFactory<>(Timestamp.class, Assertions::assertThat))
             .isEqualTo(expected);
+    }
+
+    @Test
+    public void testTimestampParseInvalidValue() {
+        //given
+        Coercing<?, ?> coercing = JavaScalars.of(Timestamp.class).getCoercing();
+
+        //when
+        var throwable = catchThrowable(() -> coercing.parseValue("foobar"));
+
+        //then
+        assertThat(throwable)
+            .isInstanceOf(CoercingParseValueException.class)
+            .hasMessageContaining("Invalid value 'foobar' for Timestamp");
     }
 
     @Test


### PR DESCRIPTION
by raising `CoersingParseValueException` with detailed message for troubleshooting